### PR TITLE
Specify github-admin namespace in label-sync 🏷

### DIFF
--- a/tekton/resources/cd/label-sync-cd.yaml
+++ b/tekton/resources/cd/label-sync-cd.yaml
@@ -83,7 +83,7 @@ spec:
           script: |
             #!/bin/sh
             set -ex
-            kubectl get configmap label-config-v2 -o template --template='{{ index .data labels.yaml" }}' \
+            kubectl -n github-admin get configmap label-config-v2 -o template --template='{{ index .data labels.yaml" }}' \
               > /workspace/labels.yaml
         - name: deploy
           image: gcr.io/tekton-releases/dogfooding/kubectl
@@ -98,10 +98,10 @@ spec:
               exit 0
             fi
             # Apply configuration changes
-            kubectl create configmap label-config-v2 \
+            kubectl -n github-admin create configmap label-config-v2 \
               --from-file=config.yaml=$(inputs.resources.source.path)/$(inputs.params.configPath) \
               --dry-run -o yaml | \
-              kubectl replace configmap label-config-v2 -n $(inputs.params.namespace) -f -
+              kubectl -n github-admin replace configmap label-config-v2 -n $(inputs.params.namespace) -f -
       inputs:
         params:
         - name: configPath


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Otherwise it will try to use the `default` namespace… where the
configmap is not 😓

Closes #255 

/cc @afrittoli 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._