### PR TITLE
Switch to latest tag for post coverage jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1185,7 +1185,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:safe # we may want ours here
+      - image: gcr.io/knative-tests/test-infra/coverage:latest # we may want ours here
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1200,7 +1200,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:safe # we may want ours here
+      - image: gcr.io/knative-tests/test-infra/coverage:latest # we may want ours here
         imagePullPolicy: Always
         command:
         - "/coverage"


### PR DESCRIPTION
# Changes

The pipeline and triggers post submit go-coverage jobs were using
the `safe` tag which does not exist. This commit moves them back to
using the latest tag.(The CLI coverage job uses a non-latest tag and
is not affected).

Fixes #328

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._