### PR TITLE
Clone licenseclassifier in GOPATH to fix go-licenses

### DIFF
--- a/tekton/images/test-runner/entrypoint.sh
+++ b/tekton/images/test-runner/entrypoint.sh
@@ -17,5 +17,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Workaround for https://github.com/google/licenseclassifier/issues/20
+git clone https://github.com/google/licenseclassifier ${GOPATH}/src/github.com/google/licenseclassifier
+
 # actually start bootstrap and the job, under the runner (which handles dind etc.)
 /usr/local/bin/runner.sh "$@"


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This is a workaround, and should be fixed once
https://github.com/google/licenseclassifier/issues/20 is fixed.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._