### PR TITLE
Add a ko-gcloud image

### DIFF
--- a/tekton/config/ko-gcloud-image-nightly-build-cron/cronjob.yaml
+++ b/tekton/config/ko-gcloud-image-nightly-build-cron/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-build-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: el-image-builder.default.svc.cluster.local:8080
+            - name: GIT_REPOSITORY
+              value: github.com/tektoncd/plumbing
+            - name: GIT_REVISION
+              value: master
+            - name: TARGET_IMAGE
+              value: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+            - name: CONTEXT_PATH
+              value: tekton/images/ko-gcloud

--- a/tekton/config/ko-gcloud-image-nightly-build-cron/kustomization.yaml
+++ b/tekton/config/ko-gcloud-image-nightly-build-cron/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../nightly-image-build-cron-base
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-ko-gcloud

--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -1,0 +1,10 @@
+FROM google/cloud-sdk:latest
+
+# Install golang
+RUN curl https://dl.google.com/go/go1.13.linux-amd64.tar.gz > go1.13.tar.gz
+RUN tar -C /usr/local -xzf go1.13.tar.gz
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+# Install ko
+ENV GOBIN=/usr/local/go/bin
+RUN go get github.com/google/ko/cmd/ko


### PR DESCRIPTION
# Changes

The release job uses gcloud for auth in the ko step, so we need an image
with both ko and gcloud. This is inspired on the image from the pipeline
repo, and it's built nightly to a dedicated tag of the ko repo:
ko:gcloud-latest


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._