### PR TITLE
 Install a pinned stable version of golangci-lint  instead of master

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -42,12 +42,14 @@ RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/google/licenseclassifier
 RUN go get -u github.com/jstemmer/go-junit-report
 RUN GO111MODULE="on" go get -u github.com/raviqqe/liche
-RUN go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
-ARG TKN_VERSION=0.4.0
-RUN curl -LO https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz && \
-    tar xvzf tkn_${TKN_VERSION}_Linux_x86_64.tar.gz -C /usr/local/bin tkn && \
-    rm tkn_${TKN_VERSION}_Linux_x86_64.tar.gz
+# Install GolangCI linter: https://github.com/golangci/golangci-lint/
+ARG GOLANGCI_VERSION=1.21.0
+RUN curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
+
+# Install the TektonCD CLI: https://github.com/tektoncd/cli/
+ARG TKN_VERSION=0.5.1
+RUN curl -sL https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz | tar -C /usr/local/bin -xvzf - --wildcards "tkn"
 
 # Extra tools through gem
 RUN gem install mixlib-config -v 2.2.4  # required because ruby is 2.1
@@ -61,4 +63,3 @@ RUN mkdir -p /go/src/github.com/knative/ && git clone https://github.com/knative
     make -C /go/src/github.com/knative/test-infra/tools/githubhelper && \
     cp /go/src/github.com/knative/test-infra/tools/githubhelper/githubhelper /usr/local/bin && \
     go install github.com/knative/test-infra/tools/dep-collector
-


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

 Install golangci-lint from a pinned version

Let's install golangci-lint from a stable pinned version instead of master which
can brings weird CI breakage.

Closes #125

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [?] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._