### PR TITLE
Rollback the coverage image to the last tag.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -167,7 +167,7 @@ presubmits:
     clone_uri: "https://github.com/tektoncd/cli.git"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
+      - image: gcr.io/knative-tests/test-infra/coverage:v20190612-ae60484
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -506,7 +506,7 @@ presubmits:
     clone_uri: "https://github.com/tektoncd/pipeline.git"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
+      - image: gcr.io/knative-tests/test-infra/coverage:v20190612-ae60484
         imagePullPolicy: Always
         command:
         - "/coverage"


### PR DESCRIPTION
# Changes

The new image (at the tag latest) causes issues for our setup. It looks
like https://github.com/knative/test-infra/pull/852 hardcodes some default
values.

# Submitter Checklist

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._