### PR TITLE
Nightly deploy of latest pipeline to robocat cluster

### DIFF
--- a/robocat/cadmin/200-rbac.yaml
+++ b/robocat/cadmin/200-rbac.yaml
@@ -17,15 +17,87 @@ metadata:
   name: tekton-deployer
   namespace: tekton-pipelines
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-admin
+rules:
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: ["*"]
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [mutatingwebhookconfigurations, validatingwebhookconfigurations]
+    verbs: ["*"]
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [clusterroles, clusterrolebindings]
+    verbs: ["*"]
+  - apiGroups: [policy]
+    resources: [podsecuritypolicies]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-deployer-tekton-admin
+subjects:
+  - kind: ServiceAccount
+    name: tekton-deployer
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: admin-plus
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: [namespaces, serviceaccounts, configmaps, secrets, services]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: ["*"]
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: tekton-deployer-admin
+  name: tekton-deployer-admin-plus
+  namespace: tekton-pipelines
 subjects:
   - kind: ServiceAccount
     name: tekton-deployer
     namespace: tekton-pipelines
 roleRef:
   kind: Role
-  name: admin
+  name: admin-plus
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-minio-secrets
+  namespace: eu-geo
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-deployer-read-minio-secrets
+  namespace: eu-geo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-minio-secrets
+subjects:
+  - kind: ServiceAccount
+    name: tekton-deployer
+    namespace: tekton-pipelines

--- a/tekton/cd/pipeline/overlays/robocat/config-artifact-bucket.yaml
+++ b/tekton/cd/pipeline/overlays/robocat/config-artifact-bucket.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: tekton-pipelines
+data:
+  bucket.service.account.field.name: BOTO_CONFIG
+  bucket.service.account.secret.key: boto-config
+  bucket.service.account.secret.name: tekton-storage
+  location: s3://tekton-pipelines

--- a/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
@@ -2,4 +2,5 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - config-artifact-bucket.yaml
+resources:
 - tekton-storage-secret.yaml

--- a/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- config-artifact-bucket.yaml
+- tekton-storage-secret.yaml

--- a/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
+++ b/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
@@ -8,9 +8,9 @@ MINIO_NAMESPACE=${MINIO_NAMESPACE:-eu-geo}
 MINIO_SECRET=${MINIO_SECRET:-s3}
 
 MINIO_ACCESS_KEY=$(kubectl get -n $MINIO_NAMESPACE secret/$MINIO_SECRET \
-  -o jsonpath='{ .data.accesskey }' | base64 -D)
+  -o jsonpath='{ .data.accesskey }' | base64 -d)
 MINIO_SECRET_KEY=$(kubectl get -n $MINIO_NAMESPACE secret/$MINIO_SECRET \
-  -o jsonpath='{ .data.secretkey }' | base64 -D)
+  -o jsonpath='{ .data.secretkey }' | base64 -d)
 
 sed -e 's/__MINIO_ACCESS_KEY__/'$MINIO_ACCESS_KEY'/g' \
   -e 's/__MINIO_SECRET_KEY__/'$MINIO_SECRET_KEY'/g' \

--- a/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
+++ b/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
@@ -2,6 +2,9 @@
 #
 # Grab Minio credentials and injects them in the storage secret used by
 # Tekton Pipeline
+set -exo pipefail
+
+echo "=== Start Pre-script Inject Minio Creds"
 BASE_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 MINIO_NAMESPACE=${MINIO_NAMESPACE:-eu-geo}
@@ -12,6 +15,8 @@ MINIO_ACCESS_KEY=$(kubectl get -n $MINIO_NAMESPACE secret/$MINIO_SECRET \
 MINIO_SECRET_KEY=$(kubectl get -n $MINIO_NAMESPACE secret/$MINIO_SECRET \
   -o jsonpath='{ .data.secretkey }' | base64 -d)
 
-sed -e 's/__MINIO_ACCESS_KEY__/'$MINIO_ACCESS_KEY'/g' \
-  -e 's/__MINIO_SECRET_KEY__/'$MINIO_SECRET_KEY'/g' \
+sed -e 's,__MINIO_ACCESS_KEY__,'$MINIO_ACCESS_KEY',g' \
+  -e 's,__MINIO_SECRET_KEY__/,'$MINIO_SECRET_KEY',g' \
   "${BASE_DIR}/tekton-storage-secret.yaml.tpl" > "${BASE_DIR}/../tekton-storage-secret.yaml"
+
+echo "=== End Pre-script Inject Minio Creds"

--- a/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
+++ b/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Grab Minio credentials and injects them in the storage secret used by
+# Tekton Pipeline
+BASE_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+
+MINIO_NAMESPACE=${MINIO_NAMESPACE:-eu-geo}
+MINIO_SECRET=${MINIO_SECRET:-s3}
+
+MINIO_ACCESS_KEY=$(kubectl get -n $MINIO_NAMESPACE secret/$MINIO_SECRET \
+  -o jsonpath='{ .data.accesskey }' | base64 -D)
+MINIO_SECRET_KEY=$(kubectl get -n $MINIO_NAMESPACE secret/$MINIO_SECRET \
+  -o jsonpath='{ .data.secretkey }' | base64 -D)
+
+sed -e 's/__MINIO_ACCESS_KEY__/'$MINIO_ACCESS_KEY'/g' \
+  -e 's/__MINIO_SECRET_KEY__/'$MINIO_SECRET_KEY'/g' \
+  "${BASE_DIR}/tekton-storage-secret.yaml.tpl" > "${BASE_DIR}/../tekton-storage-secret.yaml"

--- a/tekton/cd/pipeline/overlays/robocat/pre/tekton-storage-secret.yaml.tpl
+++ b/tekton/cd/pipeline/overlays/robocat/pre/tekton-storage-secret.yaml.tpl
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tekton-storage
+  namespace: tekton-pipelines
+type: kubernetes.io/opaque
+stringData:
+  boto-config: |
+    [Credentials]
+    aws_access_key_id = __MINIO_ACCESS_KEY__
+    aws_secret_access_key = __MINIO_SECRET_KEY__
+    [s3]
+    host = s3.eu-geo.svc.cluster.local
+    use-sigv4 = True
+    [Boto]
+    https_validate_certificates = True
+    [GSUtil]
+    prefer_api = xml

--- a/tekton/cronjobs/README.md
+++ b/tekton/cronjobs/README.md
@@ -42,6 +42,13 @@ The following configuration maps are deployed continuously:
 The following folders are deployed continuously:
 * [robotcat cadmin](robocat-cadmin-cron/README.md)
 
+The following helm charts are deployed continuously:
+* [minio](minio-helm-cron/README.md)
+
+The following Tekton services are deployed continuously:
+* [pipeline on robocat](robocat-pipeline-deploy-latest-cron/README.md)
+
+
 ## Adding a new cron job
 
 To add a new cronjob for an existing base, follow these steps.

--- a/tekton/cronjobs/configmap-cd-cron-base/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/configmap-cd-cron-base/trigger-resource-cd.yaml
@@ -34,17 +34,22 @@ spec:
               - |
                 cat <<EOF > /workspace/post-body.json
                 {
-                  "git": {
-                    "repository": "$GIT_REPOSITORY",
-                    "revision": "$GIT_REVISION"
-                  },
-                  "namespace": "$NAMESPACE",
-                  "cluster-resource": "$CLUSTER_RESOURCE",
-                  "configmap": {
-                      "name": "$CONFIGMAP_NAME",
-                      "key": "$CONFIGMAP_KEY",
-                      "description": "$CONFIGMAP_DESCRIPTION",
-                      "path": "$CONFIG_PATH"
+                  "trigger-template": "configmaps",
+                  "params": {
+                    "git": {
+                      "repository": "$GIT_REPOSITORY",
+                      "revision": "$GIT_REVISION"
+                    },
+                    "target": {
+                      "namespace": "$NAMESPACE",
+                      "cluster-resource": "$CLUSTER_RESOURCE",
+                    },
+                    "configmap": {
+                        "description": "$CONFIGMAP_DESCRIPTION",
+                        "path": "$CONFIG_PATH"
+                        "name": "$CONFIGMAP_NAME",
+                        "key": "$CONFIGMAP_KEY"
+                    },
                   }
                 }
                 EOF

--- a/tekton/cronjobs/folder-cd-cron-base/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/folder-cd-cron-base/trigger-resource-cd.yaml
@@ -34,17 +34,22 @@ spec:
               - |
                 cat <<EOF > /workspace/post-body.json
                 {
-                  "git": {
-                    "repository": "$GIT_REPOSITORY",
-                    "revision": "$GIT_REVISION"
-                  },
-                  "namespace": "$NAMESPACE",
-                  "cluster-resource": "$CLUSTER_RESOURCE",
-                  "folder": {
-                      "path": "$FOLDER_PATH",
-                      "description": "$FOLDER_DESCRIPTION",
-                      "method": "$FOLDER_METHOD",
-                      "is-overlay": "$FOLDER_OVERLAY"
+                  "trigger-template": "folders",
+                  "params": {
+                    "git": {
+                      "repository": "$GIT_REPOSITORY",
+                      "revision": "$GIT_REVISION"
+                    },
+                    "target": {
+                      "namespace": "$NAMESPACE",
+                      "cluster-resource": "$CLUSTER_RESOURCE"
+                    },
+                    "folder": {
+                        "path": "$FOLDER_PATH",
+                        "description": "$FOLDER_DESCRIPTION",
+                        "method": "$FOLDER_METHOD",
+                        "is-overlay": "$FOLDER_OVERLAY"
+                    }
                   }
                 }
                 EOF

--- a/tekton/cronjobs/helm-cd-cron-base/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/helm-cd-cron-base/trigger-resource-cd.yaml
@@ -35,18 +35,22 @@ spec:
                 CHART_PARAMS=$(echo $CHART_PARAMS | sed 's/, /,/g')
                 cat <<EOF > /workspace/post-body.json
                 {
-                  "namespace": "$NAMESPACE",
-                  "cluster-resource": "$CLUSTER_RESOURCE",
-                  "helm": {
-                      "name": "$CHART_NAME",
-                      "version": "$CHART_VERSION",
-                      "repo": "$CHART_REPO",
-                      "params": "$CHART_PARAMS",
-                      "description": "$CHART_DESCRIPTION"
+                  "trigger-template": "folders",
+                  "params": {
+                    "target": {
+                      "namespace": "$NAMESPACE",
+                      "cluster-resource": "$CLUSTER_RESOURCE"
+                    },
+                    "helm": {
+                        "name": "$CHART_NAME",
+                        "version": "$CHART_VERSION",
+                        "repo": "$CHART_REPO",
+                        "params": "$CHART_PARAMS",
+                        "description": "$CHART_DESCRIPTION"
+                    }
                   }
                 }
                 EOF
-                # Drop empty params that have a default in the template trigger
                 curl -d @/workspace/post-body.json $SINK_URL
             volumeMounts:
             - mountPath: /workspace

--- a/tekton/cronjobs/robocat-pipeline-deploy-latest-cron/README.md
+++ b/tekton/cronjobs/robocat-pipeline-deploy-latest-cron/README.md
@@ -1,0 +1,1 @@
+Cron Job to nightly deploy the latest nightly release of pipeline to robocat.

--- a/tekton/cronjobs/robocat-pipeline-deploy-latest-cron/cronjob.yaml
+++ b/tekton/cronjobs/robocat-pipeline-deploy-latest-cron/cronjob.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: tekton-release-cd-trigger
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: CLUSTER_RESOURCE
+                value: "robocat-tekton-deployer"
+              - name: TEKTON_PROJECT
+                value: "pipeline"
+              - name: TEKTON_VERSION
+                value: "latest"
+              - name: TEKTON_CLUSTER
+                value: "robocat"

--- a/tekton/cronjobs/robocat-pipeline-deploy-latest-cron/kustomization.yaml
+++ b/tekton/cronjobs/robocat-pipeline-deploy-latest-cron/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../tekton-service-cd-cron-base
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-robotcat-pipeline"

--- a/tekton/cronjobs/tekton-service-cd-cron-base/README.md
+++ b/tekton/cronjobs/tekton-service-cd-cron-base/README.md
@@ -1,0 +1,1 @@
+Cron Job template to deploy a Tekton service release.

--- a/tekton/cronjobs/tekton-service-cd-cron-base/kustomization.yaml
+++ b/tekton/cronjobs/tekton-service-cd-cron-base/kustomization.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+commonLabels:
+  app: tekton.plumbing
+resources:
+- trigger-resource-cd.yaml

--- a/tekton/cronjobs/tekton-service-cd-cron-base/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/tekton-service-cd-cron-base/trigger-resource-cd.yaml
@@ -34,18 +34,28 @@ spec:
               - |
                 cat <<EOF > /workspace/post-body.json
                 {
-                  "namespace": "$NAMESPACE",
-                  "cluster-resource": "$CLUSTER_RESOURCE",
-                  "tekton": {
-                    "project": "$TEKTON_PROJECT",
-                    "version": "$TEKTON_VERSION",
-                    "environment": "$TEKTON_CLUSTER",
-                    "bucket": "$RELEASE_BUCKET",
-                    "file": "$RELEASE_FILE"
-                  },
-                  "plumbing": {
-                    "repository": "$PLUMBING_REPOSITORY",
-                    "revision": "$PLUMBING_REVISION"
+                  "trigger-template": "tekton",
+                  "params": {
+                    "git": {
+                      "repository": "$GIT_REPOSITORY",
+                      "revision": "$GIT_REVISION"
+                    },
+                    "target": {
+                      "namespace": "$NAMESPACE",
+                      "cluster-resource": "$CLUSTER_RESOURCE"
+                    },
+                    "tekton": {
+                      "project": "$TEKTON_PROJECT",
+                      "version": "$TEKTON_VERSION",
+                      "environment": "$TEKTON_CLUSTER",
+                      "bucket": "$RELEASE_BUCKET",
+                      "file": "$RELEASE_FILE",
+                      "extra-path": "$RELEASE_EXTRA_PATH"
+                    },
+                    "plumbing": {
+                      "repository": "$PLUMBING_REPOSITORY",
+                      "revision": "$PLUMBING_REVISION"
+                    }
                   }
                 }
                 EOF
@@ -64,6 +74,8 @@ spec:
                 value: "gs://tekton-releases"
               - name: RELEASE_FILE
                 value: "release.yaml"
+              - name: RELEASE_EXTRA_PATH
+                value: ""
               - name: NAMESPACE
                 value: "tekton-pipelines"
               - name: CLUSTER_RESOURCE

--- a/tekton/cronjobs/tekton-service-cd-cron-base/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/tekton-service-cd-cron-base/trigger-resource-cd.yaml
@@ -1,0 +1,77 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: tekton-release-cd-trigger
+spec:
+  schedule: "12 * * * *" # Houly at *:12
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: workspace
+            emptyDir: {}
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            command:
+              - /bin/sh
+            args:
+              - -ce
+              - |
+                cat <<EOF > /workspace/post-body.json
+                {
+                  "namespace": "$NAMESPACE",
+                  "cluster-resource": "$CLUSTER_RESOURCE",
+                  "tekton": {
+                    "project": "$TEKTON_PROJECT",
+                    "version": "$TEKTON_VERSION",
+                    "environment": "$TEKTON_CLUSTER",
+                    "bucket": "$RELEASE_BUCKET",
+                    "file": "$RELEASE_FILE"
+                  },
+                  "plumbing": {
+                    "repository": "$PLUMBING_REPOSITORY",
+                    "revision": "$PLUMBING_REVISION"
+                  }
+                }
+                EOF
+                curl -d @/workspace/post-body.json $SINK_URL
+            volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            env:
+              - name: SINK_URL
+                value: "http://el-tekton-cd.default.svc.cluster.local:8080"
+              - name: PLUMBING_REPOSITORY
+                value: "github.com/tektoncd/plumbing"
+              - name: PLUMBING_REVISION
+                value: "master"
+              - name: RELEASE_BUCKET
+                value: "gs://tekton-releases"
+              - name: RELEASE_FILE
+                value: "release.yaml"
+              - name: NAMESPACE
+                value: "tekton-pipelines"
+              - name: CLUSTER_RESOURCE
+                value: "not-a-real-cluster"
+              - name: TEKTON_PROJECT
+                value: "invalid"
+              - name: TEKTON_VERSION
+                value: "invalid"
+              - name: TEKTON_CLUSTER
+                value: "invalid"
+          restartPolicy: Never

--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -18,9 +18,9 @@ metadata:
 spec:
   params:
   - name: namespace
-    value: $(body.namespace)
+    value: $(body.params.target.namespace)
   - name: clusterResource
-    value: $(body.cluster-resource)
+    value: $(body.params.target.cluster-resource)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -29,9 +29,9 @@ metadata:
 spec:
   params:
   - name: gitRepository
-    value: $(body.git.repository)
+    value: $(body.params.git.repository)
   - name: gitRevision
-    value: $(body.git.revision)
+    value: $(body.params.git.revision)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -40,13 +40,13 @@ metadata:
 spec:
   params:
   - name: configMapName
-    value: $(body.configmap.name)
+    value: $(body.params.configmap.name)
   - name: configMapKey
-    value: $(body.configmap.key)
+    value: $(body.params.configmap.key)
   - name: configMapDescription
-    value: $(body.configmap.description)
+    value: $(body.params.configmap.description)
   - name: configPath
-    value: $(body.configmap.path)
+    value: $(body.params.configmap.path)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -55,13 +55,13 @@ metadata:
 spec:
   params:
   - name: folderPath
-    value: $(body.folder.path)
+    value: $(body.params.folder.path)
   - name: folderDescription
-    value: $(body.folder.description)
+    value: $(body.params.folder.description)
   - name: deployMethod
-    value: $(body.folder.method)
+    value: $(body.params.folder.method)
   - name: isOverlay
-    value: $(body.folder.is-overlay)
+    value: $(body.params.folder.is-overlay)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -70,15 +70,15 @@ metadata:
 spec:
   params:
   - name: chartName
-    value: $(body.helm.name)
+    value: $(body.params.helm.name)
   - name: chartVersion
-    value: $(body.helm.version)
+    value: $(body.params.helm.version)
   - name: chartRepo
-    value: $(body.helm.repo)
+    value: $(body.params.helm.repo)
   - name: chartParams
-    value: $(body.helm.params)
+    value: $(body.params.helm.params)
   - name: chartDescription
-    value: $(body.helm.description)
+    value: $(body.params.helm.description)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -87,15 +87,15 @@ metadata:
 spec:
   params:
   - name: targetCluster
-    value: $(body.tekton.environment)
+    value: $(body.params.tekton.environment)
   - name: releaseBucket
-    value: $(body.tekton.bucket)
+    value: $(body.params.tekton.bucket)
   - name: releaseFile
-    value: $(body.tekton.file)
+    value: $(body.params.tekton.file)
   - name: tektonProject
-    value: $(body.tekton.project)
+    value: $(body.params.tekton.project)
   - name: tektonVersion
-    value: $(body.tekton.version)
+    value: $(body.params.tekton.version)
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -104,6 +104,6 @@ metadata:
 spec:
   params:
   - name: plumbingRepository
-    value: $(body.plumbing.repository)
+    value: $(body.params.plumbing.repository)
   - name: plumbingRevision
-    value: $(body.plumbing.revision)
+    value: $(body.params.plumbing.revision)

--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -79,3 +79,31 @@ spec:
     value: $(body.helm.params)
   - name: chartDescription
     value: $(body.helm.description)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-details
+spec:
+  params:
+  - name: targetCluster
+    value: $(body.tekton.environment)
+  - name: releaseBucket
+    value: $(body.tekton.bucket)
+  - name: releaseFile
+    value: $(body.tekton.file)
+  - name: tektonProject
+    value: $(body.tekton.project)
+  - name: tektonVersion
+    value: $(body.tekton.version)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: plumbing-git
+spec:
+  params:
+  - name: plumbingRepository
+    value: $(body.plumbing.repository)
+  - name: plumbingRevision
+    value: $(body.plumbing.revision)

--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -75,12 +75,21 @@ spec:
             set -ex
             kubectl get configmap -n $(inputs.params.namespace) \
               $(inputs.params.configMapName) -o template \
-              --template='{{ index .data "$(inputs.params.configMapKey)" }}' > /workspace/$(inputs.params.configMapKey)
+              --template='{{ index .data "$(inputs.params.configMapKey)" }}' > \
+               /workspace/$(inputs.params.configMapKey) || \
+               rm /workspace/$(inputs.params.configMapKey)
         - name: deploy
           image: gcr.io/tekton-releases/dogfooding/kubectl
           script: |
             #!/bin/sh
             set -ex
+            if [ ! -f /workspace/$(inputs.params.configMapKey) ]; then
+              echo "First time deployment"
+              kubectl create configmap $(inputs.params.configMapName) \
+                --from-file=$(inputs.params.configMapKey)=$(inputs.resources.source.path)/$(inputs.params.configPath) \
+                -n $(inputs.params.namespace)
+                exit 0
+            fi
             echo "diff [current-config] [new config]"
             has_diff=0
             diff /workspace/$(inputs.params.configMapKey) \

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -22,7 +22,8 @@ spec:
       interceptors:
         - cel:
             filter: >-
-              'configmap' in body
+              'trigger-template' in body &&
+              body['trigger-template'] == 'configmap'
       bindings:
         - name: deploy-target-details
         - name: deploy-source-git
@@ -33,7 +34,8 @@ spec:
       interceptors:
         - cel:
             filter: >-
-              'folder' in body
+              'trigger-template' in body &&
+              body['trigger-template'] == 'folders'
       bindings:
         - name: deploy-target-details
         - name: deploy-source-git
@@ -44,7 +46,8 @@ spec:
       interceptors:
         - cel:
             filter: >-
-              'helm' in body
+              'trigger-template' in body &&
+              body['trigger-template'] == 'helm'
       bindings:
         - name: deploy-target-details
         - name: helm-details
@@ -54,7 +57,8 @@ spec:
       interceptors:
         - cel:
             filter: >-
-              'tekton' in body
+              'trigger-template' in body &&
+              body['trigger-template'] == 'tekton'
       bindings:
         - name: deploy-target-details
         - name: tekton-details

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -50,3 +50,14 @@ spec:
         - name: helm-details
       template:
         name: deploy-helm-chart
+    - name: tekton
+      interceptors:
+        - cel:
+            filter: >-
+              'tekton' in body
+      bindings:
+        - name: deploy-target-details
+        - name: tekton-details
+        - name: plumbing-git
+      template:
+        name: deploy-tekton-release

--- a/tekton/resources/cd/tekton-template.yaml
+++ b/tekton/resources/cd/tekton-template.yaml
@@ -1,0 +1,81 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: deploy-tekton-release
+spec:
+  params:
+  - name: clusterResource
+    description: Name of the cluster resource that points to the target cluster
+  - name: targetCluster
+    description: Name of the target cluster, used for the overlay
+  - name: releaseBucket
+    description: Base URL of the bucket where the release file is stored
+    default: gs://tekton-releases
+  - name: releaseFile
+    description: Name of the release file
+    default: release.yaml
+  - name: tektonProject
+    description: Name of the project to deploy (pipeline, triggers, dashboard)
+  - name: tektonVersion
+    description: Version of the project to deploy
+  - name: namespace
+    description: Target namespace. Not enforeced, for verification.
+  - name: plumbingRepository
+    description: URL of the repository that holds plumbing scripts
+  - name: plumbingRevision
+    description: Git revision of the repository that holds plumbing scripts
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1alpha1
+    kind: TaskRun
+    metadata:
+      name: deploy-$(params.tektonProject)-release-$(params.targetCluster)-$(uid)
+    spec:
+      taskRef:
+        name: install-tekton-release
+      inputs:
+        params:
+        - name: projectName
+          value: $(params.tektonProject)
+        - name: namespace
+          value: $(params.namespace)
+        - name: version
+          value: $(params.tektonVersion)
+        - name: environment
+          value: $(params.targetCluster)
+        - name: release-file
+          value: $(params.releaseFile)
+        resources:
+          - name: release-bucket
+            resourceSpec:
+              type: storage
+              params:
+              - name: type
+                value: gcs
+              - name: location
+                value: $(params.releaseBucket)/$(params.tektonProject)
+              - name: dir
+                value: "y"
+          - name: k8s-cluster
+            resourceRef:
+              name: $(params.clusterResource)
+          - name: plumbing-library
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(params.plumbingRevision)
+              - name: url
+                value: https://$(params.plumbingRepository)

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - cd/eventListener.yaml
 - cd/folder-template.yaml
 - cd/helm-template.yaml
+- cd/tekton-template.yaml
 - cd/serviceaccount.yaml
 - org-permissions/peribolos.yaml
 - org-permissions/peribolos-trigger.yaml

--- a/tekton/resources/release/README.md
+++ b/tekton/resources/release/README.md
@@ -44,7 +44,28 @@ tkn task start \
   -i release-bucket=$TEKTON_BUCKET_RESOURCE \
   -i k8s-cluser=$TEKTON_CLUSTER_RESOURCE \
   -p projectName=$TEKTON_PROJECT \
-  -p version=$TEKTON_VERSION
+  -p version=$TEKTON_VERSION \
+  install-tekton-release
+```
+
+The release task can use a `kustomize` overlay if available. The name of the
+ovelay folder is specified via the `environment` parameter.
+The overlay folder must contain a `kustomize.yaml` configuration file. It may
+also contain a `pre` folder. Any `*.sh` script found in the folder will be
+executed before the release is installed.
+
+```
+TEKTON_BUCKET_RESOURCE=tekton-bucket
+TEKTON_CLUSTER_RESOURCE=k8s-cluster
+TEKTON_PROJECT=pipeline
+TEKTON_VERSION=v0.9.0
+
+tkn task start \
+  -i release-bucket=$TEKTON_BUCKET_RESOURCE \
+  -i k8s-cluser=$TEKTON_CLUSTER_RESOURCE \
+  -p projectName=$TEKTON_PROJECT \
+  -p version=$TEKTON_VERSION \
+  -p environment=robocat \
   install-tekton-release
 ```
 

--- a/tekton/resources/release/install_tekton_release.yaml
+++ b/tekton/resources/release/install_tekton_release.yaml
@@ -34,9 +34,6 @@ spec:
     - name: version
       description: The vX.Y.Z version that we want to install (including `v`)
       default: latest
-    - name: default-service-account
-      description: Service account to be setup as default in Tekton configmap
-      default: default
     - name: environment
       description: Name of the target environment. Used to apply relevant overalys
       default: dogfooding
@@ -51,9 +48,10 @@ spec:
       #!/usr/bin/env bash
       set -exo pipefail
 
-      KUBECONFIG=/workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
+      # Export KUBECONFIG so that it's available to pre-scripts too
+      export KUBECONFIG=/workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
       # Set up RELEASE_ROOT
-      if [[ "$(inputs.params.version)" == "latest "]]; then
+      if [[ "$(inputs.params.version)" == "latest" ]]; then
         RELEASE_ROOT=$(inputs.resources.release-bucket.path)/$(inputs.params.version)
       else
         RELEASE_ROOT=$(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)

--- a/tekton/resources/release/install_tekton_release.yaml
+++ b/tekton/resources/release/install_tekton_release.yaml
@@ -33,6 +33,7 @@ spec:
       default: tekton-pipelines
     - name: version
       description: The vX.Y.Z version that we want to install (including `v`)
+      default: latest
     - name: default-service-account
       description: Service account to be setup as default in Tekton configmap
       default: default
@@ -50,34 +51,38 @@ spec:
       #!/usr/bin/env bash
       set -exo pipefail
 
-      OVERLAY_ROOT=$(inputs.params.projectName)/overlays/$(inputs.params.environment)
-      RELEASE_ROOT=$(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)
+      KUBECONFIG=/workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
+      # Set up RELEASE_ROOT
+      if [[ "$(inputs.params.version)" == "latest "]]; then
+        RELEASE_ROOT=$(inputs.resources.release-bucket.path)/$(inputs.params.version)
+      else
+        RELEASE_ROOT=$(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)
+      fi
+
+      # Handle Overlays
+      OVERLAY_FOLDER=$(inputs.params.projectName)/overlays/$(inputs.params.environment)
+      APPLY_MODE="-k $OVERLAY_FOLDER"
 
       cd $(inputs.resources.plumbing-library.path)/tekton/cd
 
       if [ ! -d $(inputs.params.projectName) ]; then
         # There are is not base or project for $(inputs.params.projectName)
         # Apply the release as is
-        kubectl apply \
-          --filename $RELEASE_ROOT/$(inputs.params.release-file) \
-          --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
+        APPLY_MODE="--filename $RELEASE_ROOT/$(inputs.params.release-file)"
       else
-          # If the base exists, an overlay for the specified environment must exist
-          if [ ! -d  "$OVERLAY_ROOT" ]; then
-            echo "Environment $(inputs.params.environment) not found for project $(inputs.params.projectName)"
-            exit 1
-          fi
-          cp $RELEASE_ROOT/$(inputs.params.release-file) $(inputs.params.projectName)/base/release.yaml
-          find .
+        # If the base exists, an overlay for the specified environment must exist
+        if [ ! -d  "$OVERLAY_FOLDER" ]; then
+          echo "Environment $(inputs.params.environment) not found for project $(inputs.params.projectName)"
+          exit 1
+        fi
+        cp $RELEASE_ROOT/$(inputs.params.release-file) $(inputs.params.projectName)/base/release.yaml
+        find .
 
-          # Execute pre-deploy scripts if any
-          scripts=$(find ${OVERLAY_ROOT}/pre -name '*.sh' 2> /dev/null || true)
-          for script in $scripts; do $script; done
-
-          kubectl apply \
-            --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig \
-            -k $(inputs.params.projectName)/overlays/$(inputs.params.environment)
+        # Execute pre-deploy scripts if any
+        scripts=$(find ${OVERLAY_FOLDER}/pre -name '*.sh' 2> /dev/null || true)
+        for script in $scripts; do $script; done
       fi
+      kubectl apply --kubeconfig $KUBECONFIG $APPLY_MODE
 
   - name: wait-until-pods-running
     image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest

--- a/tekton/resources/release/install_tekton_release.yaml
+++ b/tekton/resources/release/install_tekton_release.yaml
@@ -50,22 +50,30 @@ spec:
       #!/usr/bin/env bash
       set -exo pipefail
 
+      OVERLAY_ROOT=$(inputs.params.projectName)/overlays/$(inputs.params.environment)
+      RELEASE_ROOT=$(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)
+
       cd $(inputs.resources.plumbing-library.path)/tekton/cd
 
       if [ ! -d $(inputs.params.projectName) ]; then
         # There are is not base or project for $(inputs.params.projectName)
         # Apply the release as is
         kubectl apply \
-          --filename $(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)/$(inputs.params.release-file) \
+          --filename $RELEASE_ROOT/$(inputs.params.release-file) \
           --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig
       else
           # If the base exists, an overlay for the specified environment must exist
-          if [ ! -d $(inputs.params.projectName)/overlays/$(inputs.params.environment) ]; then
+          if [ ! -d  "$OVERLAY_ROOT" ]; then
             echo "Environment $(inputs.params.environment) not found for project $(inputs.params.projectName)"
             exit 1
           fi
-          cp $(inputs.resources.release-bucket.path)/previous/$(inputs.params.version)/$(inputs.params.release-file) $(inputs.params.projectName)/base/release.yaml
+          cp $RELEASE_ROOT/$(inputs.params.release-file) $(inputs.params.projectName)/base/release.yaml
           find .
+
+          # Execute pre-deploy scripts if any
+          scripts=$(find ${OVERLAY_ROOT}/pre -name '*.sh' 2> /dev/null || true)
+          for script in $scripts; do $script; done
+
           kubectl apply \
             --kubeconfig /workspace/$(inputs.resources.k8s-cluster.name)/kubeconfig \
             -k $(inputs.params.projectName)/overlays/$(inputs.params.environment)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Start CD of pipeline in the robocat cluster. To do setup some preconditions:
- extend the deployment pipeline to accept version "latest"
- extend the configmap deployment pipeline to create a configmap on first run
- add a pipeline overlay for the robocat cluster
- extend the deployment pipeline to accept pre-deploy script, so we can deploy secrets
- add a service in the tektoncd trigger to run the deployment pipeline
- add a cronjob to deploy pipeline nightly from latest to robocat

Work on #224 
Depends on https://github.com/tektoncd/plumbing/pull/270 and https://github.com/tektoncd/plumbing/pull/271

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._