### PR TITLE
Deploy pipelinerun-logs with ko

### DIFF
--- a/pipelinerun-logs/README.md
+++ b/pipelinerun-logs/README.md
@@ -34,3 +34,8 @@ the Prow Build ID to be provided as a query parameter. Example url:
 ```
 https://app-public-address/?buildid=12345678
 ```
+
+## Deploying This App To Kubernetes
+
+You can deploy this app using `ko`. Simply run `ko apply -f ./config` from
+the 'pipelinerun-logs' directory of this repo.

--- a/pipelinerun-logs/cmd/http/main.go
+++ b/pipelinerun-logs/cmd/http/main.go
@@ -8,7 +8,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"cloud.google.com/go/logging/logadmin"
-	"github.com/sbwsg/loggingsvc/pkg/config"
+	"github.com/tektoncd/plumbing/pipelinerun-logs/pkg/config"
 )
 
 func main() {

--- a/pipelinerun-logs/cmd/http/server.go
+++ b/pipelinerun-logs/cmd/http/server.go
@@ -12,7 +12,7 @@ import (
 
 	"cloud.google.com/go/logging"
 	"cloud.google.com/go/logging/logadmin"
-	"github.com/sbwsg/loggingsvc/pkg/config"
+	"github.com/tektoncd/plumbing/pipelinerun-logs/pkg/config"
 	"golang.org/x/xerrors"
 	"google.golang.org/api/iterator"
 )

--- a/pipelinerun-logs/config/deployment.yaml
+++ b/pipelinerun-logs/config/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: pipelinerun-logs
-        image: gcr.io/tekton-releases/github.com/tektoncd/plumbing/pipelinerun-logs/cmd/http
+        image: github.com/tektoncd/plumbing/pipelinerun-logs/cmd/http
         command:
         - "./pipelinerun-logs"
         args:

--- a/pipelinerun-logs/go.mod
+++ b/pipelinerun-logs/go.mod
@@ -1,4 +1,4 @@
-module github.com/sbwsg/loggingsvc
+module github.com/tektoncd/plumbing/pipelinerun-logs
 
 go 1.12
 


### PR DESCRIPTION
# Changes

This PR updates the import paths and deployment for the pipelinerun-logs
app so that it can be built and deployed simply using `ko`.

In doing this I realized that I'd left imports pointing to my personal github so those have been fixed with this commit as well.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
