### PR TITLE
Add nightly Pipeline + try to fix some upgrade test stuff

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -193,11 +193,17 @@ kubectl apply --filename  https://storage.googleapis.com/tekton-releases/previou
 
 _See also [Tekton Pipelines installation instructions](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)._
 
+#### Nightly Tekton Pipelines release
+
+The prow configuration includes a `periodic` job which invokes
+[the Tekton Pipelines nightly release Pipeline](https://github.com/tektoncd/pipeline/tree/master/tekton#nightly-releases).
+
 #### Hello World Pipeline
 
 Since Prow + Pipelines in this org are a WIP (see
 [#922](https://github.com/tektoncd/pipeline/issues/922)),
-the only job that is currently configured is
+the only job (besides [nightly releases](#nightly-tekton-pipelines-release))
+that is currently configured is
 [the hello scott Pipeline](prow/helloscott.yaml).
 
 This `Pipeline` (`special-hi-scott-pipeline`) is executed on every PR to this repo

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1070,43 +1070,43 @@ postsubmits:
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
 periodics:
-  - cron: "5 2 * * *"
-    name: ci-tekton-pipeline-upgrade
-    agent: kubernetes
-    decorate: true
-    extra_refs:
-      - org: tekton
-        repo: pipeline
-        base_ref: master
-        path_alias: github.com/tektoncd/pipeline
-    spec:
-      containers:
-        - image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
-          imagePullPolicy: Always
-          args:
-            - "--scenario=kubernetes_execute_bazel"
-            - "--clean"
-            - "--job=$(JOB_NAME)"
-            - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-            - "--root=/go/src"
-            - "--service-account=/etc/test-account/service-account.json"
-            - "--upload=gs://tekton-prow/pr-logs"
-            - "--" # end bootstrap args, scenario args below
-            - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-            - "./test/e2e-tests-upgrade.sh"
-          volumeMounts:
-            - name: test-account
-              mountPath: /etc/test-account
-              readOnly: true
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/test-account/service-account.json
-            - name: E2E_CLUSTER_REGION
-              value: us-central1
-      volumes:
-        - name: test-account
-          secret:
-            secretName: test-account
+- cron: "5 2 * * *"
+  name: ci-tekton-pipeline-upgrade
+  agent: kubernetes
+  decorate: true
+  extra_refs:
+  - org: tekton
+    repo: pipeline
+    base_ref: master
+    path_alias: github.com/tektoncd/pipeline
+  spec:
+    containers:
+    - image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
+      imagePullPolicy: Always
+      args:
+      - "--scenario=kubernetes_execute_bazel"
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/tektoncd/pipeline=master"
+      - "--root=/go/src"
+      - "--service-account=/etc/test-account/service-account.json"
+      - "--upload=gs://tekton-prow/pr-logs"
+      - "--" # end bootstrap args, scenario args below
+      - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+      - "./test/e2e-tests-upgrade.sh"
+      volumeMounts:
+      - name: test-account
+        mountPath: /etc/test-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/test-account/service-account.json
+      - name: E2E_CLUSTER_REGION
+        value: us-central1
+    volumes:
+    - name: test-account
+      secret:
+        secretName: test-account
 # Nightly release for Tekton Pipelines: https://github.com/tektoncd/pipeline/tree/master/tekton#nightly-releases
 - cron: "0 0  * * *"
   name: tekton-pipelines-nightly-release

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1107,3 +1107,66 @@ periodics:
         - name: test-account
           secret:
             secretName: test-account
+# Nightly release for Tekton Pipelines: https://github.com/tektoncd/pipeline/tree/master/tekton#nightly-releases
+- cron: "0 0  * * *"
+  name: tekton-pipelines-nightly-release
+  agent: tekton-pipeline
+  extra_refs:
+  - org: tektoncd
+    repo: pipeline
+    base_ref: master
+  pipeline_run_spec:
+    trigger:
+      type: manual
+    serviceAccount: "release-right-meow"
+    pipelineRef:
+      name: pipeline-release-nightly
+    resources:
+    - name: bucket
+      resourceRef:
+        name: tekton-bucket-nightly
+    - name: source-repo
+      resourceRef:
+        name: PROW_EXTRA_GIT_REF_0
+    - name: builtKoImage
+      resourceRef:
+        name: ko-image
+    - name: builtBaseImage
+      resourceRef:
+        name: base-image
+    - name: builtEntrypointImage
+      resourceRef:
+        name: entrypoint-image
+    - name: builtKubeconfigWriterImage
+      resourceRef:
+        name: kubeconfigwriter-image
+    - name: builtCredsInitImage
+      resourceRef:
+        name: creds-init-image
+    - name: builtGitInitImage
+      resourceRef:
+        name: git-init-image
+    - name: builtNopImage
+      resourceRef:
+        name: nop-image
+    - name: builtBashImage
+      resourceRef:
+        name: bash-image
+    - name: builtGsutilImage
+      resourceRef:
+        name: gsutil-image
+    - name: builtControllerImage
+      resourceRef:
+        name: controller-image
+    - name: builtWebhookImage
+      resourceRef:
+        name: webhook-image
+    - name: builtDigestExporterImage
+      resourceRef:
+        name: digest-exporter-image
+    - name: builtPullRequestInitImage
+      resourceRef:
+        name: pull-request-init-image
+    - name: builtGcsFetcherImage
+      resourceRef:
+        name: gcs-fetcher-image


### PR DESCRIPTION
# Changes

Unfortunately this PR is a mix of 2 different changes b/c the changes all had to go into the same file and I had to fix them at the same time to apply them. They are in 2 separate commits tho!

## Change 1: Nightly release pipeline

Add nightly Pipelines release crescent_moon

This is the configuration to run the Pipeline + Tasks being added in
tektoncd/pipeline#1274 every night at midnight
PDT.

I've successfully run this by setting the cron to every 5 minutes. This
configuration is already applied to the repo.

Status can be seen at https://prow.tekton.dev/?type=periodic.

Part of tektoncd/pipeline#860

## Change 2: Trying to get upgrade test running (WIP)

Trying to get upgrade test working construction

It looked like the indentation was off, and also some of the environment
variables (e.g. $PULL_REF) provided to presubmit jobs aren't provided
to presubmit jobs. I tried to copy example configuration in the
kubernetes test-infra repo but the prow "initupload" container is still
failing with an error about cloning refs.

(continuation of #56)

Needs some more work tho @houshengbo @vdemeester 

I think the only significant change in the PR is `github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"` being hardcoded now. I also changed some indentation to be consistent but I'm not sure that mattered.

It still isn't working (https://prow.tekton.dev/?type=periodic).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._