### PR TITLE
Fix the catalog tests.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -333,6 +333,7 @@ presubmits:
       - name: github-token
         secret:
           secretName: oauth-token
+  tektoncd/catalog:
   - name: pull-tekton-catalog-build-tests
     agent: kubernetes
     context: pull-tekton-catalog-build-tests


### PR DESCRIPTION
# Changes

I missed the "tektoncd/catalog" section in yaml before. This
correctly moves the catalog tests to run on the right repo.

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

