### PR TITLE
Simpler list_changed_files 🍶

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -61,7 +61,7 @@ function pr_only_contains() {
 function list_changed_files() {
   local file="${WORK_DIR}/changed_files"
   if [[ ! -f ${file} ]]; then
-    githubhelper -list-changed-files > ${file}
+    git --no-pager diff --name-only ${PULL_BASE_SHA}..${PULL_SHA} > ${file}
   fi
   echo ${file}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Do not rely on `githubhelper` to list the changed files.
`githubhelper` is going to query the GitHub API for information that
is already present in the workspace, on the CI (with Prow, but it
would be even true without Prow).

Prow gives us `PULL_BASE_SHA` and `PULL_SHA`, which is all we need to
ask gently `git` for the modified files by the pull request, no need
to query the github api.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/hold
Validating on https://github.com/tektoncd/pipeline/pull/2487 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._