### PR TITLE
Adding a triage/wg-discuss 😅

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -146,6 +146,11 @@ default:
       name: triage/needs-information
       target: both
       addedBy: humans
+    - color: d455d0
+      description: Indicates an issue that needs to be discussed during a working group call.
+      name: triage/wg-discuss
+      target: both
+      addedBy: humans
     # If I was contributing to a repo, went to the trouble to create an issue or PR, and a maintainer
     # responded by shrugging, I think it would make me feel my contribution wasn't appreciated
     - color: f9d0c4


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This label is meant to be used, at least by the CLI WG, to be able to
mark issues or PR to be discussed during the WG calls. With the proper
automation, it will appear on the WG Project we use to track those
discussion.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @danielhelfand @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._