### PR TITLE
Add CRDs to the boskos deployment

### DIFF
--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -13,6 +13,70 @@
 # limitations under the License.
 
 # Boskos deployment for Tekton Prow instance
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamicresourcelifecycles.boskos.k8s.io
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: DRLCObject
+    listKind: DRLCObjectList
+    plural: dynamicresourcelifecycles
+    singular: dynamicresourcelifecycle
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The dynamic resource type.
+    JSONPath: .spec.config.type
+  - name: Min-Count
+    type: integer
+    description: The minimum count requested.
+    JSONPath: .spec.min-count
+  - name: Max-Count
+    type: integer
+    description: The maximum count requested.
+    JSONPath: .spec.max-count
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resources.boskos.k8s.io
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: ResourceObject
+    listKind: ResourceObjectList
+    plural: resources
+    singular: resource
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The resource type.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    description: The current state of the resource.
+    JSONPath: .status.state
+  - name: Owner
+    type: string
+    description: The current owner of the resource.
+    JSONPath: .status.owner
+  - name: Last-Updated
+    type: date
+    JSONPath: .status.lastUpdate
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Boskos used to register its CRDs from code, however now it
expectes the CRDs to be registered via a manifest, like in

https://github.com/kubernetes/test-infra/blob/76626ab4c4559f768e6519a5c5438c4b8c37b40f/prow/cluster/boskos.yaml#L15-L79

Adding the CRDs to Tekton's Boskos deployment.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._