### PR TITLE
Double the number of boskos projects 📈

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
 
 Make sure the IAM account:
 `prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
+
+After editing `boskos/boskos-config.yaml`,
+[apply the updated ConfigMap](https://github.com/kubernetes/test-infra/tree/master/boskos#config-update)
+to the `tekton-releases` `prow` cluster.

--- a/boskos/boskos-config.yaml
+++ b/boskos/boskos-config.yaml
@@ -10,6 +10,13 @@ data:
       - tekton-prow-4
       - tekton-prow-5
       - tekton-prow-6
+      - tekton-prow-7
+      - tekton-prow-8
+      - tekton-prow-9
+      - tekton-prow-10
+      - tekton-prow-11
+      - tekton-prow-12
+      - tekton-prow-13
       state: dirty
       type: gke-project
 kind: ConfigMap


### PR DESCRIPTION
# Changes

We have been seeing errors in our automated end to end tests which
indicate that boskos (which use use to manage GCP projects for our end
to end tests - see #34 about maybe not using it anymore) had no projects
left. So this PR doubles the number of boskos projects.

Note that I have already manually applied this change to the boskos
cluster.

As you can see in https://github.com/tektoncd/community/pull/25 I
decided to not give everyone access to all 7 new projects b/c managing
fine grained access across 14 boskos projects is no fun at all 😩 but I
can add them anyway if folks want them.

Fixes #29

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._