### PR TITLE
Migrate resources to work with triggers v0.2.0

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -12,3 +12,5 @@ Resources are organised in folders:
 - The [resources](resources/README.md) folder contains Tekton resources used for
   various automation tasks: building container images, doing releases,
   maintaining the GitHub org and more.
+- The [cd](cd/README.md) folder contains kustomize overlays, used to deploy the
+  various Tekton projects to the infra clusters.

--- a/tekton/cd/README.md
+++ b/tekton/cd/README.md
@@ -1,0 +1,31 @@
+# (Continuous) Deployment of Tekton Services
+
+This folder includes overlays used to maintain the configuration of Tekton
+services in the Tekton infra clusters `dogfooding` and `prow`.
+
+Tekton services can be deployed on-demand using a Tekton task called
+`install-tekton-release`. For example, Tekton Pipeline can be deployed as
+follows using the `tkn` client:
+
+```
+# The RELEASE_BUCKET_RESOURCE is a storage PipelineResource that points to
+# the bucket where the release files are stored
+export RELEASE_BUCKET_RESOURCE=<release-bucket>
+
+# The K8S_CLUSTER_RESOURCE is a cluster PipelineResource that points to the
+# k8s cluster where the Tekton service is being deployed to
+export K8S_CLUSTER_RESOURCE=<k8s-cluster>
+
+# The PLUMBING_GIT_RESOURCE is a git PipelineResource that points to the git
+# repo where shared plumbing scripts are (usually tektoncd/plumbing)
+export PLUMBING_GIT_RESOURCE=<plumbing-git>
+
+tkn task start \
+  -i release-bucket=$RELEASE_BUCKET_RESOURCE \
+  -i k8s-cluster=$K8S_CLUSTER_RESOURCE \
+  -i plumbing-library=$PLUMBING_GIT_RESOURCE \
+  -p projectName=pipeline \
+  -p version=v0.9.2 \
+  -p environment=dogfooding \
+  install-tekton-release
+```

--- a/tekton/cd/triggers/base/kustomization.yaml
+++ b/tekton/cd/triggers/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/tekton/cd/triggers/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/triggers/overlays/dogfooding/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../../base
+# patchesStrategicMerge:
+# -

--- a/tekton/resources/images/image-build-trigger.yaml
+++ b/tekton/resources/images/image-build-trigger.yaml
@@ -29,8 +29,8 @@ spec:
   serviceAccountName: release-right-meow
   triggers:
     - name: trigger
-      binding:
-        name: trigger-to-build-and-push-image
+      bindings:
+        - name: trigger-to-build-and-push-image
       template:
         name: build-and-push-image
 ---

--- a/tekton/resources/mario-github-comment.yaml
+++ b/tekton/resources/mario-github-comment.yaml
@@ -9,13 +9,13 @@ spec:
   - name: buildUUID
     value: $(body.taskRun.metadata.labels.prow\.k8s\.io/build-id)
   - name: gitURL
-    value: $(body.taskRun.spec.inputs.resources.#(name=="source").resourceSpec.params.#(name=="url").value)
+    value: $(body.taskRun.spec.inputs.resources[?(@.name == 'source')].resourceSpec.params[?(@.name == 'url')].value)
   - name: gitRevision
-    value: $(body.taskRun.spec.inputs.resources.#(name=="source").resourceSpec.params.#(name=="revision").value)
+    value: $(body.taskRun.spec.inputs.resources[?(@.name == 'source')].resourceSpec.params[?(@.name == 'revision')].value)
   - name: targetImageResourceName
-    value: $(body.taskRun.spec.outputs.resources.#(name=="image").resourceRef.name)
+    value: $(body.taskRun.spec.outputs.resources[?(@.name == 'image')].resourceRef.name)
   - name: passedOrFailed
-    value: $(body.taskRun.status.conditions.#(type=="Succeeded").status)
+    value: $(body.taskRun.status.conditions[?(@.type == 'Succeeded')].status)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -25,8 +25,8 @@ spec:
   serviceAccountName: mario-listener
   triggers:
     - name: trigger
-      binding:
-        name: trigger-to-comment-github
+      bindings:
+        - name: trigger-to-comment-github
       template:
         name: mario-comment-github
 ---

--- a/tekton/resources/mario-image-build-trigger.yaml
+++ b/tekton/resources/mario-image-build-trigger.yaml
@@ -77,14 +77,15 @@ spec:
   serviceType: LoadBalancer
   triggers:
     - name: trigger
-      interceptor:
-        objectRef:
-          kind: Service
-          name: mario
-          apiVersion: v1
-          namespace: mario
-      binding:
-        name: trigger-to-build-and-push-image
+      interceptors:
+        - webhook:
+            objectRef:
+              kind: Service
+              name: mario
+              apiVersion: v1
+              namespace: mario
+      bindings:
+        - name: trigger-to-build-and-push-image
       template:
         name: build-and-push-image
 ---

--- a/tekton/resources/nightly-release/base/eventlistener.yaml
+++ b/tekton/resources/nightly-release/base/eventlistener.yaml
@@ -6,7 +6,7 @@ spec:
   serviceAccountName: robot
   triggers:
     - name: cron-trigger
-      binding:
-        name: binding
+      bindings:
+        - name: binding
       template:
         name: template

--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -54,7 +54,7 @@ spec:
   serviceType: LoadBalancer
   triggers:
     - name: peribolos-trigger
-      binding:
-        name: peribolos-binding
+      bindings:
+        - name: peribolos-binding
       template:
         name: peribolos-template

--- a/tekton/resources/release/nightly-release-logs-trigger.yaml
+++ b/tekton/resources/release/nightly-release-logs-trigger.yaml
@@ -9,9 +9,9 @@ spec:
   - name: namespace
     value: $(body.taskRun.metadata.namespace)
   - name: bucket
-    value: $(body.taskRun.spec.outputs.resources.#(name=="bucket").resourceRef.name)
+    value: $(body.taskRun.spec.outputs.resources[?(@.name == 'bucket')].resourceRef.name)
   - name: versionTag
-    value: $(body.taskRun.spec.inputs.params.#(name=="versionTag").value)
+    value: $(body.taskRun.spec.inputs.params[?(@.name == 'versionTag')].value)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener
@@ -21,8 +21,8 @@ spec:
   serviceAccountName: release-right-meow
   triggers:
     - name: log-collection
-      binding:
-        name: publish-images-taskrun-to-release-logs
+      bindings:
+        - name: publish-images-taskrun-to-release-logs
       template:
         name: release-logs
 ---


### PR DESCRIPTION
Migrate resources to triggers v0.2.0:
    - eventlistener.binding -> bindings
    - eventlistener.interceptor -> interceptors
    - gjson to JSONPath in bindings
      - select an element from an array

Fixes #183 