### PR TITLE
Fix pull-tekton-operator-unit-tests prow job 🕹

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -650,6 +650,8 @@ presubmits:
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
+        command:
+        - /usr/local/bin/entrypoint.sh
         args:
         - "--scenario=kubernetes_execute_bazel"
         - "--clean"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The command was missing for this job, and it is required with
`decorate: true`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @nikhil-thomas @chmouel 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._