### PR TITLE
Fix the configmap key for label_sync job 🕹

### DIFF
--- a/tekton/resources/cd/label-sync-cd.yaml
+++ b/tekton/resources/cd/label-sync-cd.yaml
@@ -99,7 +99,7 @@ spec:
             fi
             # Apply configuration changes
             kubectl create configmap label-config-v2 \
-              --from-file=config.yaml=$(inputs.resources.source.path)/$(inputs.params.configPath) \
+              --from-file=labels.yaml=$(inputs.resources.source.path)/$(inputs.params.configPath) \
               --dry-run -o yaml | \
               kubectl replace configmap label-config-v2 -n $(inputs.params.namespace) -f -
       inputs:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The job definition wants `labels.yaml` and not `config.yaml`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._