### PR TITLE
Update test-infra import to place tools in $GOPATH/src/knative.dev/…

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,7 +79,7 @@ skipped.
 ### Sample presubmit test script
 
 ```bash
-source vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+source vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 
 function post_build_tests() {
   echo "Cleaning up after build tests"
@@ -187,7 +187,7 @@ the test cluster is created in a specific region, `us-west2`.
 # This test requires a cluster in LA
 E2E_CLUSTER_REGION=us-west2
 
-source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+source vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 function knative_setup() {
   start_latest_knative_serving
@@ -259,7 +259,7 @@ This is a helper script for Knative release scripts. To use it:
 ### Sample release script
 
 ```bash
-source vendor/github.com/knative/test-infra/scripts/release.sh
+source vendor/knative.dev/test-infra/scripts/release.sh
 
 function build_release() {
   # config/ contains the manifests

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -339,7 +339,7 @@ function update_licenses() {
     # See https://github.com/google/go-licenses/issues/11
     chmod +w $(find ${dst} -type d)
   else
-    run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
+    run_go_tool ./vendor/knative.dev/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
   fi
 }
 
@@ -352,7 +352,7 @@ function check_licenses() {
     # Fetch the google/licenseclassifier for its license db
     go get -u github.com/google/licenseclassifier
     # Check that we don't have any forbidden licenses in our images.
-    run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
+    run_go_tool ./vendor/knative.dev/test-infra/tools/dep-collector dep-collector -check $@
   fi
 }
 

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -59,7 +59,7 @@ RUN gem install mdl -v 0.5.0
 RUN pip install yamllint
 
 # Temporarily add test-infra to the image to build custom tools
-RUN mkdir -p /go/src/github.com/knative/ && git clone https://github.com/knative/test-infra.git /go/src/github.com/knative/test-infra && \
-    make -C /go/src/github.com/knative/test-infra/tools/githubhelper && \
-    cp /go/src/github.com/knative/test-infra/tools/githubhelper/githubhelper /usr/local/bin && \
-    go install github.com/knative/test-infra/tools/dep-collector
+RUN mkdir -p /go/src/knative.dev/ && git clone https://knative.dev/test-infra.git /go/src/knative.dev/test-infra && \
+    make -C /go/src/knative.dev/test-infra/tools/githubhelper && \
+    cp /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper /usr/local/bin && \
+    go install knative.dev/test-infra/tools/dep-collector


### PR DESCRIPTION
# Changes

> This installs knative/test-infra deps into `$GOPATH/src/knative.dev/test-infra` instead of at their old path.

Closes #63

/cc @afrittoli @ImJasonH 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._