### PR TITLE
Add the resource and docs to drive dogfooding from robocat

### DIFF
--- a/tekton/resources/cd/clusters.yaml
+++ b/tekton/resources/cd/clusters.yaml
@@ -90,3 +90,23 @@ spec:
     secretKey: ca.crt
     secretName: robocat-tektoncd-cadmin-token
   type: cluster
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: dogfooding-tekton-deployer
+  namespace: default
+spec:
+  params:
+  - name: url
+    value: https://35.222.251.168
+  - name: username
+    value: tekton-deployer
+  secrets:
+  - fieldName: token
+    secretKey: token
+    secretName: dogfooding-tekton-deployer-token
+  - fieldName: cadata
+    secretKey: ca.crt
+    secretName: dogfooding-tekton-deployer-token
+  type: cluster


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It may be useful to drive deployments on the dogfooding cluster
from robocat, since both recent updates on pipelines and
triggers require deleting resources.

Adding the pipeline resource and docs required to do that.# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._