### PR TITLE
Add Task and Triggers for deploying buildbot

### DIFF
--- a/buildbot/tekton/deploy.yaml
+++ b/buildbot/tekton/deploy.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildbot-deploy
+spec:
+  resources:
+    inputs:
+    - name: source
+      type: git
+      targetPath: go/src/github.com/tektoncd/plumbing
+  params:
+  - name: imageRegistry
+    default: "gcr.io/dibyo-spinnaker-dev/pipeline"
+  steps:
+  - name: buildbot-build-push-deploy
+    image: gcr.io/tekton-nightly/ko-ci
+    env:
+    - name: KO_DOCKER_REPO
+      value: $(params.imageRegistry)
+    - name: GOPATH
+      value: /workspace/go
+    - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+      value: /secret/release.json
+    script: |
+      #!/bin/sh
+      set -ex
+      gcloud auth configure-docker
+
+      cd /workspace/go/src/github.com/tektoncd/plumbing/buildbot
+      ko apply -f config/
+    volumeMounts:
+      - name: gcp-secret
+        mountPath: /secret
+  volumes:
+    - name: gcp-secret
+      secret:
+        secretName: gcp-secret

--- a/buildbot/tekton/resource.yaml
+++ b/buildbot/tekton/resource.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: tekton-plumbing-git
+spec:
+  type: git
+  params:
+  - name: url
+    value: https://github.com/tektoncd/plumbing
+  - name: revision
+    value: master  # REPLACE with the commit you want to release
+


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Current State:
* Task that runs `ko apply` 

TODO:
- [ ] Use workspaces instead of volumes for GCP secret or use Workload Identity
- [ ] Add a CronJob Trigger that runs the above task every day
- [ ] Document the Secret/ServiceAccount roles/permissions

Maybe TODO:
- [ ] Use Workspace/git clone task instead of PipelineResource


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._