### PR TITLE
Remove unused start_latest_tekton_serving

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -310,23 +310,6 @@ function report_go_test() {
   return ${failed}
 }
 
-# Install the latest stable Tekton/serving in the current cluster.
-function start_latest_tekton_serving() {
-  header "Starting Tekton Serving"
-  subheader "Installing Istio"
-  echo "Running Istio CRD from ${TEKTON_ISTIO_CRD_YAML}"
-  kubectl apply -f ${TEKTON_ISTIO_CRD_YAML} || return 1
-  wait_until_batch_job_complete istio-system || return 1
-  echo "Installing Istio from ${TEKTON_ISTIO_YAML}"
-  kubectl apply -f ${TEKTON_ISTIO_YAML} || return 1
-  wait_until_pods_running istio-system || return 1
-  kubectl label namespace default istio-injection=enabled || return 1
-  subheader "Installing Tekton Serving"
-  echo "Installing Serving from ${TEKTON_SERVING_RELEASE}"
-  kubectl apply -f ${TEKTON_SERVING_RELEASE} || return 1
-  wait_until_pods_running tekton-serving || return 1
-}
-
 # Run a go tool, installing it first if necessary.
 # Parameters: $1 - tool package/dir for go get/install.
 #             $2 - tool to run.


### PR DESCRIPTION
The function start_latest_tekton_serving is not used and it's not
doing anything useful either. It looks like it came from
's/knative/tekton/g'.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._