### PR TITLE
Add golang lint CI Job

### DIFF
--- a/tekton/ci/jobs.yaml
+++ b/tekton/ci/jobs.yaml
@@ -69,6 +69,55 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
+  name: golang-lint
+  namespace: tektonci
+  description: |
+    Lint golang source using golangci-lint
+spec:
+  params:
+  - name: version
+    description: golangci-lint version to use
+    default: "v1.26.0"
+  - name: flags
+    description: flags to use for the golangci-lint run command
+    default: --verbose
+  - name: GOOS
+    description: "running operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  resources:
+    inputs:
+      - name: source
+        type: git
+    outputs:
+      - name: endtrigger
+        type: cloudEvent
+  steps:
+  - name: lint
+    image: golangci/golangci-lint:$(params.version)
+    script: |
+      #!/bin/sh
+      set -ex
+      cd /workspace/source/
+      golangci-lint run $(params.flags)
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
   name: yamllint
   namespace: tektonci
   description: |

--- a/tekton/ci/plumbing-template.yaml
+++ b/tekton/ci/plumbing-template.yaml
@@ -474,3 +474,46 @@ spec:
       - name: endtrigger
         resourceRef:
           name: github-check-done
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: tekton-golang-lint-$(uid)
+      labels:
+        prow.k8s.io/build-id: $(params.buildUUID)
+        tekton.dev/check-name: plumbing-golang-lint
+        tekton.dev/kind: ci
+        tekton.dev/pr-number: $(params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitURL: "$(params.gitRepository)"
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      pipelineRef:
+        name: tekton-golang-lint
+      params:
+        - name: pullRequestNumber
+          value: $(params.pullRequestNumber)
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+        - name: fileFilterRegex
+          value: ".*"
+        - name: checkName
+          value: plumbing-images-build
+        - name: gitHubCommand
+          value: $(params.gitHubCommand)
+      resources:
+      - name: source
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(params.gitRevision)
+          - name: url
+            value: $(params.gitRepository)
+          - name: depth
+            value: $(params.gitCloneDepth)
+      - name: starttrigger
+        resourceRef:
+          name: github-check-start
+      - name: endtrigger
+        resourceRef:
+          name: github-check-done

--- a/tekton/ci/tekton-golang-lint.yaml
+++ b/tekton/ci/tekton-golang-lint.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tekton-golang-lint
+  namespace: tektonci
+spec:
+  params:
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: fileFilterRegex
+      description: Names regex to be matched in the list of modified files
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+  resources:
+    - name: source
+      type: git
+    - name: starttrigger
+      type: cloudEvent
+    - name: endtrigger
+      type: cloudEvent
+  tasks:
+  - name: check-reset
+    taskRef:
+      name: tekton-ci-reset-check-status
+    params:
+    - name: checkName
+      value: $(params.checkName)
+    resources:
+      outputs:
+      - name: trigger
+        resource: starttrigger
+    conditions:
+    - conditionRef: "check-git-files-changed"
+      params:
+      - name: gitCloneDepth
+        value: $(params.gitCloneDepth)
+      - name: regex
+        value: $(params.fileFilterRegex)
+      resources:
+      - name: source
+        resource: source
+    - conditionRef: "check-name-matches"
+      params:
+      - name: gitHubCommand
+        value: $(params.gitHubCommand)
+      - name: checkName
+        value: $(params.checkName)
+  - name: lint
+    runAfter: [check-reset]
+    taskRef:
+      name: golang-lint
+    resources:
+      inputs:
+      - name: source
+        resource: source
+      outputs:
+      - name: endtrigger
+        resource: endtrigger


### PR DESCRIPTION
Closes #378 

Adding a golang lint CI job to be run against the plumbing repository. Follows a very similar structure to #336 and makes use of `golangci-lint` image. 

# Submitter Checklist

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
