### PR TITLE
test-runner: remove githubhelper binary

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -25,7 +25,6 @@ RUN cd /go/src/k8s.io/test-infra && \
 # Build knative-tools independently of the rest
 FROM golang:1.14 as knative-tools
 RUN git clone https://github.com/knative/test-infra.git /go/src/knative.dev/test-infra
-RUN make -C /go/src/knative.dev/test-infra/tools/githubhelper
 RUN go install knative.dev/test-infra/tools/dep-collector
 
 FROM debian:buster
@@ -188,8 +187,8 @@ RUN gem install mdl -v 0.5.0
 RUN python -m pip install yamllint
 
 COPY --from=knative-tools /go/bin/dep-collector /usr/local/bin
-COPY --from=knative-tools /go/src/knative.dev/test-infra/tools/githubhelper/githubhelper /usr/local/bin
 COPY --from=kubetest /go/bin/kubetest /usr/local/bin
+
 # note the runner is also responsible for making docker in docker function if
 # env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating
 COPY ["entrypoint.sh", "runner.sh", "/usr/local/bin/"]


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The tool is not used anymore and is deprecated upstream (knative.dev)

Fixes #391

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._