### PR TITLE
Change ko:gcloud-latest image to ko-gcloud:latest

### DIFF
--- a/tekton/cronjobs/ko-gcloud-image-nightly-build-cron/cronjob.yaml
+++ b/tekton/cronjobs/ko-gcloud-image-nightly-build-cron/cronjob.yaml
@@ -19,6 +19,6 @@ spec:
             - name: GIT_REVISION
               value: master
             - name: TARGET_IMAGE
-              value: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+              value: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
             - name: CONTEXT_PATH
               value: tekton/images/ko-gcloud

--- a/tekton/resources/release/install_tekton_release.yaml
+++ b/tekton/resources/release/install_tekton_release.yaml
@@ -43,7 +43,7 @@ spec:
   steps:
 
   - name: deploy-tekton-project
-    image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
     script: |
       #!/usr/bin/env bash
       set -exo pipefail


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Using the "gcloud-latest" tag breaks the default image pull policy,
we should use the "latest" tag instead.

Work towards #370 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._