### PR TITLE
Add a tool to generate rotation csv

### DIFF
--- a/buildbot/cmd/generate-rotation-csv/README.md
+++ b/buildbot/cmd/generate-rotation-csv/README.md
@@ -1,0 +1,54 @@
+# generate-rotation-csv
+
+generate-rotation-csv prints a csv-formatted rotation from a
+comma-separated list of names. Weekend days are considered to
+be Saturday and Sunday and are skipped, meaning a blank string
+is inserted in place of a user's name.
+
+## Usage
+
+Generate a rotation CSV starting today for one year:
+```bash
+go run ./main.go -names jules,ronda,gavin,paula,don,carol
+```
+
+Generate a rotation CSV starting tomorrow (today is 2020-02-28) for 6 weeks:
+```bash
+go run ./main.go -start-date 2020-02-29 -days $((6 * 7)) -names jules,ronda,gavin,paula,don,carol
+```
+
+Generate a rotation CSV starting with carol yesterday (today is 2020-02-28) for 165 weeks:
+```bash
+go run ./main.go -start-date 2020-02-27 -days $((165 * 7)) -start-name carol -names jules,ronda,gavin,paula,don,carol
+```
+
+Print help
+```bash
+go run ./main.go -h
+```
+
+## Flags
+
+  -names string
+    	comma-separated list of user names to generate rotation from. required.
+  -days uint
+    	number of days to run the rotation for. defaults to 1 year.
+  -start-date string
+    	date to begin the rotation from in YYYY-MM-DD format. starts today if left blank.
+  -start-name string
+    	the user name to begin the rotation. defaults to the first provided name in -names list
+
+## Example Output
+
+```bash
+$ go run ./main.go -names bob,carol,donna,jules -days 8 -start-date 1991-01-01
+Date,User
+1991-01-01,bob
+1991-01-02,carol
+1991-01-03,donna
+1991-01-04,jules
+1991-01-05,
+1991-01-06,
+1991-01-07,bob
+1991-01-08,carol
+```

--- a/buildbot/cmd/generate-rotation-csv/main.go
+++ b/buildbot/cmd/generate-rotation-csv/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+const expectedDateFormat = "2006-01-02"
+const usageMessage = `
+generate-rotation-csv prints a csv-formatted rotation from a
+comma-separated list of names. Weekend days are considered to
+be Saturday and Sunday and are skipped, meaning a blank string
+is inserted in place of a user's name.
+
+The printed csv has two columns: Date and User.
+`
+
+// config is the set of options to configure printing of the rotation.
+type config struct {
+	// the complete list of names to print in the order they should appear
+	names []string
+	// the name to start from in the list of names
+	startName string
+	// the date to start printing from
+	startDate time.Time
+	// the number of days to print entries for
+	days uint
+}
+
+func main() {
+	log.SetFlags(0)
+	log.SetOutput(os.Stderr)
+
+	c, err := parseFlags()
+	if err != nil {
+		log.Fatalf("error parsing flags: %v", err)
+	}
+
+	err = validateConfig(c)
+	if err != nil {
+		log.Fatalf("error validating config: %v", err)
+	}
+
+	err = generateRotationCSV(c, os.Stdout)
+	if err != nil {
+		log.Fatalf("error printing csv: %v", err)
+	}
+}
+
+// generateRotationCSV writes a rotation starting at c.startName
+// and c.startDate and then repeatedly iterating over c.names
+// until it reaches c.startDate + c.days. Saturday and Sunday are
+// left blank. The output is written to the provided io.Writer.
+func generateRotationCSV(c config, out io.Writer) error {
+	iter := c.startDate
+	end := c.startDate.AddDate(0, 0, int(c.days))
+	n := 0
+
+	for i, name := range c.names {
+		if name == c.startName {
+			n = i
+			break
+		}
+	}
+
+	w := csv.NewWriter(out)
+	w.Write([]string{"Date", "User"})
+	for iter.Before(end) {
+		if iter.Weekday() == time.Saturday || iter.Weekday() == time.Sunday {
+			w.Write([]string{iter.Format(expectedDateFormat), ""})
+			iter = iter.AddDate(0, 0, 1)
+			continue
+		}
+		if err := w.Write([]string{iter.Format(expectedDateFormat), c.names[n]}); err != nil {
+			return err
+		}
+		n++
+		if n >= len(c.names) {
+			n = 0
+		}
+		iter = iter.AddDate(0, 0, 1)
+	}
+	w.Flush()
+	return w.Error()
+}
+
+// validateConfig checks that c is suitably populated for generating a valid
+// rotation.
+func validateConfig(c config) error {
+	if c.startName == "" {
+		return errors.New("missing starting name")
+	} else {
+		found := false
+		for _, n := range c.names {
+			if c.startName == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return errors.New("starting name does not appear in list of user names")
+		}
+	}
+	return nil
+}
+
+// parseFlags generates a config from CLI flags that the user has passed in,
+// populating certain missing portions of config with sane defaults.
+func parseFlags() (config, error) {
+	var c config
+	namesInput := ""
+	startDateInput := ""
+	defaultStartDate := time.Now().Format(expectedDateFormat)
+
+	flag.StringVar(&namesInput, "names", "", "comma-separated list of user names to generate rotation from.")
+	flag.StringVar(&c.startName, "start-name", "", "the user name to begin the rotation. (defaults to the first provided name in -names list)")
+	flag.StringVar(&startDateInput, "start-date", defaultStartDate, "date to begin the rotation from in YYYY-MM-DD format. starts today if left blank.")
+	flag.UintVar(&c.days, "days", 365, "number of days to run the rotation for.")
+	flag.Usage = func() {
+		log.Printf(strings.TrimSpace(usageMessage) + "\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	ns := strings.Split(namesInput, ",")
+	for _, n := range ns {
+		t := strings.TrimSpace(n)
+		if t != "" {
+			c.names = append(c.names, t)
+		}
+	}
+
+	if d, err := time.Parse(expectedDateFormat, startDateInput); err != nil {
+		return c, fmt.Errorf("error parsing start date of %q", startDateInput)
+	} else {
+		c.startDate = d
+	}
+
+	if c.startName == "" && len(c.names) > 0 {
+		c.startName = c.names[0]
+	}
+
+	return c, nil
+}

--- a/buildbot/cmd/generate-rotation-csv/main_test.go
+++ b/buildbot/cmd/generate-rotation-csv/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateRotationCSV(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		config      config
+		expected    string
+	}{{
+		description: "blank names are rendered on weekends",
+		config: config{
+			names:     strings.Split("bob,carol,eric", ","),
+			days:      4,
+			startDate: parseDate(t, "2020-02-28"),
+			startName: "eric",
+		},
+		expected: `
+Date,User
+2020-02-28,eric
+2020-02-29,
+2020-03-01,
+2020-03-02,bob
+`,
+	}, {
+		description: "names are repeated until rotation's end",
+		config: config{
+			names:     strings.Split("bob,carol", ","),
+			days:      4,
+			startDate: parseDate(t, "2020-03-02"),
+			startName: "bob",
+		}, expected: `
+Date,User
+2020-03-02,bob
+2020-03-03,carol
+2020-03-04,bob
+2020-03-05,carol
+`,
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			var out strings.Builder
+			if err := generateRotationCSV(tc.config, &out); err != nil {
+				t.Errorf("unable to generate csv: %v", err)
+			}
+			s := strings.TrimSpace(out.String())
+			exp := strings.TrimSpace(tc.expected)
+			if s != exp {
+				t.Errorf("--- EXPECTED ---\n%v\n--- RECEIVED ---\n%v", exp, s)
+			}
+		})
+	}
+}
+
+func parseDate(t *testing.T, s string) time.Time {
+	parsedTime, err := time.Parse(expectedDateFormat, s)
+	if err != nil {
+		t.Fatalf("error parsing test case date %q, format must be YYYY-MM-DD: %v", s, err)
+	}
+	return parsedTime
+}


### PR DESCRIPTION
# Changes

This commit adds a small go program to generate the rotation csv that
the buildbot uses to notify buildcops.

Example usage:

```bash
go run ./main.go -names jules,ronda,gavin,paula,don,carol
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._