### PR TITLE
Add a "hello world" Pipeline to be executed via Prow 🌏

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 This repo holds configuration for infrastructure used across the tektoncd org 🏗️:
 
-- [Prow](#prow) is used for
+- Automation runs [in the tektoncd GCP project](gcp.md)
+- [Prow](prow/README.md) is used for
   [pull request automation]((https://github.com/tektoncd/community/blob/master/process.md#reviews))
-- [Ingress](#ingress) configuration for access via `tekton.dev`
-- [Gubernator](#guberator) is used for holding and displaying [Prow](#prow) logs
-- [Boskos](#boskos) is used to control a pool of GCP projects which end to end tests can run against
+- [Ingress](prow/README.md#ingress) configuration for access via `tekton.dev`
+- [Gubernator](gubernator/README.md) is used for holding and displaying [Prow](prow/README.md) logs
+- [Boskos](boskos/README.md) is used to control a pool of GCP projects which end to end tests can run against
 
 ## Support
 
@@ -15,125 +16,3 @@ via the `#plumbing` channel.
 
 [Members of the Tekton governing board](goverance.md)
 [have access to the underlying resources](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access).
-
-## Prow
-
-- Prow runs in
-  [the GCP project `tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
-- Prow runs in
-  [the GKE cluster `prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
-- Prow uses the service account
-  `prow-account@tekton-releases.iam.gserviceaccount.com`
-  - Secrets for this account are configured in
-    [Prow's config.yaml](prow/config.yaml) via
-    `gcs_credentials_secret: "test-account"`
-- Prow configuration is in [infra/prow](./prow)
-
-_[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
-_[See the community docs](../CONTRIBUTING.md#pull-request-process) for more on
-Prow and the PR process._
-
-### Updating Prow itself
-
-Prow has been installed by taking the
-[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
-and modifying it for our needs.
-
-Updating (e.g. bumping the versions of the images being used) requires:
-
-0. If you are feeling cautious and motivated, manually backup the config values by hand
-   (see [prow.yaml](prow/prow.yaml) to see what values will be changed).
-1. Manually updating the `image` values and applying any other config changes found in the
-   [starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
-   to our [prow.yaml](prow/prow.yaml).
-2. Updating the `utility_images` in our [config.yaml](prow/config.yaml) if the version of
-   the `plank` component is changed.
-3. Applying the new configuration with:
-
-   ```yaml
-    # Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
-    gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
-
-    # Step 2: Update Prow itself
-    kubectl apply -f prow/prow.yaml
-
-    # Step 2: Update the configuration used by Prow
-    kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
-
-    # Step 3: Remember to configure kubectl to connect to your regular cluster!
-    gcloud container clusters get-credentials ...
-   ```
-4. Verify that the changes are working by opening a PR and **manually looking at the logs of each check**,
-   in case Prow has gotten into a state where failures are being reported as successes.
-
-These values have been removed from the original
-[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml):
-
-- The `ConfigMap` values `plugins` and `config` because they are generated from
-  [config.yaml](prow/config.yaml) and [plugins.yaml](prow/plugins.yaml)
-- The `Services` which were manually configured with a `ClusterIP` and other routing
-  information (`deck`, `tide`, `hook`)
-- The `Ingress` `ing` - Configuration for this is in [ingress.yaml](prow/ingress.yaml)
-- The `statusreconciler` Deployment, etc. - Created #54 to investigate adding this.
-- The `Role` values give `pod` permissions in the `default` namespace as well as `test-pods` -
-  The intention seems to be that `test-pods` be used to run the pods themselves, but we
-  don't currently have that configured in our [config.yaml](prow/config.yaml).
-
-### Updating Prow configuraiton
-
-TODO(#1) Apply config.yaml changes automatically
-
-Changes to [config.yaml](./prow/config.yaml) are not automatically reflected in
-the Prow cluster and must be manually applied.
-
-```bash
-# Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
-gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
-
-# Step 2: Update the configuration used by Prow
-kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
-
-# Step 3: Remember to configure kubectl to connect to your regular cluster!
-gcloud container clusters get-credentials ...
-```
-
-## Ingress
-
-- Ingress for prow is configured using
-  [cert-manager](https://github.com/jetstack/cert-manager/).
-- `cert-manager` was installed via `Helm` using this
-  [guide](https://docs.cert-manager.io/en/latest/getting-started/)
-- `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
-- https://prow.tekton.dev is pointed at the Cluster ingress address.
-
-## Gubernator
-
-- Gubernator is configured on App Engine in the project `tekton-releases`.
-- It was deployed using `gcloud app deploy .` with no configuration changes.
-- The configruation lives in [the gubernator dir](./gubernator).
-
-_[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernator)._
-
-## Boskos
-
-We use Boskos to manage GCP projects which end to end tests are run against.
-
-- Boskos configuration lives [in the `boskos` directory](./boskos)
-- It runs [in the `prow` cluster of the `tekton-releases` project](#prow), in
-  the namespace `test-pods`
-
-_[Boskos docs](https://github.com/kubernetes/test-infra/tree/master/boskos)._
-
-### Adding a project
-
-Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
-
-Make sure the IAM account:
-`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
-
-Also make sure the GKE API is enabled.
-You can do this by browsing to the GKE tab in the Cloud Console.
-
-After editing `boskos/boskos-config.yaml`,
-[apply the updated ConfigMap](https://github.com/kubernetes/test-infra/tree/master/boskos#config-update)
-to the `tekton-releases` `prow` cluster.

--- a/boskos/README.md
+++ b/boskos/README.md
@@ -1,0 +1,18 @@
+# Boskos
+
+We use Boskos to manage GCP projects which end to end tests are run against.
+
+- It runs [in the `prow` cluster of the `tekton-releases` project](../gcp.md), in
+  the namespace `test-pods`
+
+_[Boskos docs](https://github.com/kubernetes/test-infra/tree/master/boskos)._
+
+## Adding a project
+
+* Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
+* Make sure the IAM account:
+`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
+* Make sure the GKE API is enabled. You can do this by browsing to the GKE tab in the Cloud Console.
+* After editing `boskos/boskos-config.yaml`,
+[apply the updated ConfigMap](https://github.com/kubernetes/test-infra/tree/master/boskos#config-update)
+to the `tekton-releases` `prow` cluster.

--- a/gcp.md
+++ b/gcp.md
@@ -1,0 +1,16 @@
+# GCP project
+
+Automation for the `tektoncd` org runs in a GKE cluster which
+[members of the governing board](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access)
+have access to.
+
+- The GCP project the is used for GKE, storage, etc. is called
+  [`tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
+- The GKE cluster that `Prow` (and `Tekton`) run in is called
+  [`prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
+
+This project and cluster are used for:
+
+- [CI automation with Prow](prow.md)
+- Release automation, e.g.
+  [Tekton Pipelines releases](https://github.com/tektoncd/pipeline/tree/master/tekton#release-pipeline)

--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -1,0 +1,8 @@
+# Gubernator
+
+Gubernator is used to display logs and CI results.
+
+- Gubernator is configured on App Engine in the project `tekton-releases`.
+- It was deployed using `gcloud app deploy .` with no configuration changes.
+
+_[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernator)._

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,0 +1,96 @@
+# Prow
+
+`tektoncd` uses
+[`Prow`](https://github.com/kubernetes/test-infra/tree/master/prow)
+for CI automation.
+
+- Prow runs in [the tektoncd GCP project](../gcp.md)
+- [Ingress is configured to `prow.tekton.dev`](#ingress)
+- Prow results are displayed via [gubernator](../gubernator/README.md)
+- [Instructions for updating Prow](#updating-prow-itself)
+- [Instructions for updating Prow configuration](#updating-prow-configuration)
+
+_[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
+_[See the community docs](../CONTRIBUTING.md#pull-request-process) for more on
+Prow and the PR process._
+
+### Secrets
+
+- Prow uses the service account
+  `prow-account@tekton-releases.iam.gserviceaccount.com`
+- Secrets for this account are configured in [Prow's config.yaml](config.yaml) via
+  `gcs_credentials_secret: "test-account"`
+
+## Ingress
+
+- Ingress for prow is configured using
+  [cert-manager](https://github.com/jetstack/cert-manager/).
+- `cert-manager` was installed via `Helm` using this
+  [guide](https://docs.cert-manager.io/en/latest/getting-started/)
+- `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
+- https://prow.tekton.dev is pointed at the Cluster ingress address.
+- The configuration is in [ingress.yaml](./ingress.yaml)
+
+### Updating Prow itself
+
+Prow has been installed by taking the
+[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
+and modifying it for our needs.
+
+Updating (e.g. bumping the versions of the images being used) requires:
+
+0. If you are feeling cautious and motivated, manually backup the config values by hand
+   (see [prow.yaml](prow.yaml) to see what values will be changed).
+1. Manually updating the `image` values and applying any other config changes found in the
+   [starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml)
+   to our [prow.yaml](prow.yaml).
+2. Updating the `utility_images` in our [config.yaml](config.yaml) if the version of
+   the `plank` component is changed.
+3. Applying the new configuration with:
+
+   ```yaml
+    # Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
+    gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
+
+    # Step 2: Update Prow itself
+    kubectl apply -f prow/prow.yaml
+
+    # Step 2: Update the configuration used by Prow
+    kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+
+    # Step 3: Remember to configure kubectl to connect to your regular cluster!
+    gcloud container clusters get-credentials ...
+   ```
+4. Verify that the changes are working by opening a PR and **manually looking at the logs of each check**,
+   in case Prow has gotten into a state where failures are being reported as successes.
+
+These values have been removed from the original
+[starter.yaml](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml):
+
+- The `ConfigMap` values `plugins` and `config` because they are generated from
+  [config.yaml](config.yaml) and [plugins.yaml](plugins.yaml)
+- The `Services` which were manually configured with a `ClusterIP` and other routing
+  information (`deck`, `tide`, `hook`)
+- The `Ingress` `ing` - Configuration for this is in [ingress.yaml](ingress.yaml)
+- The `statusreconciler` Deployment, etc. - Created #54 to investigate adding this.
+- The `Role` values give `pod` permissions in the `default` namespace as well as `test-pods` -
+  The intention seems to be that `test-pods` be used to run the pods themselves, but we
+  don't currently have that configured in our [config.yaml](config.yaml).
+
+### Updating Prow configuration
+
+TODO(#1) Apply config.yaml changes automatically
+
+Changes to [config.yaml](./config.yaml) are not automatically reflected in
+the Prow cluster and must be manually applied.
+
+```bash
+# Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
+gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
+
+# Step 2: Update the configuration used by Prow
+kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
+
+# Step 3: Remember to configure kubectl to connect to your regular cluster!
+gcloud container clusters get-credentials ...
+```

--- a/prow/README.md
+++ b/prow/README.md
@@ -7,7 +7,7 @@ for CI automation.
 - Prow runs in [the tektoncd GCP project](../gcp.md)
 - [Ingress is configured to `prow.tekton.dev`](#ingress)
 - Prow results are displayed via [gubernator](../gubernator/README.md)
-- [Instructions for updating Prow](#updating-prow-itself)
+- [Instructions for updating Prow](#updating-prow-itself) and [Prow's Tekton Pipelines instance](#tekton-pipelines-with-prow)
 - [Instructions for updating Prow configuration](#updating-prow-configuration)
 
 _[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
@@ -76,6 +76,31 @@ These values have been removed from the original
 - The `Role` values give `pod` permissions in the `default` namespace as well as `test-pods` -
   The intention seems to be that `test-pods` be used to run the pods themselves, but we
   don't currently have that configured in our [config.yaml](config.yaml).
+
+#### Tekton Pipelines with Prow
+
+[Tekton Pipelines](https://github.com/tektoncd/pipelines) is also installed in the `prow`
+cluster so that Prow can trigger the execution of
+[`PipelineRuns`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md).
+
+[Since Prow only works with select versions of Tekton Pipelines](https://github.com/kubernetes/test-infra/issues/13948)
+the version currently installed in the cluster is v0.3.1:
+
+```bash
+kubectl apply --filename  https://storage.googleapis.com/tekton-releases/previous/v0.3.1/release.yaml
+```
+
+_See also [Tekton Pipelines installation instructions](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)._
+
+##### Hello World Pipeline
+
+Since Prow + Pipelines in this org are a WIP (see
+[#922](https://github.com/tektoncd/pipeline/issues/922)),
+the only job that is currently configured is
+[the hello scott Pipeline](prow/helloscott.yaml).
+
+This `Pipeline` (`special-hi-scott-pipeline`) is executed on every PR to this repo
+(`plumbing`) via the `try-out-prow-plus-tekton` Prow job.
 
 ### Updating Prow configuration
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -60,6 +60,22 @@ tide:
   target_url: https://prow.tekton.dev/tide
 
 presubmits:
+  tektoncd/plumbing:
+  - name: try-out-prow-plus-tekton
+    agent: tekton-pipeline
+    always_run: true
+    rerun_command: "/run try-out-tekton"
+    trigger: "(?m)^/run (all|try-out-tekton),?(\\s+|$)"
+    pipeline_run_spec:
+      trigger: # Required by versions 0.2.0 - v0.3.1 of Tekton Pipelines https://github.com/kubernetes/test-infra/issues/13948
+        type: manual
+      pipelineRef:
+        name: special-hi-scott-pipeline
+      resources:
+      - name: git
+        resourceRef:
+          name: PROW_IMPLICIT_GIT_REF # Used by Prow to create a PipelineResource with the triggering git ref
+
   tektoncd/cli:
   - name: pull-tekton-cli-build-tests
     agent: kubernetes

--- a/prow/helloscott.yaml
+++ b/prow/helloscott.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: try-some-stuff-out-scott
+spec:
+  inputs:
+    resources:
+    - name: git
+      type: git
+  steps:
+  - name: say-hi
+    image: busybox
+    command:
+    - echo
+    args:
+    - "hi scott!"
+  - name: cat-file
+    image: busybox
+    command:
+    - cat
+    args:
+    - /workspace/git/README.md
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: special-hi-scott-pipeline
+spec:
+  resources:
+  - name: git
+    type: git
+  tasks:
+  - name: cool-stuff
+    taskRef:
+      name: try-some-stuff-out-scott
+    resources:
+      inputs:
+      - name: git
+        resource: git

--- a/prow/prow.yaml
+++ b/prow/prow.yaml
@@ -836,3 +836,157 @@ subjects:
 #subjects:
 #- kind: ServiceAccount
 #  name: "statusreconciler"
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "crier"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+rules:
+- apiGroups:
+    - "prow.k8s.io"
+  resources:
+    - "prowjobs"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+    - "patch"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "crier"
+  namespace: "default"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "crier"
+subjects:
+- kind: ServiceAccount
+  name: "crier"
+  namespace: "default"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crier
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crier
+  template:
+    metadata:
+      labels:
+        app: crier
+    spec:
+      serviceAccountName: crier
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: crier
+        image: gcr.io/k8s-prow/crier:v20190814-9981dc3c5
+        args:
+        - --github-workers=1
+        - --config-path=/etc/config/config.yaml
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: config
+      - name: oauth
+        secret:
+          secretName: oauth-token
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prow-pipeline
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-pipeline
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - prow.k8s.io
+  resources:
+  - prowjobs
+  - prowjobs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-pipeline
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prow-pipeline
+subjects:
+- kind: ServiceAccount
+  name: prow-pipeline
+  namespace: default
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: prow-pipeline
+  namespace: default
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: prow-pipeline
+  template:
+    metadata:
+      labels:
+        app: prow-pipeline
+    spec:
+      serviceAccountName: prow-pipeline
+      containers:
+      - name: pipeline
+        image: gcr.io/k8s-prow/pipeline:v20190814-9981dc3c5
+        args:
+        - --all-contexts
+        - --config=/etc/prow-config/config.yaml
+        volumeMounts:
+        - mountPath: /etc/prow-config
+          name: prow-config
+          readOnly: true
+      volumes:
+      - name: prow-config
+        configMap:
+          name: config                           

--- a/prow/prow.yaml
+++ b/prow/prow.yaml
@@ -1,39 +1,3 @@
-# The content of this file is from https://github.com/kubernetes/test-infra/blob/master/prow/cluster/starter.yaml
-#---
-#
-# The content of the plugins ConfigMap lives in plugins.yaml and is updated with:
-# kubectl create configmap plugins --from-file=config.yaml=prow/plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
-#
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  namespace: default
-#  name: plugins
-#data:
-#  plugins.yaml: ""
-#---
-#
-# The content of the config ConfigMap lives in plugins.yaml and is updated with:
-# kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
-#
-#apiVersion: v1
-#kind: ConfigMap
-#metadata:
-#  namespace: default
-#  name: config
-#data:
-#  config.yaml: |
-#    prowjob_namespace: default
-#    pod_namespace: test-pods
-#    periodics:
-#    - interval: 10m
-#      agent: kubernetes
-#      name: echo-test
-#      spec:
-#        containers:
-#        - image: alpine
-#          command: ["/bin/date"]
-#---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -195,21 +159,24 @@ spec:
       - name: plugins
         configMap:
           name: plugins
-#---
-#
-# The configuration for this has been modified and applied manually.
-#
-#apiVersion: v1
-#kind: Service
-#metadata:
-#  namespace: default
-#  name: hook
-#spec:
-#  selector:
-#    app: hook
-#  ports:
-#  - port: 8888
-#  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hook
+  namespace: default
+spec:
+  clusterIP: 10.55.254.214
+  externalTrafficPolicy: Cluster
+  ports:
+  - nodePort: 30298
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: hook
+  sessionAffinity: None
+  type: NodePort
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -336,22 +303,24 @@ spec:
       - name: config
         configMap:
           name: config
-#---
-#
-# The configuration for this has been modified and applied manually.
-#
-#apiVersion: v1
-#kind: Service
-#metadata:
-#  namespace: default
-#  name: deck
-#spec:
-#  selector:
-#    app: deck
-#  ports:
-#  - port: 80
-#    targetPort: 8080
-#  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: deck
+  namespace: default
+spec:
+  clusterIP: 10.55.250.236
+  externalTrafficPolicy: Cluster
+  ports:
+  - nodePort: 31957
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: deck
+  sessionAffinity: None
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -431,46 +400,24 @@ spec:
       - name: config
         configMap:
           name: config
-#---
-#
-# The configuration for this has been modified and applied manually.
-#
-#apiVersion: v1
-#kind: Service
-#metadata:
-#  namespace: default
-#  name: tide
-#spec:
-#  selector:
-#    app: tide
-#  ports:
-#  - port: 80
-#    targetPort: 8888
-#  type: NodePort
-#---
-#
-# The configuration for this is in ingress.yaml
-#
-#apiVersion: extensions/v1beta1
-#kind: Ingress
-#metadata:
-#  namespace: default
-#  name: ing
-#spec:
-#  backend: # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend)
-#    serviceName: deck
-#    servicePort: 80
-#  rules:
-#  - http:
-#      paths:
-#      - path: /
-#        backend:
-#          serviceName: deck
-#          servicePort: 80
-#      - path: /hook
-#        backend:
-#          serviceName: hook
-#          servicePort: 8888
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tide
+  namespace: default
+spec:
+  clusterIP: 10.55.243.29
+  externalTrafficPolicy: Cluster
+  ports:
+  - nodePort: 31878
+    port: 80
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: tide
+  sessionAffinity: None
+  type: NodePort
 #---
 #
 # TODO(#54) This component was added after our initial Prow setup 


### PR DESCRIPTION
# Changes

A step toward https://github.com/tektoncd/pipeline/issues/922 !
    
This commit adds configuration and supporting docs to get Prow to execute a simple Pipeline on every pull request to the plumbing repo.
    
I am also working on docs in the Prow repo (for https://github.com/kubernetes/test-infra/issues/13874 and https://github.com/tektoncd/pipeline/issues/1187) to explain how one could put this all together from scratch.
    
One important caveat is that we were previously using the Tekton installation in this cluster to do manual releases, and we were keeping our release configuration up to date with the latest version of Tekton Pipelines. Because of https://github.com/kubernetes/test-infra/issues/13948 the newest version we can use with Prow is v0.3.1 so we need to keep our release configs in sync with this for now ( attn folks doing releases @vdemeester @a-roberts @mnuttall - the next thing I want to do is add release automation via Prow so hopefully this won't impact you for long!)
    
Note I have already manually applied this configuration to the cluster 🙏

p.s. This is branched off https://github.com/tektoncd/plumbing/pull/65 so the diff will get a bit smaller once that one is in!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._