### PR TITLE
Fix test-runner image: use python2 for bootstrap

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -35,6 +35,10 @@ RUN apt update && apt install -y --no-install-recommends \
     openssh-client \
     pkg-config \
     procps \
+    python \
+    python-dev \
+    python-openssl \
+    python-pip \
     python3 \
     python3-dev \
     python3-openssl \

--- a/tekton/images/test-runner/entrypoint.sh
+++ b/tekton/images/test-runner/entrypoint.sh
@@ -22,7 +22,7 @@ git clone https://github.com/kubernetes/test-infra
 
 # actually start bootstrap and the job, under the runner (which handles dind etc.)
 /usr/local/bin/runner.sh \
-    ./test-infra/jenkins/bootstrap.py \
+    python2 ./test-infra/jenkins/bootstrap.py \
         --job="${JOB_NAME}" \
         --service-account="${GOOGLE_APPLICATION_CREDENTIALS}" \
         --upload='gs://kubernetes-jenkins/logs' \


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The k8s/test-infra bootstrap python script doesn't work on Python 3,
so let's force it to use Python 2.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._