### PR TITLE
Add compute storage privileges for boskos clusters 💿

### DIFF
--- a/addpermissions.py
+++ b/addpermissions.py
@@ -15,6 +15,9 @@ to all GCP projects.
 
 This script requires the `gcloud` command line tool and the python
 `PyYaml` library.
+
+Example usage:
+  python3 addpermissions.py --users "andrea.frittoli@gmail.com, andrew.bayer@gmail.com, dlorenc@google.com, klewandowski@google.com, vdemeest@redhat.com, dibyajoti@google.com, sbws@google.com"
 """
 import argparse
 import shlex
@@ -30,6 +33,7 @@ ROLES = (
   "roles/container.admin",
   "roles/iam.serviceAccountUser",
   "roles/storage.admin",
+  "roles/compute.storageAdmin",
   "roles/viewer",
 )
 KNOWN_PROJECTS = (
@@ -45,12 +49,13 @@ def gcloud_required() -> None:
     sys.exit(1)
 
 
-def add_to_all_projects(user: str, projects: List[str]) -> None:
-  for project in projects:
-    for role in ROLES:
-      subprocess.check_call(shlex.split(
-          "gcloud projects add-iam-policy-binding {} --member user:{} --role {}".format(project, user, role)
-      ))
+def add_to_all_projects(users: List[str], projects: List[str]) -> None:
+  for user in users:
+    for project in projects:
+      for role in ROLES:
+        subprocess.check_call(shlex.split(
+            "gcloud projects add-iam-policy-binding {} --member user:{} --role {}".format(project, user, role)
+        ))
 
 
 def parse_boskos_projects() -> List[str]:
@@ -64,12 +69,13 @@ def parse_boskos_projects() -> List[str]:
 if __name__ == '__main__':
   arg_parser = argparse.ArgumentParser(
       description="Give a user access to all plumbing resources")
-  arg_parser.add_argument("--user", type=str, required=True,
-                          help="The name of the user's account, usually their email address")
+  arg_parser.add_argument("--users", type=str, required=True,
+                          help="The names of the users' accounts, usually their email address, comma separated")
   args = arg_parser.parse_args()
 
   gcloud_required()
 
   boskos_projects = parse_boskos_projects()
-  add_to_all_projects(args.user, list(KNOWN_PROJECTS) + boskos_projects)
+
+  add_to_all_projects([u.strip() for u in args.users.split(",")], list(KNOWN_PROJECTS) + boskos_projects)
 


### PR DESCRIPTION
# Changes

@afrittoli has been debugging a lot of boskos problems recently that
have resulted in and/or been caused by GCP compute disks not being
cleaned up. Adding the compute storage admin capability to all the folks
either in the build cop rotation or on the governing board will let
folks delete these disks if needed.

Also made it so you can run this for a bunch of users at once instead of
repeatedly for each user.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._