### PR TITLE
Add a task for preprelease checks

### DIFF
--- a/tekton/prerelease_checks.yaml
+++ b/tekton/prerelease_checks.yaml
@@ -1,0 +1,84 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: prerelease-checks
+spec:
+  inputs:
+    params:
+    - name: package
+      description: package to release
+      default: github.com/tektoncd/pipeline
+    - name: versionTag
+      description: The X.Y.Z version that the artifacts would be tagged with
+    resources:
+    - name: source-to-release
+      type: git
+    - name: release-bucket
+      type: storage
+  steps:
+    - name: check-git-tag
+      image: alpine/git
+      command:
+      - /bin/sh
+      args:
+      - -ce
+      - |
+        echo "Checking git tag"
+        # Look for the tag in the list of tags
+        git ls-remote --tags https://$(inputs.params.package) | \
+          grep $(inputs.params.versionTag) || exit 0
+        # If the version was found fail
+        echo "Version $(inputs.params.versionTag) already tagged for $(inputs.params.package)"
+        exit 1
+    - name: check-release-file
+      image: alpine
+      command:
+      - /bin/sh
+      args:
+      - -ce
+      - |
+        echo "Checking release file"
+        # Check if the release file already exists
+        if [ -f $(inputs.resources.release-bucket.path)/previous/$(inputs.params.versionTag)/release.yaml ]; then
+          echo "Release file already exists for $(inputs.params.versionTag) in the release bucket,"
+          echo "but no git tag was found. To continue remove the release file first."
+          exit 1
+        fi
+    - name: check-github-release
+      image: python:3.6-alpine3.9
+      command:
+      - /bin/sh
+      args:
+      - -ce
+      - |
+        echo "Checking GitHub release"
+        PACKAGE=$(echo $(inputs.params.package) | cut -d/ -f2,3)
+        # Check if the release exists on GitHub
+        wget -q -O- --header 'Accept: application/vnd.github.v3+json' \
+          https://api.github.com/repos/${PACKAGE}/releases | \
+          python -c 'import sys; import json; print("\n".join([x["tag_name"] for x in json.load(sys.stdin)]))' | \
+          grep $(inputs.params.versionTag) || exit 0
+        echo "Release $(inputs.params.versionTag) already exists for $(inputs.params.package)"
+        exit 1
+    - name: success-confirmation
+      image: alpine
+      command:
+      - /bin/sh
+      args:
+      - -ce
+      - |
+        echo "All prelease checks for $(inputs.params.package) @ $(inputs.params.versionTag) where successful"
+        echo "Happy releasing 😺"


### PR DESCRIPTION
Add a tasks that verifies if a release already exists. This is
useful before generating a release, to make sure we do not
overwrite an existing release. Checks are:
- tag already exists in git
- release file already exists in the bucket
- release already defined in GitHub

Closes bug tektoncd/pipeline#983

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._