### PR TITLE
Prepend "mario" to mario-bot resources

### DIFF
--- a/tekton/resources/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/resources/mario-bot/mario-image-build-trigger.yaml
@@ -55,7 +55,7 @@ roleRef:
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
-  name: trigger-to-build-and-push-image
+  name: mario-trigger-to-build-and-push-image
 spec:
   params:
   - name: buildUUID
@@ -95,9 +95,9 @@ spec:
               apiVersion: v1
               namespace: mario
       bindings:
-        - name: trigger-to-build-and-push-image
+        - name: mario-trigger-to-build-and-push-image
       template:
-        name: build-and-push-image
+        name: mario-build-and-push-image
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -112,7 +112,7 @@ spec:
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: build-and-push-image
+  name: mario-build-and-push-image
 spec:
   params:
   - name: pullRequestID


### PR DESCRIPTION
# Changes

Some of mario resources do not have "mario" in the name.
If they are applied to the wrong namespace they may override
other resources.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._