### PR TITLE
Change Boskos StatefulSet to Deployment.

### DIFF
--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -83,26 +83,6 @@ kind: Namespace
 metadata:
   name: test-pods
 ---
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  labels:
-    app: boskos
-  name: boskos-storage
-  namespace: test-pods
-spec:
-  claimRef:
-    name: boskos-volume-boskos-0
-    namespace: test-pods
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  gcePersistentDisk:
-    pdName: boskos-storage
-    fsType: ext4
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -134,15 +114,17 @@ roleRef:
   name: boskos
   apiGroup: rbac.authorization.k8s.io
 ---
-# Start of StatefulSet
+# Boskos
 apiVersion: apps/v1beta1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: boskos
   namespace: test-pods
 spec:
-  serviceName: "boskos"
   replicas: 1  # one canonical source of resources
+  selector:
+    matchLabels:
+      app: boskos
   template:
     metadata:
       labels:
@@ -161,8 +143,6 @@ spec:
           - containerPort: 8080
             protocol: TCP
         volumeMounts:
-        - name: boskos-volume
-          mountPath: /store
         - name: boskos-config
           mountPath: /etc/config
           readOnly: true
@@ -170,15 +150,6 @@ spec:
         - name: boskos-config
           configMap:
             name: resources
-  volumeClaimTemplates:
-  - metadata:
-      name: boskos-volume
-    spec:
-      accessModes: ["ReadWriteOnce"]
-      storageClassName: boskos
-      resources:
-        requests:
-          storage: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change deploys Boskos as a Deployment rather than a StatefulSet, to enable quicker feedback in the deployment process, and removing the need to delete the Boskos pods before new pods are started.

This addresses #193

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._