### PR TITLE
Upgrade to Kustomize 3.5.4

### DIFF
--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -18,6 +18,6 @@ ENV GO111MODULE on
 RUN go get github.com/google/ko/cmd/ko@master
 
 RUN apk add --no-cache musl-dev gcc git
-RUN go get sigs.k8s.io/kustomize/kustomize/v3@v3.3.0
+RUN go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4
 
 


### PR DESCRIPTION
Bump the version for dashboard release pipeline changes

For background: https://github.com/tektoncd/dashboard/issues/960 and https://github.com/tektoncd/dashboard/issues/950

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Bump it 🎉 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

Tested this using `docker run -it adamroberts/custom-ko-gcloud:latest sh` (which is my own image but with 3.5.4) and running 

```
          kustomize build overlays/dev | ko resolve --preserve-import-paths -f - > /workspace/output/bucket/$(inputs.params.bucketName)/tekton-dashboard-release.yaml
          kustomize build overlays/dev-locked-down | ko resolve --preserve-import-paths -f - > /workspace/output/bucket/$(inputs.params.bucketName)/tekton-dashboard-release-readonly.yaml
          kustomize build overlays/dev-openshift --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket/$(inputs.params.bucketName)/openshift-tekton-dashboard-release.yaml
          kustomize build overlays/dev-openshift-locked-down --load_restrictor=LoadRestrictionsNone | ko resolve --preserve-import-paths -f - > /workspace/output/bucket/$(inputs.params.bucketName)/openshift-tekton-dashboard-release-readonly.yaml
```

with the latest Tekton Dashboard code