### PR TITLE
Respond to PR feedback

### DIFF
--- a/buildbot/cmd/buildbot/main.go
+++ b/buildbot/cmd/buildbot/main.go
@@ -51,7 +51,7 @@ func main() {
 		copsID[user.Name] = user.ID
 	}
 
-	r := NewRotationFromURL(rotationURL)
+	r := NewRotation(FromURL(rotationURL))
 	currentCop = copsID[r.GetBuildCop(time.Now())]
 
 	rtm := api.NewRTM()

--- a/buildbot/cmd/buildbot/rotation.go
+++ b/buildbot/cmd/buildbot/rotation.go
@@ -4,10 +4,9 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
-
-	"k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/log"
 )
 
 // The Rotation object which knows how to dynamically find the correct build cop from
@@ -41,19 +40,19 @@ func (r Rotation) GetBuildCop(t time.Time) string {
 	tf := t.Format("2006-01-02") // Mon Jan 2 15:04:05 MST 2006
 	f, err := r.f()
 	if err != nil {
-		log.Errorf("Could not read from build cop rotation: %v", err)
+		log.Printf("Could not read from build cop rotation: %v", err)
 		return "nobody"
 	}
 	defer f.Close()
 	rotation, err := parseRotation(f)
 
 	if err != nil {
-		log.Errorf("Could not read rotation from build cop rotation: %v", err)
+		log.Printf("Could not read rotation from build cop rotation: %v", err)
 		return "nobody"
 	}
 	b, ok := rotation[tf]
 	if !ok {
-		log.Errorf("Couldn't find anyone in rotation for time %s", tf)
+		log.Printf("Couldn't find anyone in rotation for time %s", tf)
 		return "nobody"
 	}
 	return b


### PR DESCRIPTION
# Changes

Addressing feedback in #281

Decouple the file / url functionality from the logic to create a new
Rotation object. Also moving the file based logic into the tests since
it is only used by the tests. (Thanks for the feedback @vdemeester!)

Use standard log lib instead of pulling in a kubernetes dependency 😅 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._