### PR TITLE
As `cmd/{bash,nop,gsutil}` image are gone, removing them from plumbing ⛏

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1213,15 +1213,6 @@ periodics:
     - name: builtGitInitImage
       resourceRef:
         name: git-init-image
-    - name: builtNopImage
-      resourceRef:
-        name: nop-image
-    - name: builtBashImage
-      resourceRef:
-        name: bash-image
-    - name: builtGsutilImage
-      resourceRef:
-        name: gsutil-image
     - name: builtControllerImage
       resourceRef:
         name: controller-image

--- a/tekton/resources/pipeline-nightly-build-trigger.yaml
+++ b/tekton/resources/pipeline-nightly-build-trigger.yaml
@@ -108,15 +108,6 @@ spec:
       - name: builtGitInitImage
         resourceRef:
           name: git-init-image
-      - name: builtNopImage
-        resourceRef:
-          name: nop-image
-      - name: builtBashImage
-        resourceRef:
-          name: bash-image
-      - name: builtGsutilImage
-        resourceRef:
-          name: gsutil-image
       - name: builtControllerImage
         resourceRef:
           name: controller-image


### PR DESCRIPTION
# Changes

See tektoncd/pipeline#1503.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @ImJasonH

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._