### PR TITLE
Add support for multi-repo on the ci webhook

### DIFF
--- a/tekton/ci/checks/check-pr-has-kind-label.yaml
+++ b/tekton/ci/checks/check-pr-has-kind-label.yaml
@@ -146,7 +146,7 @@ spec:
             secrets:
             - fieldName: authToken
               secretName: bot-token-github
-              secretKey: oauth
+              secretKey: bot-token
         outputs:
         - name: pr
           resourceSpec:
@@ -157,7 +157,7 @@ spec:
             secrets:
             - fieldName: authToken
               secretName: bot-token-github
-              secretKey: oauth
+              secretKey: bot-token
       params:
       - name: labels
         value: $(params.labels)

--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -18,14 +18,15 @@ spec:
               - pull_request
         - cel:
             filter: >-
-              body.action == 'opened' || body.action == 'synchronize'
+              body.repository.full_name == 'tektoncd/plumbing' &&
+              (body.action == 'opened' || body.action == 'synchronize')
             overlays:
             - key: extensions.git_clone_depth
               expression: "string(body.pull_request.commits + 1.0)"
       bindings:
         - name: tekton-ci-webhook-pull-request
       template:
-        name: tekton-ci-pipeline
+        name: tekton-plumbing-ci-pipeline
     - name: comment-trigger
       interceptors:
         - github:
@@ -36,6 +37,7 @@ spec:
               - issue_comment
         - cel:
             filter: >-
+              body.repository.full_name == 'tektoncd/plumbing' &&
               body.action == 'created' &&
               'pull_request' in body.issue &&
               body.issue.state == 'open' &&
@@ -56,7 +58,7 @@ spec:
       bindings:
         - name: tekton-ci-webhook-comment
       template:
-        name: tekton-ci-pipeline
+        name: tekton-plumbing-ci-pipeline
     - name: trigger-check-pr-labels
       interceptors:
         - github:
@@ -67,6 +69,8 @@ spec:
               - pull_request
         - cel:
             filter: >-
+              body.repository.full_name.startsWith('tektoncd/') &&
+              body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'catalog', 'hub'] &&
               (body.action == 'opened' ||
                body.action == 'labeled' ||
                body.action == 'unlabeled')

--- a/tekton/ci/plumbing-template.yaml
+++ b/tekton/ci/plumbing-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-ci-pipeline
+  name: tekton-plumbing-ci-pipeline
   namespace: tektonci
 spec:
   params:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Change the CI pipeline name for plumbing to "tekton-plumbing-ci-pipeline"
Added CEL filters to ensure we only run the plumbing pipeline on
changes to the plumbing repo.
Make it possible for several repos to use the kind label check.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._