### PR TITLE
Add quotes to fix the pipelinerun logs app deployment

### DIFF
--- a/pipelinerun-logs/config/deployment.yaml
+++ b/pipelinerun-logs/config/deployment.yaml
@@ -35,4 +35,4 @@ spec:
         - containerPort: 9999
       nodeSelector:
         # Schedule this deployment onto nodes with workload identity enabled
-        iam.gke.io/gke-metadata-server-enabled: true
+        iam.gke.io/gke-metadata-server-enabled: "true"


### PR DESCRIPTION
I tried deploying the pipelinerun logs app with the latest version
of the deployment, but it fails unless quotes are used for "true".

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._