### PR TITLE
Linting yamls with yamllint 🏷

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,38 @@
+ignore: |
+  /vendor
+  prow/prow.yaml
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+    ignore: |
+      prow/config.yaml
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: enable
+  hyphens: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning
+
+  # accept both     key:
+  #                   - item
+  #
+  # and             key:
+  #                 - item
+  indentation:
+    indent-sequences: whatever

--- a/boskos/boskos-config.yaml
+++ b/boskos/boskos-config.yaml
@@ -24,4 +24,3 @@ metadata:
   creationTimestamp: null
   name: resources
   namespace: test-pods
-

--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -111,7 +111,7 @@ spec:
   - metadata:
       name: boskos-volume
     spec:
-      accessModes: [ "ReadWriteOnce" ]
+      accessModes: ["ReadWriteOnce"]
       storageClassName: boskos
       resources:
         requests:

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -1,4 +1,4 @@
-
+---
 # Copyright 2018 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -34,7 +34,7 @@ default:
       name: area/release
       target: issues
       addedBy: label
-    - color: 008672
+    - color: "008672"
       description: Indicates an issue on dogfooding (aka using Pipeline to test Pipeline)
       name: area/dogfooding
       target: issues
@@ -122,7 +122,7 @@ default:
       target: issues
       prowPlugin: help
       addedBy: anyone
-    - color: 008672
+    - color: "008672"
       description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
       name: 'help wanted'
       previously:
@@ -234,7 +234,7 @@ default:
       prowPlugin: require-matching-label
       addedBy: prow
     - color: b60205
-      description: Indicates a PR that requires an org member to verify it is safe to test. # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
+      description: Indicates a PR that requires an org member to verify it is safe to test.  # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
       name: needs-ok-to-test
       target: prs
       prowPlugin: trigger
@@ -252,25 +252,25 @@ default:
       prowPlugin: require-matching-label
       addedBy: prow
     - color: 15dd18
-      description: Indicates a non-member PR verified by an org member that is safe to test. # This is the opposite of needs-ok-to-test and should be mutually exclusive.
+      description: Indicates a non-member PR verified by an org member that is safe to test.  # This is the opposite of needs-ok-to-test and should be mutually exclusive.
       name: ok-to-test
       target: prs
       prowPlugin: trigger
       addedBy: prow
     - color: fef2c0
-      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done. # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
+      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.  # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
       name: priority/awaiting-more-evidence
       target: both
       prowPlugin: label
       addedBy: anyone
     - color: fbca04
-      description: Higher priority than priority/awaiting-more-evidence. # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
+      description: Higher priority than priority/awaiting-more-evidence.  # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
       name: priority/backlog
       target: both
       prowPlugin: label
       addedBy: anyone
     - color: e11d21
-      description: Highest priority. Must be actively worked on as someone's top priority right now. # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
+      description: Highest priority. Must be actively worked on as someone's top priority right now.  # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
       name: priority/critical-urgent
       target: both
       prowPlugin: label
@@ -294,13 +294,13 @@ default:
       prowPlugin: releasenote
       addedBy: prow
     - color: c2e0c6
-      description: Denotes a PR that introduces potentially breaking changes that require user action. # These actions will be specifically called out when it comes time to generate release notes.
+      description: Denotes a PR that introduces potentially breaking changes that require user action.  # These actions will be specifically called out when it comes time to generate release notes.
       name: release-note-action-required
       target: prs
       prowPlugin: releasenote
       addedBy: prow
     - color: c2e0c6
-      description: Denotes a PR that doesn't merit a release note. # will be ignored when it comes time to generate release notes.
+      description: Denotes a PR that doesn't merit a release note.  # will be ignored when it comes time to generate release notes.
       name: release-note-none
       target: prs
       prowPlugin: releasenote
@@ -381,12 +381,12 @@ repos:
         addedBy: humans
   tektoncd/pipeline:
     labels:
-    - color: e11d21
-      description: Categorizes issue or PR as related to the beta api
-      name: kind/beta-blocking
-      target: both
-      prowPlugin: label
-      addedBy: anyone
+      - color: e11d21
+        description: Categorizes issue or PR as related to the beta api
+        name: kind/beta-blocking
+        target: both
+        prowPlugin: label
+        addedBy: anyone
       - color: ffcdc4
         description: For consideration when planning the next milestone
         name: maybe-next-milestone

--- a/prow/ingress.yaml
+++ b/prow/ingress.yaml
@@ -21,4 +21,4 @@ spec:
       - backend:
           serviceName: hook
           servicePort: 8888
-        path: /hook    
+        path: /hook

--- a/tekton/config/nightly-image-build-cron-base/trigger-image-build.yaml
+++ b/tekton/config/nightly-image-build-cron-base/trigger-image-build.yaml
@@ -16,7 +16,7 @@ kind: CronJob
 metadata:
   name: image-build-cron-trigger
 spec:
-  schedule: "0 2 * * *" # Daily at 2am
+  schedule: "0 2 * * *"  # Daily at 2am
   jobTemplate:
     spec:
       template:

--- a/tekton/config/nightly-release-cron-base/trigger-with-uuid.yaml
+++ b/tekton/config/nightly-release-cron-base/trigger-with-uuid.yaml
@@ -16,7 +16,7 @@ kind: CronJob
 metadata:
   name: pipeline-cron-trigger
 spec:
-  schedule: "0 2 * * *" # Daily at 2am
+  schedule: "0 2 * * *"  # Daily at 2am
   jobTemplate:
     spec:
       template:

--- a/tekton/resources/install_tekton_release.yaml
+++ b/tekton/resources/install_tekton_release.yaml
@@ -38,7 +38,7 @@ spec:
       default: default
   steps:
 
-  - name: make-pipeline-folder # This is a hack to have a consistent folder structure
+  - name: make-pipeline-folder  # This is a hack to have a consistent folder structure
     image: busybox
     command:
     - /bin/sh
@@ -105,7 +105,7 @@ spec:
       description: The vX.Y.Z version that we want to install (including `v`)
   steps:
 
-  - name: make-pipeline-folder # This is a hack to have a consistent folder structure
+  - name: make-pipeline-folder  # This is a hack to have a consistent folder structure
     image: busybox
     command:
     - /bin/sh


### PR DESCRIPTION
# Changes

Next update of plumbing will enable `yamllint` check, so this make
sure we have linted yaml before 👼

Related to tektoncd/catalog#101 (not closing it yet as the CI is not hooked up, needs tektoncd/plumbing#111 and a prow config update :stuck_out_tongue: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._