### PR TITLE
Put securityContext on the right place for tektoncd/pipeline postsubmit

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1046,15 +1046,15 @@ postsubmits:
           value: /etc/nightly-account/service-account.json
         - name: DOCKER_IN_DOCKER_ENABLED
           value: "true"
+        # FIXME(vdemeester): use kaniko or buildah to build+push instead
+        securityContext:
+          privileged: true
       volumes:
       # this secret/service-account has access to the tekton-nightly project, specifically make it possible to push
       # images to gcr.io/tekton-nightly 👼
       - name: nightly-account
         secret:
           secretName: nightly-account
-      # FIXME(vdemeester): use kaniko or buildah to build+push instead
-      securityContext:
-        privileged: true
   - name: post-tekton-pipeline-go-coverage
     branches:
     - master


### PR DESCRIPTION
# Changes

I think I forgot to commit this, thus it got reseted when updating the
prow configuration from elsewhere.

/cc @abayer @bobcatfish

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._