### PR TITLE
Update tkn Image to v0.8.0

### DIFF
--- a/tekton/images/tkn/Dockerfile
+++ b/tekton/images/tkn/Dockerfile
@@ -14,6 +14,6 @@
 FROM alpine:3.10
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
-ARG TKN_VERSION=0.7.1
+ARG TKN_VERSION=0.8.0
 
 RUN wget -O- https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz | tar zxf - -C /usr/local/bin


### PR DESCRIPTION
Not sure if this image is used in any capacity like the [test runner image](https://github.com/tektoncd/plumbing/blob/f2cb918059f532b0a2ef97370fc237774bbf9161/tekton/images/test-runner/Dockerfile#L207), but wanted to keep it up to date with the latest version of `tkn`.

# Submitter Checklist

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)