### PR TITLE
Re-remove the v from the version in the github_release task

### DIFF
--- a/tekton/resources/release/github_release.yaml
+++ b/tekton/resources/release/github_release.yaml
@@ -187,6 +187,6 @@ spec:
 
         hub release create --draft --prerelease \
           --commitish $(inputs.resources.source.revision) \
-          -a $(inputs.resources.release-bucket.path)/previous/v${VERSION}/release.yaml \
-          -a $(inputs.resources.release-bucket.path)/previous/v${VERSION}/release.notags.yaml \
+          -a $(inputs.resources.release-bucket.path)/previous/${VERSION}/release.yaml \
+          -a $(inputs.resources.release-bucket.path)/previous/${VERSION}/release.notags.yaml \
           --file $HOME/release.md ${VERSION}


### PR DESCRIPTION
# Changes

This `v` character got reintroduced at some point.  Life is better without it.