### PR TITLE
Fix the taskrun name for label sync

### DIFF
--- a/tekton/resources/cd/label-sync-cd.yaml
+++ b/tekton/resources/cd/label-sync-cd.yaml
@@ -59,7 +59,7 @@ spec:
   - apiVersion: tekton.dev/v1alpha1
     kind: TaskRun
     metadata:
-      name: deploy-prow-config-$(uid)
+      name: deploy-label-sync-$(uid)
     spec:
       taskSpec:
         inputs:
@@ -83,7 +83,7 @@ spec:
           script: |
             #!/bin/sh
             set -ex
-            kubectl get configmap labels-config-v2 -o template --template='{{ index .data labels.yaml" }}' \
+            kubectl get configmap label-config-v2 -o template --template='{{ index .data labels.yaml" }}' \
               > /workspace/labels.yaml
         - name: deploy
           image: gcr.io/tekton-releases/dogfooding/kubectl
@@ -98,10 +98,10 @@ spec:
               exit 0
             fi
             # Apply configuration changes
-            kubectl create configmap labels-config-v2 \
+            kubectl create configmap label-config-v2 \
               --from-file=config.yaml=$(inputs.resources.source.path)/$(inputs.params.configPath) \
               --dry-run -o yaml | \
-              kubectl replace configmap labels-config-v2 -n $(inputs.params.namespace) -f -
+              kubectl replace configmap label-config-v2 -n $(inputs.params.namespace) -f -
       inputs:
         params:
         - name: configPath

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -1,5 +1,3 @@
-commonLabels:
-  app: tekton.plumbing
 resources:
 - images/image-build-trigger.yaml
 - release/install_and_test_tekton_release.yaml
@@ -9,3 +7,4 @@ resources:
 - release/save-release-logs.yaml
 - release/test_tekton_release.yaml
 - cd/prow-config-cd.yaml
+- cd/label-sync-cd.yaml


### PR DESCRIPTION
The taskrun name is copy pasted from the prow config deploy.

Fixes: #251 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._