### PR TITLE
Add an extra_initialization step before running tests

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -270,6 +270,10 @@ function main() {
     fi
   fi
 
+  if function_exists extra_initialization; then
+     extra_initialization
+  fi
+
   [[ -z $1 ]] && set -- "--all-tests"
 
   local TEST_TO_RUN=""


### PR DESCRIPTION
# Changes

This should allow user of these scripts to do extrat setup steps they
need for their tests to run later on. On example is, on
tektoncd/dashboard, to get `node` and `npm`.

The end goal is to create specific image, with the recipes hosted
here, for those cases 😉.

/cc @abayer @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._