### PR TITLE
Add support to rotation generator for swaps and holidays

### DIFF
--- a/buildbot/cmd/generate-rotation-csv/README.md
+++ b/buildbot/cmd/generate-rotation-csv/README.md
@@ -37,6 +37,40 @@ go run ./main.go -h
     	date to begin the rotation from in YYYY-MM-DD format. starts today if left blank.
   -start-name string
     	the user name to begin the rotation. defaults to the first provided name in -names list
+  -overrides string
+    	path to a csv file in YYYY-MM-DD,user format that should override whatever this program generates for that date.
+
+## Overrides
+
+Specify an overrides file with the -overrides flag. This allows
+for rotation swaps and global holidays to be recorded somewhere.
+
+Each override entry will replace whatever value is generated
+for a given date.
+
+Th file should be CSV with each record having at least two fields, one
+for date and one for user name.
+
+Override entries can include extra fields for comments or other
+additional info. Extra fields will be ignored.
+
+Here's an example overrides.csv for the holiday season of 2020. bob
+swaps with sbws on 23rd / 24th and then nobody is on rotation from
+24th Dec until 2nd of Jan, when the rotation will resume:
+
+```
+Date,User
+2020-12-23,bob,Swapping with sbws tomorrow
+2020-12-24,sbws,Covering for bobs first day of vacation
+2020-12-25,
+2020-12-26,
+2020-12-27,
+2020-12-28,
+2020-12-29,
+2020-12-30,
+2020-12-31,
+2020-1-1,,Happy New Year!
+```
 
 ## Example Output
 

--- a/buildbot/cmd/generate-rotation-csv/main_test.go
+++ b/buildbot/cmd/generate-rotation-csv/main_test.go
@@ -40,6 +40,24 @@ Date,User
 2020-03-04,bob
 2020-03-05,carol
 `,
+	}, {
+		description: "overrides usurp generated values",
+		config: config{
+			names:     strings.Split("ronda,carol,eric,dan", ","),
+			days:      4,
+			startDate: parseDate(t, "2020-03-02"),
+			startName: "ronda",
+			overrides: map[string]string{
+				"2020-03-03": "dan",
+				"2020-03-04": "",
+			},
+		}, expected: `
+Date,User
+2020-03-02,ronda
+2020-03-03,dan
+2020-03-04,
+2020-03-05,dan
+	`,
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			var out strings.Builder
@@ -49,7 +67,62 @@ Date,User
 			s := strings.TrimSpace(out.String())
 			exp := strings.TrimSpace(tc.expected)
 			if s != exp {
-				t.Errorf("--- EXPECTED ---\n%v\n--- RECEIVED ---\n%v", exp, s)
+				t.Errorf("\n--- EXPECTED ---\n%v\n--- RECEIVED ---\n%v", exp, s)
+			}
+		})
+	}
+}
+
+func TestLoadOverrides(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		in          string
+		expected    map[string]string
+	}{{
+		description: "overrides parse ok from two fields",
+		in: `
+Date,User
+2020-03-03,dan
+2020-04-01,jane`,
+		expected: map[string]string{
+			"2020-03-03": "dan",
+			"2020-04-01": "jane",
+		},
+	}, {
+		description: "overrides are allowed to have extra fields for comments etc",
+		in: `
+Date,User
+2020-03-03,dan,Swapping with Ronda on 2020-03-05
+2020-03-05,ronda,Swapping with Dan on 2020-03-03
+2020-04-01,jane`,
+		expected: map[string]string{
+			"2020-03-03": "dan",
+			"2020-03-05": "ronda",
+			"2020-04-01": "jane",
+		},
+	}, {
+		description: "overrides are allowed to have blank users to indicate noone should buildcop that day",
+		in: `
+Date,User
+2020-12-25,,Happy holidays!
+		`,
+		expected: map[string]string{
+			"2020-12-25": "",
+		},
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			r := strings.NewReader(strings.TrimSpace(tc.in))
+			out, err := loadOverrides(r)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(out) != len(tc.expected) {
+				t.Fatalf("expected %d records but received %d", len(tc.expected), len(out))
+			}
+			for date, name := range out {
+				if tc.expected[date] != name {
+					t.Fatalf("expected %s:%s but received %s:%s", date, tc.expected[date], date, out[date])
+				}
 			}
 		})
 	}

--- a/buildbot/rotation-overrides.csv
+++ b/buildbot/rotation-overrides.csv
@@ -1,0 +1,12 @@
+Date,User
+2020-03-26,sbws
+2020-04-03,sbws
+2020-12-24,,Happy holidays!
+2020-12-25,,Happy holidays!
+2020-12-26,,Happy holidays!
+2020-12-27,,Happy holidays!
+2020-12-28,,Happy holidays!
+2020-12-29,,Happy holidays!
+2020-12-30,,Happy holidays!
+2020-12-31,,Happy holidays!
+2021-1-1,,Happy holidays!


### PR DESCRIPTION
# Changes

People on rotation often need others to cover a shift, swap
with them or cancel a rotation over a holiday period.

This PR adds an -overrides flag to the rotation generator tool that
reads a CSV file describing these kinds of overrides.

I've re-generated the buildbot's overrides.csv using this new flag to
see if it would produce the same output, and it does.

Regenerated rotation using following command:

```bash
go run ./buildbot/cmd/generate-rotation-csv/main.go \
  -start-date 2020-03-09 \
  -days 297 \
  -names wlynch,vdemeest,andrea.frittoli,dibyo,christiewilson,sbws \
  -overrides ./buildbot/rotation-overrides.csv
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes tests
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._