### PR TITLE
Fix pull-tekton-experimental-helm-lint

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -462,6 +462,7 @@ presubmits:
       - image: alpine/helm:3.1.2
         imagePullPolicy: IfNotPresent
         args:
+        - helm
         - lint
         - ./helm/pipeline
   tektoncd/operator:


### PR DESCRIPTION
Added missing entrypoint.

It should be ok now, sorry for the inconvenience, it's not easy to get the job definition right first try.