### PR TITLE
Update build bot to load rotation dynamically 🚚

### DIFF
--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -18,3 +18,12 @@ data:
   BOTID: URCPZNB37
   CHANNELID: CPY3T4YHM
 ```
+
+## Deploying
+
+When connected to [the dogfood cluster](https://github.com/tektoncd/plumbing/blob/master/gcp.md):
+
+```bash
+# must be run from the `buildbot` dir or it will use the go.mod file one level up
+buildbot$ KO_DOCKER_REPO=gcr.io/tekton-releases/buildbot ko --context dogfood apply -f config/deployment.yaml
+```

--- a/buildbot/cmd/buildbot/kodata/rotation.csv
+++ b/buildbot/cmd/buildbot/kodata/rotation.csv
@@ -1,1 +1,0 @@
-../../../rotation.csv

--- a/buildbot/cmd/buildbot/main.go
+++ b/buildbot/cmd/buildbot/main.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"strings"
 	"time"
 
 	"github.com/nlopes/slack"
 )
+
+const rotationURL = "https://raw.githubusercontent.com/tektoncd/plumbing/master/buildbot/rotation.csv"
 
 var (
 	currentCop string
@@ -50,11 +51,7 @@ func main() {
 		copsID[user.Name] = user.ID
 	}
 
-	// When building with "ko", templates is deployed under KO_DATA_PATH
-	// If KO_DATA_PATH is not defined, the path will be a relative one
-	basePath := os.Getenv("KO_DATA_PATH")
-	csvfile := path.Join(basePath, "rotation.csv")
-	r := NewRotation(csvfile)
+	r := NewRotationFromURL(rotationURL)
 	currentCop = copsID[r.GetBuildCop(time.Now())]
 
 	rtm := api.NewRTM()

--- a/buildbot/cmd/buildbot/rotation.go
+++ b/buildbot/cmd/buildbot/rotation.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/csv"
+	"os"
+	"time"
+
+	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/log"
+)
+
+// The Rotation object which knows how to dynamically find the correct build cop from
+// the file it is initialized with.
+type Rotation struct {
+	file string
+}
+
+// NewRotation returns a new Rotation object which will read from file.
+func NewRotation(file string) Rotation {
+	return Rotation{file: file}
+}
+
+// GetBuildCop returns the name of the build cop for the requested time
+func (r Rotation) GetBuildCop(t time.Time) string {
+	tf := t.Format("2006-01-02") // Mon Jan 2 15:04:05 MST 2006
+	rotation, err := readRotation(r.file)
+	if err != nil {
+		log.Errorf("Could not read from build cop rotation file %s: %v", r.file, err)
+		return "nobody"
+	}
+	b, ok := rotation[tf]
+	if !ok {
+		log.Errorf("Couldn't find anyone in rotation %s for time %s", r.file, tf)
+		return "nobody"
+	}
+	return b
+}
+
+func readRotation(filename string) (map[string]string, error) {
+	rotation := map[string]string{}
+	// Open CSV file
+	f, err := os.Open(filename)
+	if err != nil {
+		return rotation, err
+	}
+	defer f.Close()
+
+	// Read File into a Variable
+	lines, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return rotation, err
+	}
+
+	for i, line := range lines {
+		if i == 0 {
+			continue
+		}
+		rotation[line[0]] = line[1]
+	}
+	return rotation, nil
+}

--- a/buildbot/cmd/buildbot/rotation_test.go
+++ b/buildbot/cmd/buildbot/rotation_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetBuildCop(t *testing.T) {
+	r := NewRotation("testdata/rotation.csv")
+
+	for _, c := range []struct {
+		desc        string
+		time        time.Time
+		expectedCop string
+	}{{
+		desc:        "success",
+		time:        time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC),
+		expectedCop: "christiewilson",
+	}, {
+		desc:        "no one on the date",
+		time:        time.Date(2019, time.December, 15, 0, 0, 0, 0, time.UTC),
+		expectedCop: "",
+	}, {
+		desc:        "time not found",
+		time:        time.Date(2016, time.August, 15, 0, 0, 0, 0, time.UTC),
+		expectedCop: "nobody",
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			cop := r.GetBuildCop(c.time)
+			if cop != c.expectedCop {
+				t.Errorf("Expected build cop %s for %s but got %s", c.expectedCop, c.time, cop)
+			}
+		})
+	}
+}
+
+func TestGetBuildCop_Invalid(t *testing.T) {
+	r := NewRotation("testdata/rotation-invalid.csv")
+	cop := r.GetBuildCop(time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC))
+	if cop != "nobody" {
+		t.Errorf("Expected build cop nobody when file is invalid but got %s", cop)
+	}
+}

--- a/buildbot/cmd/buildbot/rotation_test.go
+++ b/buildbot/cmd/buildbot/rotation_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetBuildCop(t *testing.T) {
-	r := NewRotation("testdata/rotation.csv")
+	r := NewRotationFromFile("testdata/rotation.csv")
 
 	for _, c := range []struct {
 		desc        string
@@ -35,7 +35,7 @@ func TestGetBuildCop(t *testing.T) {
 }
 
 func TestGetBuildCop_Invalid(t *testing.T) {
-	r := NewRotation("testdata/rotation-invalid.csv")
+	r := NewRotationFromFile("testdata/rotation-invalid.csv")
 	cop := r.GetBuildCop(time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC))
 	if cop != "nobody" {
 		t.Errorf("Expected build cop nobody when file is invalid but got %s", cop)

--- a/buildbot/cmd/buildbot/testdata/rotation-invalid.csv
+++ b/buildbot/cmd/buildbot/testdata/rotation-invalid.csv
@@ -1,0 +1,2 @@
+hello i am an invalid header
+and i am an invalid file, yeah, yeah, yeah

--- a/buildbot/cmd/buildbot/testdata/rotation.csv
+++ b/buildbot/cmd/buildbot/testdata/rotation.csv
@@ -1,0 +1,14 @@
+Date,User
+2019-12-03,dibyo
+2019-12-04,christiewilson
+2019-12-05,sbws
+2019-12-06,jasonhall
+2019-12-07,
+2019-12-08,
+2019-12-09,vdemeest
+2019-12-10,andrea.frittoli
+2019-12-11,dibyo
+2019-12-12,christiewilson
+2019-12-13,sbws
+2019-12-14,
+2019-12-15,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Build cop bot will now load the csv file from github every time it checks it.

Previously the buildbot binary was being built with the rotation csv as
part of the binary itself, which meant that updating the rotation would
require rebuilding and redeploying the image.

This change makes it so that the rotation can be updating without
needing to update the image - the downside is that the running binary is
now coupled to the repo but I think it's worth it!

Follow up TODOS:
* run unit tests on every PR https://github.com/tektoncd/plumbing/issues/283
* deploy build bot binary automatically https://github.com/tektoncd/plumbing/issues/282

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._