### PR TITLE
Deployment overlay for the dashboard in dogfooding

### DIFF
--- a/tekton/cd/dashboard/base/kustomization.yaml
+++ b/tekton/cd/dashboard/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/tekton/cd/dashboard/base/release.yaml
+++ b/tekton/cd/dashboard/base/release.yaml
@@ -1,0 +1,305 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: extensions.dashboard.tekton.dev
+spec:
+  group: dashboard.tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-dashboard
+    kind: Extension
+    plural: extensions
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-dashboard-minimal
+  namespace: tekton-pipelines
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - namespaces
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dashboard.tekton.dev
+  resources:
+  - extensions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - eventlisteners
+  - triggerbindings
+  - triggertemplates
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-dashboard-minimal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - name: http
+    port: 9097
+    protocol: TCP
+    targetPort: 9097
+  selector:
+    app: tekton-dashboard
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-dashboard
+  template:
+    metadata:
+      labels:
+        app: tekton-dashboard
+      name: tekton-dashboard
+    spec:
+      containers:
+      - env:
+        - name: PORT
+          value: "9097"
+        - name: WEB_RESOURCES_DIR
+          value: /var/run/ko/web
+        - name: PIPELINE_RUN_SERVICE_ACCOUNT
+          value: ""
+        - name: INSTALLED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/tekton-nightly/github.com/tektoncd/dashboard/cmd/dashboard@sha256:2e357d14cf8645a600400417c933716d353f4b8a43909a6c1da71cca7cc6f459
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9097
+        name: tekton-dashboard
+        ports:
+        - containerPort: 9097
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9097
+      serviceAccountName: tekton-dashboard
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline0
+  namespace: tekton-pipelines
+spec:
+  params:
+  - default: /workspace/git-source
+    description: The path to the resource files to apply
+    name: pathToResourceFiles
+    type: string
+  - default: .
+    description: The directory from which resources are to be applied
+    name: apply-directory
+    type: string
+  - default: tekton-pipelines
+    description: The namespace in which to create the resources being imported
+    name: target-namespace
+    type: string
+  resources:
+  - name: git-source
+    type: git
+  tasks:
+  - name: pipeline0-task
+    params:
+    - name: pathToResourceFiles
+      value: $(params.pathToResourceFiles)
+    - name: apply-directory
+      value: $(params.apply-directory)
+    - name: target-namespace
+      value: $(params.target-namespace)
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source
+    taskRef:
+      name: pipeline0-task
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: pipeline0-task
+  namespace: tekton-pipelines
+spec:
+  inputs:
+    params:
+    - default: /workspace/git-source
+      description: The path to the resource files to apply
+      name: pathToResourceFiles
+      type: string
+    - default: .
+      description: The directory from which resources are to be applied
+      name: apply-directory
+      type: string
+    - default: tekton-pipelines
+      description: The namespace where created resources will go
+      name: target-namespace
+      type: string
+    resources:
+    - name: git-source
+      type: git
+  steps:
+  - args:
+    - apply
+    - -f
+    - $(inputs.params.pathToResourceFiles)/$(inputs.params.apply-directory)
+    - -n
+    - $(inputs.params.target-namespace)
+    command:
+    - kubectl
+    image: lachlanevenson/k8s-kubectl:latest
+    name: kubectl-apply
+
+---

--- a/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  name: ing
+  namespace: tekton-pipelines
+spec:
+  tls:
+  - secretName: dashboard-dogfooding-tekton-dev-tls
+    hosts:
+    - dashboard.dogfooding.tekton.dev
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: tekton-dashboard
+          servicePort: 9097
+        path: /*

--- a/tekton/cd/dashboard/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- tekton-dashboard-service.yaml
+resources:
+- ingress.yaml

--- a/tekton/cd/dashboard/overlays/dogfooding/tekton-dashboard-service.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/tekton-dashboard-service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+spec:
+  type: nodePort

--- a/tekton/certificates/clusterissuer.yaml
+++ b/tekton/certificates/clusterissuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: andrea.frittoli@uk.ibm.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: nginx


### PR DESCRIPTION
# Changes

Add an overlay for the dashboard in the dogfooding cluster.
The overlay includes:
- an ingress resource
- setting the service to "nodePort", which is required for
  the ingress to work with GKE.

This patch includes also a ClusterIssuer that can be used for
any ingress in the cluster. Using the cluster issuer requires
cert-manager to be installed first:

https://cert-manager.io/docs/installation/kubernetes/#installing-with-regular-manifests

GKE load balancer setup the health check to point to the
readiness probe defined in the pods associated to the service.
The probe is expected to return 200, while in the latest
dashboard it returns 204 No Content. This patch fixes the issue:
https://github.com/tektoncd/dashboard/pull/1017

Partially fixes #182

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._