### PR TITLE
Use tektoncd CLI 0.5.1

### DIFF
--- a/tekton/images/tkn/Dockerfile
+++ b/tekton/images/tkn/Dockerfile
@@ -14,5 +14,5 @@
 FROM alpine:3.10
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
-ARG TKN_VERSION=0.4.0
+ARG TKN_VERSION=0.5.1
 RUN wget -O- https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin


### PR DESCRIPTION
Update tektoncd cli container image to pull out from the latest tektoncd-cli release (0.5.1)