### PR TITLE
Update Version to 0.6.0 for tkn Image

### DIFF
--- a/tekton/images/tkn/Dockerfile
+++ b/tekton/images/tkn/Dockerfile
@@ -14,5 +14,5 @@
 FROM alpine:3.10
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
-ARG TKN_VERSION=0.5.1
+ARG TKN_VERSION=0.6.0
 RUN wget -O- https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin


### PR DESCRIPTION
This was updated for [test-runner](https://github.com/tektoncd/plumbing/blob/847dcf196de9555b15ff6ebb397d11513aa920d2/tekton/images/test-runner/Dockerfile#L51), but now updating version to v0.6.0 for tkn image.

# Submitter Checklist

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
