### PR TITLE
Make labels a bit easier for build cops 👮‍♀️

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -61,12 +61,24 @@ default:
       prowPlugin: label
       addedBy: anyone
     
-    # Kinds and areas
+    # Areas
     - color: 0052cc
       description: Indicates an issue or PR that deals with the API.
       name: area/api
       target: issues
       addedBy: label
+    - color: 7057ff
+      description: Indicates an issue on release (process, tasks).
+      name: area/release
+      target: issues
+      addedBy: label
+    - color: 10677f
+      description: Issues or PRs related to the plumbing infrastructure but needing attention in a non-plumbing repo.
+      name: area/plumbing
+      target: both
+      addedBy: label
+    
+    # Kinds
     - color: e11d21
       description: Categorizes issue or PR as related to a bug.
       name: kind/bug
@@ -75,6 +87,9 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - color: f7c6c7
+      description: Categorizes issue or PR as related to a flakey test. Please escalate this and treat it as an emergency.
+      name: kind/flake
     - color: c7def8
       description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
       name: kind/cleanup
@@ -105,6 +120,30 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    
+    # For further discussion in the next Productivity WG meeting
+
+    # Would like to understand when this label should be used vs. using GitHub syntax or ZenHub
+    - color: d455d0
+      description: Indicates an issue is a duplicate of other open issue.
+      name: triage/duplicate
+      previously:
+        - name: duplicate
+      target: both
+    # needs-information seems like it serves the same function as kind/question or "waiting for response"
+    - color: d455d0
+      description: Indicates an issue needs more information in order to work on it.
+      name: triage/needs-information
+      target: both
+      addedBy: humans
+    # If I was contributing to a repo, went to the trouble to create an issue or PR, and a maintainer
+    # responded by shrugging, I think it would make me feel my contribution wasn't appreciated
+    - color: f9d0c4
+      description: ¯\\\_(ツ)_/¯
+      name: "¯\\_(ツ)_/¯"
+      target: both
+      prowPlugin: shrug
+      addedBy: humans
 
     
     ##########################################################################

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -8,78 +8,115 @@
 ---
 default:
   labels:
-    - color: e11d21
-      description: Categorizes an issue or PR as actively needing an API review.
-      name: api-review
+    ##########################################################################
+    # Triage labels: Build cops (more at https://github.com/tektoncd/plumbing/tree/master/buildbot) should
+    # apply these labels when triaging issues:
+    ##########################################################################
+
+    # Signals to other contributors
+    - color: 7057ff
+      description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
+      name: 'good first issue'
+      target: issues
+      prowPlugin: help
+      addedBy: anyone
+    - color: "008672"
+      description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
+      name: 'help wanted'
+      previously:
+        - name: help-wanted
+      target: issues
+      prowPlugin: help
+      addedBy: anyone
+
+    # Priorities
+    - color: fef2c0
+      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.  # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
+      name: priority/awaiting-more-evidence
       target: both
       prowPlugin: label
       addedBy: anyone
+    - color: fbca04
+      description: Higher priority than priority/awaiting-more-evidence.  # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
+      name: priority/backlog
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Highest priority. Must be actively worked on as someone's top priority right now.  # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
+      name: priority/critical-urgent
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: eb6420
+      description: Important over the long term, but may not be staffed and/or may need multiple releases to complete.
+      name: priority/important-longterm
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: eb6420
+      description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
+      name: priority/important-soon
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    
+    # Kinds and areas
     - color: 0052cc
-      description: Issues or PRs related to Kubernetes licensing
-      name: area/licensing
-      target: both
-      addedBy: label
-    - color: 0052cc
-      description: Issues or PRs related to dependency changes
-      name: area/dependency
-      target: both
-      addedBy: label
-    - color: 75ef9a
-      description: Issues or PRs related to testing
-      name: area/testing
-      target: both
-      addedBy: label
-    - color: 7057ff
-      description: Indicates an issue on release (process, tasks)
-      name: area/release
+      description: Indicates an issue or PR that deals with the API.
+      name: area/api
       target: issues
       addedBy: label
-    - color: 10677f
-      description: Indicates an issue on dogfooding (aka using Pipeline to test Pipeline)
-      name: area/dogfooding
+    - color: e11d21
+      description: Categorizes issue or PR as related to a bug.
+      name: kind/bug
+      previously:
+        - name: bug
       target: both
-      addedBy: label
-    - color: 10677f
-      description: Issues or PRs related to the testing infrastructure
-      name: area/test-infra
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
+      name: kind/cleanup
+      previously:
+        - name: kind/friction
+        - name: kind/technical-debt
+    - color: c7def8
+      description: Categorizes issue or PR as related to design.
+      name: kind/design
       target: both
-      addedBy: label
+      prowPlugin: label
+      addedBy: anyone
+    - color: bfd4f2
+      description: Categorizes issue or PR as related to documentation.
+      name: kind/documentation
+      previously:
+        - name: mostly-docs
+        - name: kind/docs
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to a new feature.
+      name: kind/feature
+      previously:
+        - name: enhancement
+        - name: kind/enhancement
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+
+    
+    ##########################################################################
+    # These labels are modified by automation and should not be added manually
+    ##########################################################################
+
     - color: abea59
       description: Indicates a PR has been approved by an approver from all required OWNERS files.
       name: approved
       target: prs
       prowPlugin: approve
       addedBy: approvers
-    - color: d455d0
-      description: Indicates an issue is a duplicate of other open issue.
-      name: triage/duplicate
-      previously:
-        - name: duplicate
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue needs more information in order to work on it.
-      name: triage/needs-information
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue can not be reproduced as described.
-      name: triage/not-reproducible
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue that is a support question.
-      name: triage/support
-      target: both
-      addedBy: humans
-    - color: d455d0
-      description: Indicates an issue that can not or will not be resolved.
-      name: triage/unresolved
-      previously:
-        - name: invalid
-        - name: wontfix
-      target: both
-      addedBy: humans
     - color: e11d21
       description: Indicates the PR's author has not signed the CNCF CLA.
       name: 'cncf-cla: no'
@@ -116,78 +153,6 @@ default:
       target: prs
       prowPlugin: wip
       addedBy: prow
-    - color: 7057ff
-      description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
-      name: 'good first issue'
-      target: issues
-      prowPlugin: help
-      addedBy: anyone
-    - color: "008672"
-      description: Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.
-      name: 'help wanted'
-      previously:
-        - name: help-wanted
-      target: issues
-      prowPlugin: help
-      addedBy: anyone
-    - color: e11d21
-      description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
-      name: kind/api-change
-      previously:
-        - name: kind/new-api
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: e11d21
-      description: Categorizes issue or PR as related to a bug.
-      name: kind/bug
-      previously:
-        - name: bug
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: c7def8
-      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
-      name: kind/cleanup
-      previously:
-        - name: kind/friction
-        - name: kind/technical-debt
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: c7def8
-      description: Categorizes issue or PR as related to design.
-      name: kind/design
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: bfd4f2
-      description: Categorizes issue or PR as related to documentation.
-      name: kind/documentation
-      previously:
-        - name: mostly-docs
-        - name: kind/docs
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: e11d21
-      description: Categorizes issue or PR as related to a consistently or frequently failing test.
-      name: kind/failing-test
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: c7def8
-      description: Categorizes issue or PR as related to a new feature.
-      name: kind/feature
-      previously:
-        - name: enhancement
-        - name: kind/enhancement
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: f7c6c7
-      description: Categorizes issue or PR as related to a flaky test.
-      name: kind/flake
       target: both
       prowPlugin: label
       addedBy: anyone
@@ -197,42 +162,6 @@ default:
       target: prs
       prowPlugin: lgtm
       addedBy: reviewers or members
-    - color: d3e2f0
-      description: Indicates that an issue or PR should not be auto-closed due to staleness.
-      name: lifecycle/frozen
-      previously:
-        - name: keep-open
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone
-    - color: 8fc951
-      description: Indicates that an issue or PR is actively being worked on by a contributor.
-      name: lifecycle/active
-      previously:
-        - name: active
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone
-    - color: "604460"
-      description: Denotes an issue or PR that has aged beyond stale and will be auto-closed.
-      name: lifecycle/rotten
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone or [@fejta-bot](https://github.com/fejta-bot) via [periodic-test-infra-rotten prowjob](https://prow.k8s.io/?job=periodic-test-infra-rotten)
-    - color: "795548"
-      description: Denotes an issue or PR has remained open with no activity and has become stale.
-      name: lifecycle/stale
-      previously:
-        - name: stale
-      target: both
-      prowPlugin: lifecycle
-      addedBy: anyone or [@fejta-bot](https://github.com/fejta-bot) via [periodic-test-infra-stale prowjob](https://prow.k8s.io/?job=periodic-test-infra-stale)
-    - color: ededed
-      description: Indicates a PR lacks a `kind/foo` label and requires one.
-      name: needs-kind
-      target: prs
-      prowPlugin: require-matching-label
-      addedBy: prow
     - color: b60205
       description: Indicates a PR that requires an org member to verify it is safe to test.  # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
       name: needs-ok-to-test
@@ -245,66 +174,12 @@ default:
       target: prs
       prowPlugin: needs-rebase
       addedBy: prow
-    - color: ededed
-      description: Indicates an issue or PR lacks a `sig/foo` label and requires one.
-      name: needs-sig
-      target: both
-      prowPlugin: require-matching-label
-      addedBy: prow
     - color: 15dd18
       description: Indicates a non-member PR verified by an org member that is safe to test.  # This is the opposite of needs-ok-to-test and should be mutually exclusive.
       name: ok-to-test
       target: prs
       prowPlugin: trigger
       addedBy: prow
-    - color: fef2c0
-      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.  # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
-      name: priority/awaiting-more-evidence
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: fbca04
-      description: Higher priority than priority/awaiting-more-evidence.  # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
-      name: priority/backlog
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: e11d21
-      description: Highest priority. Must be actively worked on as someone's top priority right now.  # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
-      name: priority/critical-urgent
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: eb6420
-      description: Important over the long term, but may not be staffed and/or may need multiple releases to complete.
-      name: priority/important-longterm
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: eb6420
-      description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
-      name: priority/important-soon
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-    - color: c2e0c6
-      description: Denotes a PR that will be considered when it comes time to generate release notes.
-      name: release-note
-      target: prs
-      prowPlugin: releasenote
-      addedBy: prow
-    - color: c2e0c6
-      description: Denotes a PR that introduces potentially breaking changes that require user action.  # These actions will be specifically called out when it comes time to generate release notes.
-      name: release-note-action-required
-      target: prs
-      prowPlugin: releasenote
-      addedBy: prow
-    - color: c2e0c6
-      description: Denotes a PR that doesn't merit a release note.  # will be ignored when it comes time to generate release notes.
-      name: release-note-none
-      target: prs
-      prowPlugin: releasenote
-      addedBy: prow or member or author
     - color: ee9900
       description: Denotes a PR that changes 100-499 lines, ignoring generated files.
       name: size/L
@@ -341,39 +216,9 @@ default:
       target: prs
       prowPlugin: size
       addedBy: prow
-    - color: f9d0c4
-      description: ¯\\\_(ツ)_/¯
-      name: "¯\\_(ツ)_/¯"
-      target: both
-      prowPlugin: shrug
-      addedBy: humans
 repos:
-  tektoncd/cli:
-    labels:
-      - color: 3f6eb5
-        description: Issues related to user-studies
-        name: user-study
-        target: issues
-        addedBy: humans
-  tektoncd/community:
-    labels:
-      - color: 0052cc
-        description: Issues or PRs related to the CDF summit(s)
-        name: area/cdf-summit
-        target: both
-        addedBy: label
   tektoncd/dashboard:
     labels:
-      - color: 0052cc
-        description: Indicates an issue on api area.
-        name: area/api
-        target: issues
-        addedBy: label
-      - color: 3f6eb5
-        description: Issues related to user-studies
-        name: user-study
-        target: issues
-        addedBy: humans
       - color: 160a72
         description: This issue needs some help during design phase
         name: design-help-wanted
@@ -387,34 +232,11 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: ffcdc4
-        description: For consideration when planning the next milestone
-        name: maybe-next-milestone
-        target: both
-        addedBy: humans
-      - color: 0052cc
-        description: Indicates an issue on api area.
-        name: area/api
-        target: issues
-        addedBy: label
-      - color: 3f6eb5
-        description: Issues related to user-studies
-        name: user-study
-        target: issues
-        addedBy: humans
-      - color: 4cdbd6
-        description: This task is mostly about implementation!!! And docs and tests of course but that's a given
-        name: meaty-juicy-coding-work
-        target: both
-        addedBy: humans
+      
+      # This label is automatically added by ZenHub
       - color: 3E4B9E
         description: Issues that should be considered as Epics (aka multiple sub-tasks, …)
         name: Epic
-        target: both
-        addedBy: humans
-      - color: 64e5ba
-        description: This is for some internal Google project tracking
-        name: okr
         target: both
         addedBy: humans
   tektoncd/plumbing:


### PR DESCRIPTION
# Changes

I was build cop today and I noticed in our "build cop runbook" we
talked about the purposes of a few labels, but definitely not all of
them. Since this is the authoritative source on what labels we have, I
think it makes sense to make this our documentation as well, and also to
clean out labels we don't need (many are copied from knative which
copied from kubernetes)

Removed some labels:
- triage/duplicate: Can use "Duplicate of" instead
  (https://help.github.com/en/github/managing-your-work-on-github/about-duplicate-issues-and-pull-requests)
- triage/needs-information: Could use zenhub "waiting for response"
  and/or "kind/question" instead
- triage/not-reproducible, triage/support, triage/unresolved - not
  really sure what these would mean for us
- kind/api-change, "api-review": Can use "area/api" instead
- area/release, area/dogfooding, area/test-infra - We have a separate
  plumbing repo where we can put these issues instead
- kind/failing-test, kind/flake - Seems oddly specific. Instead IMO this is kind of
  bug, and in fact something we should drop everything to fix.
- lifecycle/* - We do not use this plugin
- needs-kind, needs-sig, release-note*, shrug - We don't use these

Remove labels from repos that aren't used:
- cli: user-study
- community: area/cdf-summit
- pipeline: maybe-next-milestone (can use priority instead), user-study,
  also old silly labels like "meaty-juicy-coding-work", okr (not using
  anymore)

Removed labels from repos that were also global

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._