### PR TITLE
Deploy Tekton services from release with overlay

### DIFF
--- a/tekton/cd/pipeline/base/kustomization.yaml
+++ b/tekton/cd/pipeline/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/tekton/cd/pipeline/overlays/dogfooding/config-artifact-bucket.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/config-artifact-bucket.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: tekton-pipelines
+data:
+  bucket.service.account.field.name: GOOGLE_APPLICATION_CREDENTIALS
+  bucket.service.account.secret.key: release.json
+  bucket.service.account.secret.name: release-secret

--- a/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- config-artifact-bucket.yaml

--- a/tekton/resources/release/install_tekton_release.yaml
+++ b/tekton/resources/release/install_tekton_release.yaml
@@ -36,38 +36,42 @@ spec:
     - name: default-service-account
       description: Service account to be setup as default in Tekton configmap
       default: default
+    - name: environment
+      description: Name of the target environment. Used to apply relevant overalys
+      default: dogfooding
   steps:
 
-  - name: make-pipeline-folder  # This is a hack to have a consistent folder structure
-    image: busybox
-    command:
-    - /bin/sh
-    args:
-    - -ce
-    - |
-      if [ "$(inputs.params.projectName)" == "pipeline" ]; then
-        mkdir -p "$(inputs.resources.release-bucket.path)/$(inputs.params.projectName)" || true
-        ln -s $(inputs.resources.release-bucket.path)/previous $(inputs.resources.release-bucket.path)/$(inputs.params.projectName)/
+  - name: deploy-tekton-project
+    image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+    workingDir: $(inputs.resources.plumbing-library.path)/tekton/cd
+    script: |
+      #!/usr/bin/env bash
+      set -exo pipefail
+
+      if [ ! -d $(inputs.params.projectName) ]; then
+        # There are is not base or project for $(inputs.params.projectName)
+        # Apply the release as is
+        kubectl apply \
+          --filename $(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)/release.yaml \
+          --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
+      else
+          # If the base exists, an overlay for the specified environment must exist
+          if [ ! -d $(inputs.params.projectName)/overlays/$(inputs.params.environment) ]; then
+            echo "Environment $(inputs.params.environment) not found for project $(inputs.params.projectName)"
+            exit 1
+          fi
+          cp $(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)/release.yaml $(inputs.params.projectName)/base/release.yaml
+          find .
+          kubectl apply \
+            --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig \
+            -k $(inputs.params.projectName)/overlays/$(inputs.params.environment)
       fi
 
-  - name: deploy-tekton-project
-    image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
-    command:
-    - /bin/bash
-    args:
-    - -ce
-    - |
-      kubectl apply \
-      --filename $(inputs.resources.release-bucket.path)/$(inputs.params.projectName)/previous/$(inputs.params.version)/release.yaml \
-      --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
-
   - name: setup-default-service-account
-    image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
-    command:
-    - /bin/bash
-    args:
-    - -ce
-    - |
+    image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+    script: |
+      #!/usr/bin/env bash
+      set -exo pipefail
       kubectl patch \
       cm/config-defaults -n "$(inputs.params.namespace)" \
       -p '{"data": {"default-service-account": "$(inputs.params.default-service-account)"}}'
@@ -76,12 +80,10 @@ spec:
       -l app.kubernetes.io/name=tekton-pipelines | xargs kubectl delete -n "$(inputs.params.namespace)"
 
   - name: wait-until-pods-running
-    image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
-    command:
-    - /bin/bash
-    args:
-    - -ce
-    - |
+    image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+    script: |
+      #!/usr/bin/env bash
+      set -exo pipefail
       source $(inputs.resources.plumbing-library.path)/scripts/library.sh
       wait_until_pods_running "$(inputs.params.namespace)"
     env:
@@ -105,20 +107,8 @@ spec:
       description: The vX.Y.Z version that we want to install (including `v`)
   steps:
 
-  - name: make-pipeline-folder  # This is a hack to have a consistent folder structure
-    image: busybox
-    command:
-    - /bin/sh
-    args:
-    - -ce
-    - |
-      if [ "$(inputs.params.projectName)" == "pipeline" ]; then
-        mkdir -p "$(inputs.resources.release-bucket.path)/$(inputs.params.projectName)" || true
-        ln -s $(inputs.resources.release-bucket.path)/previous $(inputs.resources.release-bucket.path)/$(inputs.params.projectName)/
-      fi
-
   - name: compare-github-vs-bucket
-    image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
+    image: gcr.io/tekton-releases/tests/test-runner
     command:
     - /bin/sh
     args:
@@ -154,7 +144,7 @@ spec:
   steps:
 
   - name: cleanup-resources
-    image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
+    image: gcr.io/tekton-releases/tests/test-runner
     command:
     - /bin/bash
     args:
@@ -167,7 +157,7 @@ spec:
       done
 
   - name: uninstall-tekton-project
-    image: gcr.io/tekton-releases/tests/test-runner@sha256:a4a64b2b70f85a618bbbcc6c0b713b313b2e410504dee24c9f90ec6fe3ebf63f
+    image: gcr.io/tekton-releases/tests/test-runner
     env:
       - name: KUBECONFIG
         value: /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig


### PR DESCRIPTION
Add support for deploying a release of a Tekton service using
overlays for kustomize. Add an overlay for pipeline that set
up the artifact bucket for the dogfooding environment.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._