### PR TITLE
Prerelease Check: Only fail if version tag endings are exact match

### DIFF
--- a/tekton/resources/release/prerelease_checks.yaml
+++ b/tekton/resources/release/prerelease_checks.yaml
@@ -39,7 +39,7 @@ spec:
         echo "Checking git tag"
         # Look for the tag in the list of tags
         git ls-remote --tags https://$(inputs.params.package) | \
-          grep $(inputs.params.versionTag) || exit 0
+          grep "$(inputs.params.versionTag)$" || exit 0
         # If the version was found fail
         echo "Version $(inputs.params.versionTag) already tagged for $(inputs.params.package)"
         exit 1
@@ -70,7 +70,7 @@ spec:
         wget -q -O- --header 'Accept: application/vnd.github.v3+json' \
           https://api.github.com/repos/${PACKAGE}/releases | \
           python -c 'import sys; import json; print("\n".join([x["tag_name"] for x in json.load(sys.stdin)]))' | \
-          grep $(inputs.params.versionTag) || exit 0
+          grep "$(inputs.params.versionTag)$" || exit 0
         echo "Release $(inputs.params.versionTag) already exists for $(inputs.params.package)"
         exit 1
     - name: success-confirmation


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously the prerelease check would fail if any tag in the git repo _contained_ the version tag supplied to the Task.  For example, `v0.11.0` would be disallowed if there was an existing tag of `v0.11.0-rc1`.

This PR changes the prerelease check so that the tag endings must match exactly.  `v0.11.0` will be allowed even if tag `v0.11.0-rc1` exists.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._