### PR TITLE
Add release.notags.yaml file to the release page 💫

### DIFF
--- a/tekton/resources/release/github_release.yaml
+++ b/tekton/resources/release/github_release.yaml
@@ -187,5 +187,6 @@ spec:
 
         hub release create --draft --prerelease \
           --commitish $(inputs.resources.source.revision) \
-          -a $(inputs.resources.release-bucket.path)/previous/${VERSION}/release.yaml \
+          -a $(inputs.resources.release-bucket.path)/previous/v${VERSION}/release.yaml \
+          -a $(inputs.resources.release-bucket.path)/previous/v${VERSION}/release.notags.yaml \
           --file $HOME/release.md ${VERSION}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the new `release.notags.yaml` release file that only contains
digests in the release that we create using `hub`.

Related to tektoncd/plumbing#1829

/hold

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._