### PR TITLE
Add a image with `hub` and a nightly build job

### DIFF
--- a/tekton/config/hub-image-nightly-build-cron/cronjob.yaml
+++ b/tekton/config/hub-image-nightly-build-cron/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-build-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: el-image-builder.default.svc.cluster.local:8080
+            - name: GIT_REPOSITORY
+              value: github.com/tektoncd/plumbing
+            - name: GIT_REVISION
+              value: master
+            - name: TARGET_IMAGE
+              value: gcr.io/tekton-releases/dogfooding/hub:latest
+            - name: CONTEXT_PATH
+              value: tekton/images/hub

--- a/tekton/config/hub-image-nightly-build-cron/kustomization.yaml
+++ b/tekton/config/hub-image-nightly-build-cron/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../nightly-image-build-cron-base
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-hub"

--- a/tekton/images/hub/Dockerfile
+++ b/tekton/images/hub/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM alpine:3.10
+LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+
+ARG HUB_VERSION=2.13.0
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN apk add --no-cache \
+    git=2.22.0-r0 \
+    bash=5.0.0-r0 \
+    hub=${HUB_VERSION}-r0


### PR DESCRIPTION
Hub is a CLI interface to GitHub. This image will be used to run release automation scripts.
Add a cronjob that builds the image nightly to tag "latest".