### PR TITLE
tektoncd/pipeline postsubmit job needs docker socket access

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1028,12 +1028,17 @@ postsubmits:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/nightly-account/service-account.json
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
       volumes:
       # this secret/service-account has access to the tekton-nightly project, specifically make it possible to push
       # images to gcr.io/tekton-nightly 👼
       - name: nightly-account
         secret:
           secretName: nightly-account
+      # FIXME(vdemeester): use kaniko or buildah to build+push instead
+      securityContext:
+        privileged: true
   - name: post-tekton-pipeline-go-coverage
     branches:
     - master


### PR DESCRIPTION
# Changes

Updating the job to have those. Will need to fix later on to use
kaniko or a user-mode builder (most likely using pipeline itself)

/hold

1. I think that works :crossed_fingers: 
2. I wanna make sure there is no more change to do before merging this one

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._