### PR TITLE
Additional revert dep-collector repository path to knative.

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -349,7 +349,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool ./vendor/github.com/tektoncd/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.


### PR DESCRIPTION
# Changes

This repo exists in knative/test-infra. This repo does not exist in
tekton. We missed one in the previous fix :bowing_man: sorrryy !

cc @wlynch @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._