### PR TITLE
Moveci-tekton-pipeline-nightly-release to postsubmit

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -813,26 +813,8 @@ postsubmits:
       - name: nightly-account
         secret:
           secretName: nightly-account
-    tektoncd/pipeline:
-  - name: post-tekton-pipeline-go-coverage
-    branches:
-    - master
-    agent: kubernetes
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest # we may want ours here
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--artifacts=$(ARTIFACTS)"
-        - "--cov-threshold-percentage=0"
-    
-
-periodics:
-  - cron: "31 8 * * *"
-    name: ci-tekton-pipeline-nightly-release
+  tektoncd/pipelines:
+  - name: tekton-pipeline-publish-images
     always_run: true
     spec:
       containers:
@@ -862,3 +844,17 @@ periodics:
       - name: nightly-account
         secret:
           secretName: nightly-account
+  - name: post-tekton-pipeline-go-coverage
+    branches:
+    - master
+    agent: kubernetes
+    decorate: true
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest # we may want ours here
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--artifacts=$(ARTIFACTS)"
+        - "--cov-threshold-percentage=0"


### PR DESCRIPTION
# Changes

I want to be able to see status and logs for this job, and currently
it doesn't show up in prow.tekton.dev, so moving it to postsubmit.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._