### PR TITLE
Add a postsubmits to dashboard to push nightly images

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -526,3 +526,36 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+
+postsubmits:
+  tektoncd/dashboard:
+  - name: tekton-dashboard-publish-images
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/nightly-account/service-account.json"
+        - "--upload=gs://tekton-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/publish-images.sh"
+        volumeMounts:
+        - name: nightly-account
+          mountPath: /etc/nightly-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/nightly-account/service-account.json
+      volumes:
+      # this secret/service-account has access to the tekton-nightly project, specifically make it possible to push
+      # images to gcr.io/tekton-nightly 👼
+      - name: nightly-account
+        secret:
+          secretName: nightly-account


### PR DESCRIPTION
# Changes

This is the first take on having postsubmits jobs on tektoncd, to
publish nightly builds. We start with the simplest, aka dashboard

/cc @dlorenc 

Does the job definition make sense ?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._