### PR TITLE
Limit the branches that dashboard's publish images job runs against

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -976,6 +976,8 @@ postsubmits:
         - "--cov-threshold-percentage=0"
   tektoncd/dashboard:
   - name: tekton-dashboard-publish-images
+    branches:
+    - master
     always_run: true
     spec:
       containers:


### PR DESCRIPTION
In PR https://github.com/tektoncd/dashboard/pull/1030 we saw an error
reported by Prow that the "tekton-dashboard-publish-images" job
had failed. This job isn't intended to run on PRs. Christie pointed
out that Prow will run a postsubmit job against every branch unless
a branch list is specified for it. This info is documented for Prow
here:
https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#how-to-configure-new-jobs

This PR adds a branch list to limit the postsubmit job to only run
against master.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._