### PR TITLE
Update base image used by test-runner image

### DIFF
--- a/prow/images/test-runner/Dockerfile
+++ b/prow/images/test-runner/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20190729-351ea95-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:latest-master
 LABEL maintainer "Adriano Cunha <adrcunha@google.com>"
 
 # Install extras on top of base image


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the base image used by the Prow test-runner image, to one that will remain up-to-date.

The previous base image was pinned to a specific date, which means we'd have to update it manually before future builds.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n/a ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ y ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._