### PR TITLE
tektoncd/operator integration tests needs a Docker socket…

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -426,10 +426,14 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
+        securityContext:
+          privileged: true
       volumes:
       - name: test-account
         secret:


### PR DESCRIPTION
# Changes

We are using `DOCKER_IN_DOCKER_ENABLED` environment variable to setup
a docker-in-docker daemon for this job. Also needs `privileged`.

Note this is temporary, we can use alternative builder for `operator-sdk`, will update the image *and* upstream later on :angel: 

/cc @abayer 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._