### PR TITLE
Add a service for the metrics endpoint

### DIFF
--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -195,6 +195,21 @@ spec:
     port: 80
     targetPort: 8080
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: boskos-metrics
+  namespace: test-pods
+spec:
+  selector:
+    app: boskos
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  type: NodePort
+---
 # Janitor
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added a service for the metrics endpoint, so that it becomes easier to check the status of boskos resources. The service is of type NodePort, so that it can work with an ingress on top if we decide to expose this endpoint publicly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._