### PR TITLE
Move test infrastructure to this repo 🚚

### DIFF
--- a/.github/issue-template.md
+++ b/.github/issue-template.md
@@ -1,0 +1,16 @@
+---
+name: Issue Template
+about: Template for both bug reports and feature requests
+---
+
+# Expected Behavior
+
+# Actual Behavior
+
+# Steps to Reproduce the Problem
+
+1.
+2.
+3.
+
+# Additional Info

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+# Changes
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+# Submitter Checklist
+
+These are the criteria that every PR should meet, please check them off as you
+review them:
+
+- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
+- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
+
+_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
+for more details._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to the plumbing repo
+
+Thank you for your interest in contributing!
+
+**All contributors must comply with
+[the code of conduct](./code-of-conduct.md).**
+
+* The [OWNERS](OWNERS) of this repo are the [members of the Tekton governing board](goverance.md)
+  who will need to approve changes to the repo.
+* This repo holds configuration for infrastructure that is used by projects in
+  https://github.com/tektoncd.
+* [The README](README.md) describes components of this infrastructure and how to interact
+  with those components.
+
+In [the community repo](https://github.com/tektoncd/community) you'll
+find info on:
+
+* [Contacting other contributors](https://github.com/tektoncd/community/blob/master/contact.md)
+* [Development standards](https://github.com/tektoncd/community/blob/master/standards.md) around
+  [principles](https://github.com/tektoncd/community/blob/master/standards.md#principles),
+  [commit messages](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
+  and [code](https://github.com/tektoncd/community/blob/master/standards.md#coding-standards)
+* [Processes](https://github.com/tektoncd/community/blob/master/process.md) like
+  [reviews](https://github.com/tektoncd/community/blob/master/process.md#reviews)
+  and [becoming an OWNER](https://github.com/tektoncd/community/blob/master/process.md#owners)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,3 @@
+# Development guide
+
+_[See CONTRIBUTING.md](CONTRIBUTING.md)._

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- bobcatfish
+- dlorenc
+- vdemeester
+- kimsterv
+- abayer

--- a/README.md
+++ b/README.md
@@ -1,2 +1,86 @@
-# plumbing
-This repo holds configuration for infrastructure used across the tektoncd org 🏗️
+# Plumbing
+
+This repo holds configuration for infrastructure used across the tektoncd org 🏗️:
+
+- [Prow](#prow) is used for
+  [pull request automation]((https://github.com/tektoncd/community/blob/master/process.md#reviews))
+- [Ingress](#ingress) configuration for access via `tekton.dev`
+- [Gubernator](#guberator) is used for holding and displaying [Prow](#prow) logs
+- [Boskos](#boskos) is used to control a pool of GCP projects which end to end tests can run against
+
+## Support
+
+If you need support, reach out [in the tektoncd slack](https://github.com/tektoncd/community/blob/master/contact.md#slack)
+via the `#plumbing` channel.
+
+[Members of the Tekton governing board](goverance.md)
+[have access to the underlying resources](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access).
+
+## Prow
+
+- Prow runs in
+  [the GCP project `tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
+- Prow runs in
+  [the GKE cluster `prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
+- Prow uses the service account
+  `prow-account@tekton-releases.iam.gserviceaccount.com`
+  - Secrets for this account are configured in
+    [Prow's config.yaml](prow/config.yaml) via
+    `gcs_credentials_secret: "test-account"`
+- Prow configuration is in [infra/prow](./prow)
+
+_[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
+_[See the community docs](../CONTRIBUTING.md#pull-request-process) for more on
+Prow and the PR process._
+
+### Updating Prow
+
+TODO(#1) Apply config.yaml changes automatically
+
+Changes to [config.yaml](./prow/config.yaml) are not automatically reflected in
+the Prow cluster and must be manually applied.
+
+```bash
+# Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
+gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
+
+# Step 2: Update the configuration used by Prow
+kubectl create configmap config --from-file=config.yaml=infra/prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+
+# Step 3: Remember to configure kubectl to connect to your regular cluster!
+gcloud container clusters get-credentials ...
+```
+
+## Ingress
+
+- Ingress for prow is configured using
+  [cert-manager](https://github.com/jetstack/cert-manager/).
+- `cert-manager` was installed via `Helm` using this
+  [guide](https://docs.cert-manager.io/en/latest/getting-started/)
+- `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
+- https://prow.tekton.dev is pointed at the Cluster ingress address.
+
+## Gubernator
+
+- Gubernator is configured on App Engine in the project `tekton-releases`.
+- It was deployed using `gcloud app deploy .` with no configuration changes.
+- The configruation lives in [the gubernator dir](./gubernator).
+
+_[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernator)._
+
+## Boskos
+
+We use Boskos to manage GCP projects which end to end tests are run against.
+
+- Boskos configuration lives [in the `boskos` directory](./boskos)
+- It runs [in the `prow` cluster of the `tekton-releases` project](#prow), in
+  the namespace `test-pods`
+
+_[Boskos docs](https://github.com/kubernetes/test-infra/tree/master/boskos)._
+
+### Adding a project
+
+Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
+
+Make sure the IAM account:
+`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.

--- a/boskos/boskos-config.yaml
+++ b/boskos/boskos-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  config: |
+    resources:
+    - names:
+      - tekton-prow-0
+      - tekton-prow-1
+      - tekton-prow-2
+      - tekton-prow-3
+      - tekton-prow-4
+      - tekton-prow-5
+      state: dirty
+      type: gke-project
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: resources
+  namespace: test-pods
+

--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -1,0 +1,5 @@
+resources:
+- names:
+  - tekton-releases
+  state: dirty
+  type: gke-project

--- a/boskos/storage-class.yaml
+++ b/boskos/storage-class.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: boskos
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+  replication-type: none

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at
+tekton-code-of-conduct@googlegroups.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of
+specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -1,0 +1,30 @@
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default_external_services:
+  gcs_pull_prefix: tekton-prow/pr-logs/pull
+  prow_url: prow.tekton.dev
+default_org: tektoncd
+default_repo: pipeline
+external_services:
+  tektoncd:
+    gcs_bucket: tekton-prow/
+    gcs_pull_prefix: tekton-prow/pr-logs/pull
+    prow_url: prow.tekton.dev
+jobs:
+  tekton-prow/pr-logs/directory/:
+  - pull-tekton-pipeline-build-tests
+  - pull-tekton-pipeline-integration-tests
+recursive_artifacts: false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,0 +1,187 @@
+plank:
+  job_url_template: 'https://tekton-releases.appspot.com/build/tekton-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  report_template: '[Full PR test history](https://tekton-releases.appspot.com/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.tekton.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
+  pod_pending_timeout: 60m
+  default_decoration_config:
+    timeout: 7200000000000 # 2h
+    grace_period: 15000000000 # 15s
+    utility_images:
+      clonerefs: "gcr.io/k8s-prow/clonerefs@sha256:b62ba1f379ac19c5ec9ee7bcab14d3f0b3c31cea9cdd4bc491e98e2c5f346c07"
+      initupload: "gcr.io/k8s-prow/initupload@sha256:58f89f2aae68f7dc46aaf05c7e8204c4f26b53ec9ce30353d1c27ce44a60d121"
+      entrypoint: "gcr.io/k8s-prow/entrypoint:v20180512-0255926d1"
+      sidecar: "gcr.io/k8s-prow/sidecar@sha256:8807b2565f4d2699920542fcf890878824b1ede4198d7ff46bca53feb064ed44"
+    gcs_configuration:
+      bucket: "tekton-prow"
+      path_strategy: "explicit"
+    gcs_credentials_secret: "test-account"
+branch-protection:
+  orgs:
+    tektoncd:
+      # Protect all branches in tekton
+      # This means all prow jobs with "always_run" set are required
+      # to pass before tide can merge the PR.
+      # Currently this is manually enabled by the tekton org admins,
+      # but it's stated here for documentation and reference purposes.
+      protect: true
+      # Admins can overrule checks
+      enforce_admins: false
+tide:
+  queries:
+  - repos:
+    - tektoncd/pipeline
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+  - repos:
+    - tektoncd/community
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+  merge_method:
+    tektoncd/pipeline: rebase
+  target_url: https://prow.tekton.dev/tide
+
+presubmits:
+  tektoncd/pipeline:
+  - name: pull-tekton-pipeline-build-tests
+    agent: kubernetes
+    context: pull-tekton-pipeline-build-tests
+    always_run: true
+    rerun_command: "/test pull-tekton-pipeline-build-tests"
+    trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests@sha256:39296f6df4f29812689b41c47c78bdb00fbbec5ee63407fcbfefec0f48f5b6b1
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/test-account/service-account.json"
+        - "--upload=gs://tekton-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--build-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-tekton-pipeline-unit-tests
+    agent: kubernetes
+    context: tekton-pipeline-unit-tests
+    always_run: true
+    rerun_command: "/test tekton-pipeline-unit-tests"
+    trigger: "(?m)^/test (all|tekton-pipeline-unit-tests),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests@sha256:39296f6df4f29812689b41c47c78bdb00fbbec5ee63407fcbfefec0f48f5b6b1
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/test-account/service-account.json"
+        - "--upload=gs://tekton-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--unit-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-tekton-pipeline-integration-tests
+    agent: kubernetes
+    context: pull-tekton-pipeline-integration-tests
+    always_run: true
+    rerun_command: "/test pull-tekton-pipeline-integration-tests"
+    trigger: "(?m)^/test (all|pull-tekton-pipeline-integration-tests),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/prow-tests@sha256:39296f6df4f29812689b41c47c78bdb00fbbec5ee63407fcbfefec0f48f5b6b1
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/test-account/service-account.json"
+        - "--upload=gs://tekton-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--integration-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
+  - name: pull-tekton-pipeline-go-coverage
+    agent: kubernetes
+    context: pull-tekton-pipeline-go-coverage
+    always_run: true
+    rerun_command: "/test pull-tekton-pipeline-go-coverage"
+    trigger: "(?m)^/test (all|pull-tekton-pipeline-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    clone_uri: "https://github.com/tektoncd/pipeline.git"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--postsubmit-gcs-bucket=tekton-prow"
+        - "--postsubmit-job-name=pull-tekton-pipeline-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--profile-name=coverage_profile.txt"
+        - "--cov-target=."
+        - "--cov-threshold-percentage=80"
+        - "--github-token=/etc/github-token/oauth"
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: oauth-token

--- a/prow/ingress.yaml
+++ b/prow/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+  name: ing
+  namespace: default
+spec:
+  tls:
+  - secretName: prow-tekton-dev-tls
+    hosts:
+    - prow.tekton.dev
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: deck
+          servicePort: 80
+        path: /*
+      - backend:
+          serviceName: hook
+          servicePort: 8888
+        path: /hook    

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -1,0 +1,43 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+approve:
+- repos:
+  - tektoncd
+  implicit_self_approve: true
+  review_acts_as_approve: true
+
+plugins:
+  tektoncd:
+  - approve
+  - assign
+  - blunderbuss
+  - buildifier
+  - cat
+  - dog
+  - golint
+  - heart
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - milestone
+  - shrug
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - wip
+  - yuks


### PR DESCRIPTION
This configuration was previously at https://github.com/tektoncd/pipeline/tree/master/infra
but now we want to use this same infrastructure for multiple `tektoncd`
projects.

Permissions for accessing this infrastructure are given to Tekton
governing board members (see
https://github.com/tektoncd/community/pull/15).

This also brings the repo up to its requirements: https://github.com/tektoncd/community/blob/master/process.md#project-requirements :tada: 