### PR TITLE
Add yamllint to the test-runner image and scripts 📦

### DIFF
--- a/prow/images/test-runner/Dockerfile
+++ b/prow/images/test-runner/Dockerfile
@@ -53,6 +53,9 @@ RUN curl -LO https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/t
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
 RUN gem install mdl -v 0.5.0
 
+# Extra tools through pip
+RUN pip install yamllint
+
 # Temporarily add test-infra to the image to build custom tools
 RUN mkdir -p /go/src/github.com/knative/ && git clone https://github.com/knative/test-infra.git /go/src/github.com/knative/test-infra && \
     make -C /go/src/github.com/knative/test-infra/tools/githubhelper && \

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -21,6 +21,7 @@ source $(dirname ${BASH_SOURCE})/library.sh
 
 # Custom configuration of presubmit tests
 readonly DISABLE_MD_LINTING=${DISABLE_MD_LINTING:-0}
+readonly DISABLE_YAML_LINTING=${DISABLE_YAML_LINTING:-0}
 readonly DISABLE_MD_LINK_CHECK=${DISABLE_MD_LINK_CHECK:-0}
 readonly PRESUBMIT_TEST_FAIL_FAST=${PRESUBMIT_TEST_FAIL_FAST:-0}
 
@@ -129,9 +130,17 @@ function markdown_build_tests() {
   return ${failed}
 }
 
+# Perform yaml build tests if necessary, unless disabled.
+function yaml_build_tests() {
+    (( DISABLE_YAML_LINTING )) && return 0
+    subheader "Linting the yaml files"
+    yamllint "${CHANGED_FILES}"
+}
+
 # Default build test runner that:
 # * check go code style with gofmt
 # * check markdown files
+# * check yaml files
 # * `go build` on the entire repo
 # * run `/hack/verify-codegen.sh` (if it exists)
 # * check licenses in all go packages
@@ -146,6 +155,8 @@ function default_build_test_runner() {
   echo "$gofmt_out"
   # Perform markdown build checks first
   markdown_build_tests || failed=1
+  # Check yaml using yamllint
+  yaml_build_tests || failed=1
   # For documentation PRs, just check the md files
   (( IS_DOCUMENTATION_PR )) && return ${failed}
   # Skip build test if there is no go code


### PR DESCRIPTION
# Changes

- Add yamllint binary to the test-runner image
- Add an yamllint check to `build_test`, that can be disabled using
  the environment variable `DISABLE_YAML_LINTING`

This is related to tektoncd/catalog#101 but should be useful for more repositories :wink: 

/cc @chmouel @afrittoli @abayer @bobcatfish 

I'll update the test-runner image once the nightly builds it and bump `tektoncd/plumbing` on the tektoncd repositories :wink: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._