### PR TITLE
Write changed files to file instead of storing in a global var.

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -41,16 +41,23 @@ IS_PRESUBMIT_EXEMPT_PR=0
 # Flags that this PR contains only changes to documentation.
 IS_DOCUMENTATION_PR=0
 
+# Directory to use for temporary files.
+WORK_DIR=""
+
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
-  [[ -z "$(echo "${CHANGED_FILES}" | grep -v "\(${1// /\\|}\)$")" ]]
+  [[ -z "$(cat "${CHANGED_FILES}" | grep -v "\(${1// /\\|}\)$")" ]]
 }
 
 # List changed files in the current PR.
 # This is implemented as a function so it can be mocked in unit tests.
 function list_changed_files() {
-  githubhelper -list-changed-files
+  local file="${WORK_DIR}/changed_files"
+  if [[ ! -f ${file} ]]; then
+    githubhelper -list-changed-files > ${file}
+  fi
+  echo ${file}
 }
 
 # Initialize flags and context for presubmit tests:
@@ -60,9 +67,12 @@ function initialize_environment() {
   IS_PRESUBMIT_EXEMPT_PR=0
   IS_DOCUMENTATION_PR=0
   (( ! IS_PRESUBMIT )) && return
+  trap teardown_environment EXIT
+
+  WORK_DIR=$(mktemp -d)
   CHANGED_FILES="$(list_changed_files)"
-  if [[ -n "${CHANGED_FILES}" ]]; then
-    echo -e "Changed files in commit ${PULL_PULL_SHA}:\n${CHANGED_FILES}"
+  if [[ -n "$(cat ${CHANGED_FILES})" ]]; then
+    echo -e "Changed files in commit ${PULL_PULL_SHA}:\n$(cat ${CHANGED_FILES})"
     local no_presubmit_files="${NO_PRESUBMIT_FILES[*]}"
     pr_only_contains "${no_presubmit_files}" && IS_PRESUBMIT_EXEMPT_PR=1
     pr_only_contains "\.md ${no_presubmit_files}" && IS_DOCUMENTATION_PR=1
@@ -72,6 +82,10 @@ function initialize_environment() {
   readonly CHANGED_FILES
   readonly IS_DOCUMENTATION_PR
   readonly IS_PRESUBMIT_EXEMPT_PR
+}
+
+function teardown_environment() {
+  rm -rf ${WORK_DIR}
 }
 
 # Display a pass/fail banner for a test group.
@@ -114,7 +128,7 @@ function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
   # Get changed markdown files (ignore /vendor and deleted files)
   local mdfiles=""
-  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/ | grep -v ^third_party/); do
+  for file in $(cat "${CHANGED_FILES}" | grep \.md$ | grep -v '^vendor/' | grep -v '^third_party/'); do
     [[ -f "${file}" ]] && mdfiles="${mdfiles} ${file}"
   done
   [[ -z "${mdfiles}" ]] && return 0
@@ -135,7 +149,11 @@ function yaml_build_tests() {
   (( DISABLE_YAML_LINTING )) && return 0
   subheader "Linting the yaml files"
   local yamlfiles=""
-  for file in $(echo "${CHANGED_FILES}" | grep '\.yaml$\|\.yml$' | grep -v ^vendor/); do
+   
+  for file in $(cat ${CHANGED_FILES}); do
+    [[ -z $(echo "${file}" | grep '\.yaml$\|\.yml$' | grep -v '^vendor/' | grep -v '^third_party/') ]] && continue
+
+    echo "found ${file}"
     [[ -f "${file}" ]] && yamlfiles="${yamlfiles} ${file}"
   done
   [[ -z "${yamlfiles}" ]] && return 0


### PR DESCRIPTION
For large PRs, presubmit tests break if we store the changed files in a
global variable. This changes the behavior to store the filepaths on
disk to avoid this issue.

Example in production: https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/1607/pull-tekton-pipeline-build-tests/1202649284323840002/

Simple shell reproduction:

```
$ FILES=$(find $GOPATH/src/github.com/tektoncd/pipeline -type f)
$ ls
<works fine>
$ export FILES
$ ls
bash: /usr/bin/ls: Argument list too long
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._