### PR TITLE
Fix the eventlistener kustomize config

### DIFF
--- a/tekton/resources/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/resources/mario-bot/mario-image-build-trigger.yaml
@@ -3,9 +3,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: triggers-minimal
 rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "tasks", "taskruns"]
-  verbs: ["get"]
+  verbs: ["get", "list"]
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["create"]
@@ -105,6 +108,10 @@ metadata:
   name: build-and-push-image
 spec:
   params:
+  - name: pullRequestID
+    description: The pullRequestID
+  - name: buildUUID
+    description: the buildUUID for logging purposes
   - name: gitRepository
     description: The git repository that hosts context and Dockerfile
   - name: gitRevision

--- a/tekton/resources/nightly-release/base/kustomizeconfig/eventlistener.yaml
+++ b/tekton/resources/nightly-release/base/kustomizeconfig/eventlistener.yaml
@@ -2,9 +2,9 @@
 nameReference:
 - kind: TriggerBinding
   fieldSpecs:
-  - path: spec/triggers/binding/name
+  - path: spec/triggers/bindings/name
     kind: EventListener
-- kind: TriggerTemplate 
+- kind: TriggerTemplate
   fieldSpecs:
   - path: spec/triggers/template/name
     kind: EventListener

--- a/tekton/resources/nightly-release/base/serviceaccount.yaml
+++ b/tekton/resources/nightly-release/base/serviceaccount.yaml
@@ -4,3 +4,30 @@ metadata:
   name: robot
 secrets:
 - name: nightly-account
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-minimal
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["tekton.dev"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "tasks", "taskruns"]
+  verbs: ["get", "list"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "pipelineresources", "taskruns"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: robot-release-minimal
+subjects:
+- kind: ServiceAccount
+  name: robot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-minimal


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Change the kustomize config for event listener to support binding*s*
Add a role to the service account used to nightly releases.
Make sure service accounts for release and Mario bot can get/list/watch configmaps.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._