### PR TITLE
Add a Dockerfile that adds a non-root user to alpine/git base

### DIFF
--- a/tekton/ci/plumbing-template.yaml
+++ b/tekton/ci/plumbing-template.yaml
@@ -517,3 +517,48 @@ spec:
       - name: endtrigger
         resourceRef:
           name: github-check-done
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: plumbing-alpine-git-nonroot-build-$(uid)
+      labels:
+        prow.k8s.io/build-id: $(params.buildUUID)
+        tekton.dev/check-name: plumbing-alpine-git-nonroot-build
+        tekton.dev/kind: ci
+        tekton.dev/pr-number: $(params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitURL: "$(params.gitRepository)"
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      pipelineRef:
+        name: tekton-image-build
+      params:
+        - name: imageName
+          value: alpine-git-nonroot
+        - name: pullRequestNumber
+          value: $(params.pullRequestNumber)
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+        - name: fileFilterRegex
+          value: "tekton/images/alpine-git-nonroot/**"
+        - name: checkName
+          value: plumbing-alpine-git-nonroot-build
+        - name: gitHubCommand
+          value: $(params.gitHubCommand)
+      resources:
+      - name: source
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(params.gitRevision)
+          - name: url
+            value: $(params.gitRepository)
+          - name: depth
+            value: $(params.gitCloneDepth)
+      - name: starttrigger
+        resourceRef:
+          name: github-check-start
+      - name: endtrigger
+        resourceRef:
+          name: github-check-done

--- a/tekton/cronjobs/alpine-git-nonroot-image-nightly-build-cron/README.md
+++ b/tekton/cronjobs/alpine-git-nonroot-image-nightly-build-cron/README.md
@@ -1,0 +1,3 @@
+Cron Job to build an alpine container image with `git` installed and a
+non-root user set up.
+The image is published daily to [gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest](gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest).

--- a/tekton/cronjobs/alpine-git-nonroot-image-nightly-build-cron/cronjob.yaml
+++ b/tekton/cronjobs/alpine-git-nonroot-image-nightly-build-cron/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-build-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: el-image-builder.default.svc.cluster.local:8080
+            - name: GIT_REPOSITORY
+              value: github.com/tektoncd/plumbing
+            - name: GIT_REVISION
+              value: master
+            - name: TARGET_IMAGE
+              value: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
+            - name: CONTEXT_PATH
+              value: tekton/images/alpine-git-nonroot

--- a/tekton/cronjobs/alpine-git-nonroot-image-nightly-build-cron/kustomization.yaml
+++ b/tekton/cronjobs/alpine-git-nonroot-image-nightly-build-cron/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../nightly-image-build-cron-base
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-alpine-git-nonroot"

--- a/tekton/images/alpine-git-nonroot/Dockerfile
+++ b/tekton/images/alpine-git-nonroot/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM alpine/git:v2.24.3
+LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+
+RUN adduser -D nonroot -u 1000
+USER nonroot


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In order to test Pipelines credentials in environments without
root users (i.e. in openshift clusters, or other more locked-down
envs) we need a container image that has a non-root user along
with a tool to exercise the credentials.

This commit adds an alpine-git-nonroot image to our plumbing repo
for use in testing credentials in non-root environments. It uses
alpine/git as its base and then adds a user called nonroot with
UID 1000 to it. This image's first intended use is as a Step in
an example TaskRun that will test creds-init credentials with
non-root securityContext. That PR is ongoing here:
https://github.com/tektoncd/pipeline/pull/2671




# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)