### PR TITLE
Add script for setting up GCP project permissions 🔒

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 This repo holds configuration for infrastructure used across the tektoncd org 🏗️:
 
 - Automation runs [in the tektoncd GCP project](gcp.md)
+- The script [addpermissions.py](addpermissions.py) gives users access to
+  [the GCP projects](gcp.md)
 - [Prow](prow/README.md) is used for
   [pull request automation]((https://github.com/tektoncd/community/blob/master/process.md#reviews))
 - [Ingress](prow/README.md#ingress) configuration for access via `tekton.dev`
 - [Gubernator](gubernator/README.md) is used for holding and displaying [Prow](prow/README.md) logs
 - [Boskos](boskos/README.md) is used to control a pool of GCP projects which end to end tests can run against
+
 
 ## Support
 

--- a/addpermissions.py
+++ b/addpermissions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+"""
+addpermissions.py gives users access to the Tekton GCP projects
+
+In order to interact with GCP resources
+(https://github.com/tektoncd/plumbing/blob/master/gcp.md)
+folks sometimes need to be able to do actions like push images and view
+a project in the web console.
+
+This script will add the permissions allowed to folks on the governing board
+(https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access)
+to all GCP projects.
+
+
+This script requires the `gcloud` command line tool and the python
+`PyYaml` library.
+"""
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+import urllib.request
+import yaml
+from typing import List
+
+
+ROLES = (
+  "roles/container.admin",
+  "roles/iam.serviceAccountUser",
+  "roles/storage.admin",
+  "roles/viewer",
+)
+KNOWN_PROJECTS = (
+  "tekton-releases",
+  "tekton-nightly",
+)
+BOSKOS_CONFIG_URL = "https://raw.githubusercontent.com/tektoncd/plumbing/master/boskos/boskos-config.yaml"
+
+
+def gcloud_required() -> None:
+  if shutil.which("gcloud") is None:
+    sys.stderr.write("gcloud binary is required; https://cloud.google.com/sdk/install")
+    sys.exit(1)
+
+
+def add_to_all_projects(user: str, projects: List[str]) -> None:
+  for project in projects:
+    for role in ROLES:
+      subprocess.check_call(shlex.split(
+          "gcloud projects add-iam-policy-binding {} --member user:{} --role {}".format(project, user, role)
+      ))
+
+
+def parse_boskos_projects() -> List[str]:
+  config = urllib.request.urlopen(BOSKOS_CONFIG_URL).read()
+  c = yaml.load(config)
+  nested_config = c["data"]["config"]
+  cc = yaml.load(nested_config)
+  return cc["resources"][0]["names"]
+
+
+if __name__ == '__main__':
+  arg_parser = argparse.ArgumentParser(
+      description="Give a user access to all plumbing resources")
+  arg_parser.add_argument("--user", type=str, required=True,
+                          help="The name of the user's account, usually their email address")
+  args = arg_parser.parse_args()
+
+  gcloud_required()
+
+  boskos_projects = parse_boskos_projects()
+  add_to_all_projects(args.user, list(KNOWN_PROJECTS) + boskos_projects)
+


### PR DESCRIPTION
# Changes

In https://github.com/tektoncd/pipeline/issues/1500 @vdemeester wanted
to be able to access our boskos projects to try to debug it but I had
been lazy and not given everyone access b/c there are so many of them. I
didn't want to do it (lazy) but then I realized that a script would make
it easy! So I wrote this script; it doesn't have any tests or automation
yet but eventually we could execute it as part of a Tekton pipeline and
use it to make sure permissions are always what we expect.

I've run this for @vdemeester @afrittoli @abayer @kimsterv 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._