### PR TITLE
Add a build-cross-tests job to the cli 🏗

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -95,6 +95,40 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-tekton-cli-build-cross-tests
+    agent: kubernetes
+    always_run: true
+    rerun_command: "/test pull-tekton-cli-build-cross-tests"
+    trigger: "(?m)^/test (all|pull-tekton-cli-build-cross-tests),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
+        imagePullPolicy: Always
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/test-account/service-account.json"
+        - "--upload=gs://tekton-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--build-cross-tests"
+        volumeMounts:
+        - name: test-account
+          mountPath: /etc/test-account
+          readOnly: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/test-account/service-account.json
+        - name: E2E_CLUSTER_REGION
+          value: us-central1
+      volumes:
+      - name: test-account
+        secret:
+          secretName: test-account
   - name: pull-tekton-cli-unit-tests
     agent: kubernetes
     always_run: true


### PR DESCRIPTION
# Changes

The cli is built for several targets (linux, windows, darwin) and
architecture (x86, x86_64, arm, …). Those takes time, so adding a job
for those to run in parallel of build.

It's already deployed.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._