### PR TITLE
An EnvVar needs to be a string otherwise prow fails 😟

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -618,7 +618,7 @@ presubmits:
         - name: E2E_CLUSTER_REGION
           value: us-central1
         - name: DISABLE_MD_LINK_CHECK
-          value: true
+          value: "true"
       volumes:
       - name: test-account
         secret:


### PR DESCRIPTION
# Changes

This made `hook` and `plank` fail and crashloop…

/cc @sbwsg @afrittoli @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._