### PR TITLE
Configure stackdriver access for pipelinerun-logs app

### DIFF
--- a/pipelinerun-logs/README.md
+++ b/pipelinerun-logs/README.md
@@ -39,3 +39,16 @@ https://app-public-address/?buildid=12345678
 
 You can deploy this app using `ko`. Simply run `GO111MODULE=on ko apply -f ./config` from
 the 'pipelinerun-logs' directory of this repo.
+
+## Access to Stackdriver
+
+This app relies on access to the Stackdriver API in order to fetch log
+entries for a given Prow Build ID. This requires a cluster running on GKE
+with "Stackdriver Kubernetes Engine Monitoring" enabled.
+
+### Service Account
+
+This app's `ko` deployment is configured to use a service account named
+"pipelinerun-logs-viewer" when accessing the Stackdriver API. This service
+account has been added to the dogfooding cluster with a Workload Identity
+that ties it to an IAM service account in the Google Cloud Console.

--- a/pipelinerun-logs/config/deployment.yaml
+++ b/pipelinerun-logs/config/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: pipelinerun-logs
     spec:
+      # this service account has access to the stackdriver API
+      # via workload identity
+      serviceAccountName: pipelinerun-logs-viewer
       containers:
       - name: pipelinerun-logs
         image: github.com/tektoncd/plumbing/pipelinerun-logs/cmd/http
@@ -30,3 +33,6 @@ spec:
         - "9999"
         ports:
         - containerPort: 9999
+      nodeSelector:
+        # Schedule this deployment onto nodes with workload identity enabled
+        iam.gke.io/gke-metadata-server-enabled: true


### PR DESCRIPTION
# Changes
The pipelinerun-logs app needs access to stackdriver APIs in order to show log entries for pipelineruns. GCP supports a feature called workload identities that enables a k8s serviceaccount to refer to an IAM serviceaccount and use its credentials when accessing google cloud apis. This means we don't need to download JSON keys and inject them as secrets for apps running in the cluster to utilize cloud apis.

I've created a service account in GCP that has access to stackdriver, I've created a corollary service account in k8s (in the default namespace) that references the GCP service account, and I've created a node pool that has the workload identity metadata service running. The pipelinerun-logs deployment has been updated to schedule its pods on the new nodes and after manual testing the app seems to now have access to stackdriver APIs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)