### PR TITLE
Remove buildbot Dockerfile 🤖

### DIFF
--- a/buildbot/Dockerfile
+++ b/buildbot/Dockerfile
@@ -1,5 +1,0 @@
-FROM golang:1.13.1-alpine3.10
-WORKDIR /go/src/buildbot
-COPY . .
-RUN go build -o ./buildbot ./cmd/buildbot
-CMD ["./buildbot"]


### PR DESCRIPTION
# Changes

The README directs us to use ko to build and deploy the buildbot,
doesn't seem like we need this dockerfile anymore (maybe!)

Unless there's a reason we still need it @vdemeester ?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._