### PR TITLE
Add support to mount another secret "e2e-secret" into integration tests.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -682,6 +682,9 @@ presubmits:
         - name: test-account
           mountPath: /etc/test-account
           readOnly: true
+        - name: e2e-secrets
+          mountPath: /etc/e2e-secret
+          readOnly: true
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
@@ -691,6 +694,9 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+      - name: e2e-secrets
+        secret:
+          secretName: e2e-secret
   - name: pull-tekton-pipeline-go-coverage
     agent: kubernetes
     always_run: true


### PR DESCRIPTION
# Changes

This secret will contain credentials used to access APIs required in tests.
Examples include:
- github/gitlab tokens for the PR resource
- registry tokens
- more!

We should still strive to make tests hermetic where possible, but test coverage
with secrets and service dependencies is better than no coverage.

See https://github.com/tektoncd/pipeline/pull/1557 for the other half of how this
will be used.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._