### PR TITLE
Add tkn to test runner

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1106,6 +1106,29 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- cron: "0 1  * * *"
+  name: tekton-runner-image-nigtly
+  agent: tekton-pipeline
+  extra_refs:
+  - org: tektoncd
+    repo: plumbing
+    base_ref: master
+  pipeline_run_spec:
+    trigger:
+      type: manual
+    serviceAccount: "release-right-meow"
+    pipelineRef:
+      name: pipeline-test-runner-image-nightly
+    params:
+      - name: CONTEXT
+        value: ./prow/images/test-runner/
+    resources:
+    - name: source-repo
+      resourceRef:
+        name: PROW_EXTRA_GIT_REF_0
+    - name: image
+      resourceRef:
+        name: test-runner-image
 # Nightly release for Tekton Pipelines: https://github.com/tektoncd/pipeline/tree/master/tekton#nightly-releases
 - cron: "0 0  * * *"
   name: tekton-pipelines-nightly-release

--- a/prow/images/tekton/pipeline-test-runner-image.yaml
+++ b/prow/images/tekton/pipeline-test-runner-image.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline-test-runner-image-nightly
+spec:
+  params:
+  - name: CONTEXT
+    description: The build context used by Kaniko.
+    default: ./
+  resources:
+  - name: source-repo
+    type: git
+  - name: image
+    type: image
+  tasks:
+  - name: build
+    taskRef:
+      name: kaniko
+    params:
+    - name: CONTEXT
+      value: ${params.CONTEXT}
+    resources:
+      inputs:
+      - name: source
+        resource: source-repo
+      outputs:
+      - name: image
+        resource: image

--- a/prow/images/tekton/resources.yaml
+++ b/prow/images/tekton/resources.yaml
@@ -1,0 +1,21 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: test-runner-image
+spec:
+  type: image
+  params:
+  - name: url
+    value: gcr.io/tekton-releases/tests/test-runner

--- a/prow/images/tekton/task-kaniko.yaml
+++ b/prow/images/tekton/task-kaniko.yaml
@@ -1,0 +1,49 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: kaniko
+spec:
+  inputs:
+    params:
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+    - name: CONTEXT
+      description: The build context used by Kaniko.
+      default: ./
+    resources:
+    - name: source
+      type: git
+
+  outputs:
+    resources:
+    - name: image
+      type: image
+
+  steps:
+  - name: build-and-push
+    workingdir: /workspace/source
+    image: gcr.io/kaniko-project/executor:v0.13.0
+    # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
+    # https://github.com/tektoncd/pipeline/pull/706
+    env:
+    - name: DOCKER_CONFIG
+      value: /builder/home/.docker
+    command:
+    - /kaniko/executor
+    - --dockerfile=${inputs.params.DOCKERFILE}
+    - --context=/workspace/source/${inputs.params.CONTEXT} # The user does not need to care the workspace and the source.
+    - --destination=${outputs.resources.image.url}

--- a/prow/images/test-runner/Dockerfile
+++ b/prow/images/test-runner/Dockerfile
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 FROM gcr.io/k8s-testimages/kubekins-e2e:v20190729-351ea95-master
-LABEL maintainer "Adriano Cunha <adrcunha@google.com>"
+LABEL maintainer "Vincent Demeester <vdemeest@redhat.com>"
 
 # Install extras on top of base image
-
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN gcloud components update
@@ -34,7 +33,7 @@ RUN go get -u github.com/google/ko/cmd/ko
 RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/google/licenseclassifier
 RUN go get -u github.com/jstemmer/go-junit-report
-RUN go get -u github.com/raviqqe/liche
+RUN GO111MODULE="on" go get -u github.com/raviqqe/liche
 RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # Extra tools through gem

--- a/prow/images/test-runner/Dockerfile
+++ b/prow/images/test-runner/Dockerfile
@@ -36,6 +36,11 @@ RUN go get -u github.com/jstemmer/go-junit-report
 RUN GO111MODULE="on" go get -u github.com/raviqqe/liche
 RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
+ARG TKN_VERSION=0.4.0
+RUN curl -LO https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz && \
+    tar xvzf tkn_${TKN_VERSION}_Linux_x86_64.tar.gz -C /usr/local/bin tkn && \
+    rm tkn_${TKN_VERSION}_Linux_x86_64.tar.gz
+
 # Extra tools through gem
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
 RUN gem install mdl


### PR DESCRIPTION
# Changes

This does a few things:
- Fix the current image build (`make images` fails on `liche`)
- Add tkn to the image
- Add a prow job using `tektoncd-pipeline` to build it nightly − that way, it's gonna be quicker to see that the build fails *and* we won't need to build the image manually when we need to update it on the cluster.

/cc @afrittoli 
I decided to go with prow but we may want to use the dogfooding cluster for this instead (and thus not be stuck in 0.3.x)

This is linked to https://github.com/tektoncd/pipeline/pull/1414

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._