### PR TITLE
Move docs into separate files 📝

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 This repo holds configuration for infrastructure used across the tektoncd org 🏗️:
 
-- [Prow](#prow) is used for
+- Automation runs [in the tektoncd GCP project](gcp.md)
+- [Prow](prow/README.md) is used for
   [pull request automation]((https://github.com/tektoncd/community/blob/master/process.md#reviews))
-- [Ingress](#ingress) configuration for access via `tekton.dev`
-- [Gubernator](#guberator) is used for holding and displaying [Prow](#prow) logs
-- [Boskos](#boskos) is used to control a pool of GCP projects which end to end tests can run against
+- [Ingress](prow/README.md#ingress) configuration for access via `tekton.dev`
+- [Gubernator](gubernator/README.md) is used for holding and displaying [Prow](prow/README.md) logs
+- [Boskos](boskos/README.md) is used to control a pool of GCP projects which end to end tests can run against
 
 ## Support
 
@@ -15,125 +16,3 @@ via the `#plumbing` channel.
 
 [Members of the Tekton governing board](goverance.md)
 [have access to the underlying resources](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access).
-
-## Prow
-
-- Prow runs in
-  [the GCP project `tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
-- Prow runs in
-  [the GKE cluster `prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
-- Prow uses the service account
-  `prow-account@tekton-releases.iam.gserviceaccount.com`
-  - Secrets for this account are configured in
-    [Prow's config.yaml](prow/config.yaml) via
-    `gcs_credentials_secret: "test-account"`
-- Prow configuration is in [infra/prow](./prow)
-
-_[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
-_[See the community docs](../CONTRIBUTING.md#pull-request-process) for more on
-Prow and the PR process._
-
-### Updating Prow itself
-
-Prow has been installed by taking the
-[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
-and modifying it for our needs.
-
-Updating (e.g. bumping the versions of the images being used) requires:
-
-0. If you are feeling cautious and motivated, manually backup the config values by hand
-   (see [prow.yaml](prow/prow.yaml) to see what values will be changed).
-1. Manually updating the `image` values and applying any other config changes found in the
-   [starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
-   to our [prow.yaml](prow/prow.yaml).
-2. Updating the `utility_images` in our [config.yaml](prow/config.yaml) if the version of
-   the `plank` component is changed.
-3. Applying the new configuration with:
-
-   ```yaml
-    # Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
-    gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
-
-    # Step 2: Update Prow itself
-    kubectl apply -f prow/prow.yaml
-
-    # Step 2: Update the configuration used by Prow
-    kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
-
-    # Step 3: Remember to configure kubectl to connect to your regular cluster!
-    gcloud container clusters get-credentials ...
-   ```
-4. Verify that the changes are working by opening a PR and **manually looking at the logs of each check**,
-   in case Prow has gotten into a state where failures are being reported as successes.
-
-These values have been removed from the original
-[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml):
-
-- The `ConfigMap` values `plugins` and `config` because they are generated from
-  [config.yaml](prow/config.yaml) and [plugins.yaml](prow/plugins.yaml)
-- The `Services` which were manually configured with a `ClusterIP` and other routing
-  information (`deck`, `tide`, `hook`)
-- The `Ingress` `ing` - Configuration for this is in [ingress.yaml](prow/ingress.yaml)
-- The `statusreconciler` Deployment, etc. - Created #54 to investigate adding this.
-- The `Role` values give `pod` permissions in the `default` namespace as well as `test-pods` -
-  The intention seems to be that `test-pods` be used to run the pods themselves, but we
-  don't currently have that configured in our [config.yaml](prow/config.yaml).
-
-### Updating Prow configuraiton
-
-TODO(#1) Apply config.yaml changes automatically
-
-Changes to [config.yaml](./prow/config.yaml) are not automatically reflected in
-the Prow cluster and must be manually applied.
-
-```bash
-# Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
-gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
-
-# Step 2: Update the configuration used by Prow
-kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
-
-# Step 3: Remember to configure kubectl to connect to your regular cluster!
-gcloud container clusters get-credentials ...
-```
-
-## Ingress
-
-- Ingress for prow is configured using
-  [cert-manager](https://github.com/jetstack/cert-manager/).
-- `cert-manager` was installed via `Helm` using this
-  [guide](https://docs.cert-manager.io/en/latest/getting-started/)
-- `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
-- https://prow.tekton.dev is pointed at the Cluster ingress address.
-
-## Gubernator
-
-- Gubernator is configured on App Engine in the project `tekton-releases`.
-- It was deployed using `gcloud app deploy .` with no configuration changes.
-- The configruation lives in [the gubernator dir](./gubernator).
-
-_[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernator)._
-
-## Boskos
-
-We use Boskos to manage GCP projects which end to end tests are run against.
-
-- Boskos configuration lives [in the `boskos` directory](./boskos)
-- It runs [in the `prow` cluster of the `tekton-releases` project](#prow), in
-  the namespace `test-pods`
-
-_[Boskos docs](https://github.com/kubernetes/test-infra/tree/master/boskos)._
-
-### Adding a project
-
-Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
-
-Make sure the IAM account:
-`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
-
-Also make sure the GKE API is enabled.
-You can do this by browsing to the GKE tab in the Cloud Console.
-
-After editing `boskos/boskos-config.yaml`,
-[apply the updated ConfigMap](https://github.com/kubernetes/test-infra/tree/master/boskos#config-update)
-to the `tekton-releases` `prow` cluster.

--- a/boskos/README.md
+++ b/boskos/README.md
@@ -1,0 +1,18 @@
+# Boskos
+
+We use Boskos to manage GCP projects which end to end tests are run against.
+
+- It runs [in the `prow` cluster of the `tekton-releases` project](../gcp.md), in
+  the namespace `test-pods`
+
+_[Boskos docs](https://github.com/kubernetes/test-infra/tree/master/boskos)._
+
+## Adding a project
+
+* Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
+* Make sure the IAM account:
+`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
+* Make sure the GKE API is enabled. You can do this by browsing to the GKE tab in the Cloud Console.
+* After editing `boskos/boskos-config.yaml`,
+[apply the updated ConfigMap](https://github.com/kubernetes/test-infra/tree/master/boskos#config-update)
+to the `tekton-releases` `prow` cluster.

--- a/gcp.md
+++ b/gcp.md
@@ -1,0 +1,16 @@
+# GCP project
+
+Automation for the `tektoncd` org runs in a GKE cluster which
+[members of the governing board](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access)
+have access to.
+
+- The GCP project the is used for GKE, storage, etc. is called
+  [`tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
+- The GKE cluster that `Prow` (and `Tekton`) run in is called
+  [`prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
+
+This project and cluster are used for:
+
+- [CI automation with Prow](prow.md)
+- Release automation, e.g.
+  [Tekton Pipelines releases](https://github.com/tektoncd/pipeline/tree/master/tekton#release-pipeline)

--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -1,0 +1,8 @@
+# Gubernator
+
+Gubernator is used to display logs and CI results.
+
+- Gubernator is configured on App Engine in the project `tekton-releases`.
+- It was deployed using `gcloud app deploy .` with no configuration changes.
+
+_[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernator)._

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,0 +1,96 @@
+# Prow
+
+`tektoncd` uses
+[`Prow`](https://github.com/kubernetes/test-infra/tree/master/prow)
+for CI automation.
+
+- Prow runs in [the tektoncd GCP project](../gcp.md)
+- [Ingress is configured to `prow.tekton.dev`](#ingress)
+- Prow results are displayed via [gubernator](../gubernator/README.md)
+- [Instructions for updating Prow](#updating-prow-itself)
+- [Instructions for updating Prow configuration](#updating-prow-configuration)
+
+_[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
+_[See the community docs](../CONTRIBUTING.md#pull-request-process) for more on
+Prow and the PR process._
+
+### Secrets
+
+- Prow uses the service account
+  `prow-account@tekton-releases.iam.gserviceaccount.com`
+- Secrets for this account are configured in [Prow's config.yaml](config.yaml) via
+  `gcs_credentials_secret: "test-account"`
+
+## Ingress
+
+- Ingress for prow is configured using
+  [cert-manager](https://github.com/jetstack/cert-manager/).
+- `cert-manager` was installed via `Helm` using this
+  [guide](https://docs.cert-manager.io/en/latest/getting-started/)
+- `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
+- https://prow.tekton.dev is pointed at the Cluster ingress address.
+- The configuration is in [ingress.yaml](./ingress.yaml)
+
+### Updating Prow itself
+
+Prow has been installed by taking the
+[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
+and modifying it for our needs.
+
+Updating (e.g. bumping the versions of the images being used) requires:
+
+0. If you are feeling cautious and motivated, manually backup the config values by hand
+   (see [prow.yaml](prow.yaml) to see what values will be changed).
+1. Manually updating the `image` values and applying any other config changes found in the
+   [starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
+   to our [prow.yaml](prow.yaml).
+2. Updating the `utility_images` in our [config.yaml](config.yaml) if the version of
+   the `plank` component is changed.
+3. Applying the new configuration with:
+
+   ```yaml
+    # Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
+    gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
+
+    # Step 2: Update Prow itself
+    kubectl apply -f prow/prow.yaml
+
+    # Step 2: Update the configuration used by Prow
+    kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+
+    # Step 3: Remember to configure kubectl to connect to your regular cluster!
+    gcloud container clusters get-credentials ...
+   ```
+4. Verify that the changes are working by opening a PR and **manually looking at the logs of each check**,
+   in case Prow has gotten into a state where failures are being reported as successes.
+
+These values have been removed from the original
+[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml):
+
+- The `ConfigMap` values `plugins` and `config` because they are generated from
+  [config.yaml](config.yaml) and [plugins.yaml](plugins.yaml)
+- The `Services` which were manually configured with a `ClusterIP` and other routing
+  information (`deck`, `tide`, `hook`)
+- The `Ingress` `ing` - Configuration for this is in [ingress.yaml](ingress.yaml)
+- The `statusreconciler` Deployment, etc. - Created #54 to investigate adding this.
+- The `Role` values give `pod` permissions in the `default` namespace as well as `test-pods` -
+  The intention seems to be that `test-pods` be used to run the pods themselves, but we
+  don't currently have that configured in our [config.yaml](config.yaml).
+
+### Updating Prow configuration
+
+TODO(#1) Apply config.yaml changes automatically
+
+Changes to [config.yaml](./config.yaml) are not automatically reflected in
+the Prow cluster and must be manually applied.
+
+```bash
+# Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
+gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
+
+# Step 2: Update the configuration used by Prow
+kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+
+# Step 3: Remember to configure kubectl to connect to your regular cluster!
+gcloud container clusters get-credentials ...
+```


### PR DESCRIPTION
# Changes

I am about to start adding some configuration to allow Prow to run
Tekton Pipelines (https://github.com/tektoncd/pipeline/issues/922)
and before I do that I wanted to reorganize the docs a bit to make it
easier to add a bit more detail and make the main README a bit less
busy.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._