### PR TITLE
Accept UUID as well as Prow-format Build IDs

### DIFF
--- a/pipelinerun-logs/cmd/http/query.go
+++ b/pipelinerun-logs/cmd/http/query.go
@@ -3,15 +3,10 @@ package main
 import (
 	"errors"
 	"fmt"
-	"regexp"
 )
 
 const (
 	StackdriverBuildIDLabel = "k8s-pod/prow_k8s_io/build-id"
-)
-
-var (
-	buildIDRegex = regexp.MustCompile(`^[0-9]+$`)
 )
 
 type Query struct {
@@ -35,9 +30,6 @@ func (q *Query) Validate() error {
 	}
 	if q.BuildID == "" {
 		return errors.New("Invalid query: missing build id")
-	}
-	if !buildIDRegex.MatchString(q.BuildID) {
-		return errors.New("Invalid query: build id does not match expected pattern")
 	}
 	return nil
 }

--- a/pipelinerun-logs/cmd/http/query_test.go
+++ b/pipelinerun-logs/cmd/http/query_test.go
@@ -41,38 +41,6 @@ func TestValidate(t *testing.T) {
 			BuildID:   "",
 		},
 		expectedError: "build id",
-	}, {
-		q: Query{
-			Project:   "FooProject",
-			Cluster:   "FooCluster",
-			Namespace: "FooNamespace",
-			BuildID:   "12345a6",
-		},
-		expectedError: "pattern",
-	}, {
-		q: Query{
-			Project:   "FooProject",
-			Cluster:   "FooCluster",
-			Namespace: "FooNamespace",
-			BuildID:   "alphabet",
-		},
-		expectedError: "pattern",
-	}, {
-		q: Query{
-			Project:   "FooProject",
-			Cluster:   "FooCluster",
-			Namespace: "FooNamespace",
-			BuildID:   "123456!",
-		},
-		expectedError: "pattern",
-	}, {
-		q: Query{
-			Project:   "FooProject",
-			Cluster:   "FooCluster",
-			Namespace: "FooNamespace",
-			BuildID:   " ",
-		},
-		expectedError: "pattern",
 	}} {
 		err := tc.q.Validate()
 		if err == nil || !strings.Contains(err.Error(), tc.expectedError) {

--- a/pipelinerun-logs/cmd/http/server_test.go
+++ b/pipelinerun-logs/cmd/http/server_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tektoncd/plumbing/pipelinerun-logs/pkg/config"
+)
+
+func TestValidateBuildID(t *testing.T) {
+	for _, tc := range []struct {
+		buildID   string
+		shouldErr bool
+	}{{
+		buildID:   "",
+		shouldErr: true,
+	}, {
+		buildID:   " ",
+		shouldErr: true,
+	}, {
+		buildID:   "abcdef12-abc1-def2-abc3-def123456789",
+		shouldErr: false,
+	}, {
+		buildID:   "123456",
+		shouldErr: false,
+	}} {
+		conf := &config.Config{
+			Hostname:  "",
+			Port:      "",
+			Project:   "",
+			Cluster:   "",
+			Namespace: "",
+		}
+		s := &Server{
+			conf:        conf,
+			client:      nil,
+			adminClient: nil,
+			entriesTmpl: nil,
+		}
+		err := s.validateBuildID(tc.buildID)
+		if tc.shouldErr && err == nil {
+			t.Errorf("expected error for build ID %q but received none", tc.buildID)
+		} else if !tc.shouldErr && err != nil {
+			t.Errorf("didnt expect error for build ID %q but received: %v", tc.buildID, err)
+		}
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We'd like to be able to annotate our dogfooding pipelineruns with uuid
Build IDs so that we can look them up using the pipelinerun log viewer.

At the moment the viewer only accepts "prow-format" build IDs which are
just strings of ints. This commit updates the server to also accept
UUIDs.

# Submitter Checklist

- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
