### PR TITLE
Improve tekton-experimental-helm-lint prow job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -450,35 +450,17 @@ presubmits:
         secret:
           secretName: test-account
   - name: pull-tekton-experimental-helm-lint
-    agent: tekton-pipeline
+    agent: kubernetes
     always_run: true
     rerun_command: /run tekton-experimental-helm-lint
     trigger: "(?m)^/run (all|tekton-experimental-helm-lint),?(\\s+|$)"
-    pipeline_run_spec:
-      pipelineSpec:
-        resources:
-          - name: src
-            type: git
-        tasks:
-          - taskSpec:
-              inputs:
-                resources:
-                  - name: src
-                    type: git
-              steps:
-                - image: alpine/helm:3.1.2
-                  workingDir: /workspace/src/helm
-                  script: |
-                    #!/usr/bin/env sh
-                    helm lint ./pipeline
-            resources:
-              inputs:
-                - name: src
-                  resource: src
-      resources:
-        - name: src
-          resourceRef:
-            name: PROW_IMPLICIT_GIT_REF
+    spec:
+      containers:
+      - image: alpine/helm:3.1.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - lint
+        - ./helm/pipeline
   tektoncd/operator:
   - name: pull-tekton-operator-build-tests
     agent: kubernetes


### PR DESCRIPTION
Use kubernetes agent instead of pipeline.

This is related to tektoncd/experimental#494