### PR TITLE
Add a default GOFLAGS for specific cases 🌔

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -47,6 +47,9 @@ WORK_DIR=""
 # yamllint config file to override some rules, see https://git.io/JvLom
 YAML_LINT_CONFIG=${YAML_LINT_CONFIG:-}
 
+# goflags to use to override default behavior (if a go.mod file and a vendor folder exists, set it "-mod=vendor")
+GOFLAGS=${GOFLAGS:-}
+
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
@@ -325,6 +328,8 @@ function main() {
   if function_exists extra_initialization; then
      extra_initialization
   fi
+
+  [[ -z "${GOFLAGS}" ]] && [[ -e go.mod ]] && [[ -d vendor/ ]] && export GOFLAGS="-mod=vendor"
 
   [[ -z $1 ]] && set -- "--all-tests"
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
If we find a `go.mod` and there is a root `vendor` folder, we define
`-mod=vendor` in order to use the vendor code instead of downloading
the dependencies all the time.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @chmouel 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._