### PR TITLE
Always make sure module cache is downloaded.

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -378,3 +378,9 @@ function main() {
 
   exit ${failed}
 }
+
+# Download module dependencies to the local cache.
+# This should only be slow on the first run, and fast on subsequent runs.
+# If this command fails for any reason (e.g. not ran in a modules enabled
+# repo), always result in true.
+go mod download || true


### PR DESCRIPTION
# Changes

This ensures that `go mod download` in tests/scripts to make sure all
dependencies are present. This should generally only be slow on the first
attempt when it needs to download the modules locally, but subsequent calls
should result in no change.

This solves an issue raised in
https://github.com/tektoncd/pipeline/pull/1792 where the license DB used
by a required tool wasn't being downloaded.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._