### PR TITLE
Add missing charts to be linted

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -535,7 +535,9 @@ presubmits:
         args:
         - helm
         - lint
+        - ./helm/dashboard
         - ./helm/pipeline
+        - ./helm/triggers
   tektoncd/operator:
   - name: pull-tekton-operator-build-tests
     agent: kubernetes


### PR DESCRIPTION
This PR adds dashboard and triggers charts to the linter job.

Related issue: #306 

~~Do not merge before https://github.com/tektoncd/experimental/pull/513 is merged~~