### PR TITLE
Add docs on secrets in the clusters 🤫

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,29 @@
 
 This repo holds configuration for infrastructure used across the tektoncd org 🏗️:
 
-- Automation runs [in the tektoncd GCP projects](#gcp-projects), including clusters such as dogfooding and
-  [robocat](robocat/)
-- The script [addpermissions.py](addpermissions.py) gives users access to
-  [the GCP projects](#gcp-projects)
-- [Prow](prow/README.md) is used for
-  [pull request automation]((https://github.com/tektoncd/community/blob/master/process.md#reviews))
+- Automation runs [in the tektoncd GCP projects](clusters/README.md#gcp-projects), including
+  [clusters](#clusters)
 - [Tekton](tekton/README.md) is used to release projects, build docker images and run periodic jobs
 - [Ingress](prow/README.md#ingress) configuration for access via `tekton.dev`
 - [Gubernator](gubernator/README.md) is used for holding and displaying [Prow](prow/README.md) logs
 - [Boskos](boskos/README.md) is used to control a pool of GCP projects which end to end tests can run against
 - [Peribolos](tekton/resources/org-permissions/README.md) is used to control org and repo permissions
+
+## Support
+
+If you need support, reach out [in the tektoncd slack](https://github.com/tektoncd/community/blob/master/contact.md#slack)
+via the `#plumbing` channel.
+
+[Members of the Tekton governing board](goverance.md)
+[have access to the underlying resources](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access).
+
+## Clusters
+
+Tekton uses several kubernetes clusters:
+
+* [dogfooding](#the-dogfooding-cluster) which exists in [tekton-releases](#gcp-projects)
+* [robocat](robocat/) which exists in [tekton-nightly](#gcp-projects)
+* The cluster [prow](../prow) also exists in [tekton-releases](#gcp-projects)
 
 ## GCP projects
 
@@ -29,12 +41,60 @@ There are several GCP projects used by Tekton:
     [`dogfooding`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfooding?project=tekton-releases)
 - The GCP project
   [`tekton-nightly`](http://console.cloud.google.com/home/dashboard?project=tekton-nightly)
-  is used to hold nightly release artifacts and [the robocat cluster](robocat/)
+  is used to hold nightly release artifacts and [the robocat cluster](#the-robocat-cluster)
 
-## Support
+The script [addpermissions.py](addpermissions.py) gives users access to these projects.
 
-If you need support, reach out [in the tektoncd slack](https://github.com/tektoncd/community/blob/master/contact.md#slack)
-via the `#plumbing` channel.
+### The prow cluster
 
-[Members of the Tekton governing board](goverance.md)
-[have access to the underlying resources](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access).
+[The prow cluster](prow) is where we run Prow, which currently does a lot of our CI, though
+we are trying to [dogfood](#the-dogfooding-cluster) more and more.
+
+#### Prow secrets
+
+Secrets which have been applied to the prow cluster but are not committed here are:
+
+- `GitHub` secrets:
+ - `bot-token-github` in the default namespace
+ - `bot-token-github` in the github-admin namespace
+
+### The robocat cluster
+
+[The robocat cluster](robocat) is where we test the nightly releases of all Tekton projects.
+
+#### Robocat secrets
+
+Secrets which have been applied to the robocat cluster but are not committed here are:
+
+- [cluster admin secret](robocat/README.md#create-a-cluster-admin-service-account)
+- [secrets used by cronjobs](robocat/README.md#run-the-cronjobs)
+- [deployment secrets](robocat/README.md#set-up-robocat-to-drive-deployments-to-the-dogfooding-cluster)
+
+### The Dogfooding cluster
+
+The dogfooding cluster is where we run Tekton for CI. Configuration for the CI itself lives
+in [the tekton folder](tekton). This cluster is part of
+[the tekton-releases GCP project](#gcp-projects)
+
+#### Dogfooding Secrets
+
+Secrets which have been applied to the dogfooding cluster but are not committed here are:
+
+- `GitHub` secrets:
+  - In the default namespace:
+    - `bot-token-github` used for syncing label configuration and org configuration
+    - `github-token` used to create a draft release
+  - In the `tektonci` namespace:
+    - `bot-token-github` used for ?
+  - In the [mario](../../mariobot) namespace:
+    - `mario-github-secret` contains the secret used to verify requests are coming from github
+    - `mario-github-token` used for updating PRs
+- `GCP` secrets:
+  - `nightly-account` is used by nightly releases to push releases
+  to the nightly bucket. It's a token for service account
+  `release-right-meow@tekton-releases.iam.gserviceaccount.com`.
+  - `release-secret` is used by Tekton Pipeline to push pipeline artifacts to a
+    GCS bucket. It's also used to push images built by cron trigger (or [Mario](../../mariobot])
+    to the image registry on GCP.
+- Lots of other secrets, hopefully we can add more documentation on them
+  here as we go.

--- a/mariobot/README.md
+++ b/mariobot/README.md
@@ -86,3 +86,5 @@ spec:
 ## Configuring the GitHub secret
 
 The Mario Bot requires a GitHub Hook Secret in the environment variable `GITHUB_SECRET_TOKEN`.
+
+The bot uses [secrets in the dogfooding cluster](../README.md#dogfooding-secrets).

--- a/prow/README.md
+++ b/prow/README.md
@@ -2,7 +2,8 @@
 
 `tektoncd` uses
 [`Prow`](https://github.com/kubernetes/test-infra/tree/master/prow)
-for CI automation.
+for CI automation, though we are moving this over to
+[use our own dogfooding](../README.md#the-dogfooding-cluster).
 
 - Prow runs in [the tektoncd GCP project](../README.md#gcp-projects)
 - [Ingress is configured to `prow.tekton.dev`](#ingress)

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -4,6 +4,8 @@ This folder includes `Tasks`, `Pipelines` and other shared resources used to
 setup CI/CD pipelines for all repositories in the tektoncd org. It also
 includes `tektoncd/plumbing` specific tasks and pipelines.
 
+These resources are applied to [the dogfooding cluster](../README.md#the-dogfooding-cluster).
+
 Resources are organised in folders:
 - The [config](config/README.md) folder holds `CronJobs` definition for regular
   tasks, like building images, deploying configuration, nightly releases
@@ -15,14 +17,6 @@ Resources are organised in folders:
 - The [cd](cd/README.md) folder contains kustomize overlays, used to deploy the
   various Tekton projects to the infra clusters.
 
-# Secrets
+## Secrets
 
-Some of the resources require secrets to operate.
-- `GitHub` secrets: `bot-token-github` used for syncing label configuration and
-  org configuration requires, `github-token` used to create a draft release
-- `GCP` secrets: `nightly-account` is used by nightly releases to push releases
-  to the nightly bucket. It's a token for service account
-  `release-right-meow@tekton-releases.iam.gserviceaccount.com`.
-  `release-secret` is used by Tekton Pipeline to push pipeline artifacts to a
-  GCS bucket. It's also used to push images built by cron trigger (or Mario)
-  to the image registry on GCP.
+Some of the resources require [secrets](../README.md) to operate.


### PR DESCRIPTION
# Changes

I tried to update some of the secrets today but I had to guess which
ones were the right ones because our docs had fallen way behind what is
actually in the cluster. There are many many secrets in these clusters
and I don't know what they all do, but I tried to make a start at
writing some of them down.

I'd really like to have a "clusters" folder which has all the config
(e.g. robocat and prow dirs) and docs for the clusters we are using, but
I have a feeling moving these around will mean our configuration needs
to be updated and I didn't feel I could take that one on today.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._