### PR TITLE
Fix tektoncd/pipeline upgrade tests periodics job : no decorate 🍂

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1073,7 +1073,6 @@ periodics:
 - cron: "5 2 * * *"
   name: ci-tekton-pipeline-upgrade-tests
   agent: kubernetes
-  decorate: true
   extra_refs:
   - org: tektoncd
     repo: pipeline


### PR DESCRIPTION
# Changes

`ci-tekton-pipeline-upgrade-tests` should not be decorated (see
https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md
for what decorate does).

/cc @abayer @afrittoli @bobcatfish 

Already deployed, the job is running :tada: (it might fail, but if it fails, the fix would be on on tektoncd/pipeline) (logs [here](https://prow.tekton.dev/log?job=ci-tekton-pipeline-upgrade-tests&id=1180049492594921472))

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._