### PR TITLE
Add tide to all tektoncd repos 🌊

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the Prow cluster and must be manually applied.
 gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
 
 # Step 2: Update the configuration used by Prow
-kubectl create configmap config --from-file=config.yaml=infra/prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
 
 # Step 3: Remember to configure kubectl to connect to your regular cluster!
 gcloud container clusters get-credentials ...

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -29,14 +29,12 @@ tide:
   queries:
   - repos:
     - tektoncd/pipeline
-    labels:
-    - lgtm
-    - approved
-    missingLabels:
-    - do-not-merge/hold
-    - do-not-merge/work-in-progress
-  - repos:
     - tektoncd/community
+    - tektoncd/plumbing
+    - tektoncd/dashboard
+    - tektoncd/cli
+    - tektoncd/experimental
+    - tektoncd/website
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
# Changes

Before this change only `community` and `pipeline` had automatic tide
merging via Prow. Now all of the existing repos will have it.

Partially addresses #3

(Also simplified the config, looking at the knative config as an example
https://github.com/knative/test-infra/blob/691caf51f2bb9ef86888772a8cc5d7952687b7c6/ci/prow/config.yaml#L51-L65
it looks like we can use the same stanza for multiple repos)

p.s. I have already applied this manually :innocent: 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._