### PR TITLE
Fix hub image with the latest git and bash versions

### DIFF
--- a/tekton/images/hub/Dockerfile
+++ b/tekton/images/hub/Dockerfile
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 ARG HUB_VERSION=2.14.1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk add --no-cache \
-    git=2.22.0-r0 \
-    bash=5.0.0-r0 \
+    git=2.24.1-r0 \
+    bash=5.0.11-r1 \
     hub=${HUB_VERSION}-r0


### PR DESCRIPTION
The PR introduced earlier today
https://github.com/tektoncd/plumbing/pull/213/files was broken since the git and
bash versionw were outdated.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._