### PR TITLE
Add a dockerfile and deployment description for pipelinerun-logs

### DIFF
--- a/pipelinerun-logs/Dockerfile
+++ b/pipelinerun-logs/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.13.1-alpine3.10
+WORKDIR /go/src/pipelinerun-logs
+COPY . .
+RUN go build -o ./pipelinerun-logs ./cmd/http
+CMD ["./pipelinerun-logs"]

--- a/pipelinerun-logs/deployment.yaml
+++ b/pipelinerun-logs/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pipelinerun-logs-deployment
+  labels:
+    app: pipelinerun-logs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pipelinerun-logs
+  template:
+    metadata:
+      labels:
+        app: pipelinerun-logs
+    spec:
+      containers:
+      - name: pipelinerun-logs
+        image: gcr.io/tekton-releases/github.com/tektoncd/plumbing/pipelinerun-logs/cmd/http
+        command:
+        - "./pipelinerun-logs"
+        args:
+        - "--project"
+        - "tekton-releases"
+        - "--cluster"
+        - "dogfooding"
+        - "--namespace"
+        - "default"
+        - "--hostname"
+        - "0.0.0.0"
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit working on pipelinerun-logs required pulling the
code down locally and then manually constructing a container from it.

This commit adds a Dockerfile and example kubernetes deployment for
running pipelinerun-logs.

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)