### PR TITLE
Allow project to specify a yamllint config

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -44,6 +44,9 @@ IS_DOCUMENTATION_PR=0
 # Directory to use for temporary files.
 WORK_DIR=""
 
+# yamllint config file to override some rules, see https://git.io/JvLom
+YAML_LINT_CONFIG=${YAML_LINT_CONFIG:-}
+
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
@@ -146,18 +149,22 @@ function markdown_build_tests() {
 
 # Perform yaml build tests if necessary, unless disabled.
 function yaml_build_tests() {
+  local yamllintargs
+
   (( DISABLE_YAML_LINTING )) && return 0
   subheader "Linting the yaml files"
   local yamlfiles=""
-   
+
   for file in $(cat ${CHANGED_FILES}); do
     [[ -z $(echo "${file}" | grep '\.yaml$\|\.yml$' | grep -v '^vendor/' | grep -v '^third_party/') ]] && continue
 
     echo "found ${file}"
     [[ -f "${file}" ]] && yamlfiles="${yamlfiles} ${file}"
   done
+
   [[ -z "${yamlfiles}" ]] && return 0
-  yamllint ${yamlfiles}
+  [[ -f ${YAML_LINT_CONFIG} ]] && yamllintargs="-c ${YAML_LINT_CONFIG}"
+  yamllint ${yamllintargs} ${yamlfiles}
 }
 
 # Default build test runner that:


### PR DESCRIPTION
If you specify a YAML_LINT_CONFIG variable and have a yamllint config file in
there the projects would be able to add some project specific rules.

Some examples of yamllintrc files : 

https://github.com/adrienverge/yamllint#features

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._