### PR TITLE
Fixes to draft release docs 📝

### DIFF
--- a/tekton/resources/release/README.md
+++ b/tekton/resources/release/README.md
@@ -35,10 +35,10 @@ is expected to be at `<bucket>/<projectName>/previous/<version>/release.yaml`
 An example using `tkn`:
 
 ```
-TEKTON_BUCKET_RESOURCE=tekton-bucket
-TEKTON_CLUSTER_RESOURCE=k8s-cluster
-TEKTON_PROJECT=pipeline
-TEKTON_VERSION=v0.9.0
+export TEKTON_BUCKET_RESOURCE=tekton-bucket
+export TEKTON_CLUSTER_RESOURCE=k8s-cluster
+export TEKTON_PROJECT=pipeline
+export TEKTON_VERSION=v0.9.0
 
 tkn task start \
   -i release-bucket=$TEKTON_BUCKET_RESOURCE \
@@ -55,10 +55,10 @@ also contain a `pre` folder. Any `*.sh` script found in the folder will be
 executed before the release is installed.
 
 ```
-TEKTON_BUCKET_RESOURCE=tekton-bucket
-TEKTON_CLUSTER_RESOURCE=k8s-cluster
-TEKTON_PROJECT=pipeline
-TEKTON_VERSION=v0.9.0
+export TEKTON_BUCKET_RESOURCE=tekton-bucket
+export TEKTON_CLUSTER_RESOURCE=k8s-cluster
+export TEKTON_PROJECT=pipeline
+export TEKTON_VERSION=v0.9.0
 
 tkn task start \
   -i release-bucket=$TEKTON_BUCKET_RESOURCE \
@@ -86,10 +86,10 @@ needed both as input and output of the task.
 An example using `tkn`:
 
 ```
-TEKTON_BUCKET_RESOURCE=tekton-bucket-nightly-4csms
-TEKTON_PIPELINERUN=pipeline-release-nightly-zrgdp-6n44c
-TEKTON_VERSION=v20191203-883dd4d5df
-TEKTON_NAMESPACE=default
+export TEKTON_BUCKET_RESOURCE=tekton-bucket-nightly-4csms
+export TEKTON_PIPELINERUN=pipeline-release-nightly-zrgdp-6n44c
+export TEKTON_VERSION=v20191203-883dd4d5df
+export TEKTON_NAMESPACE=default
 
 tkn task start \
   -i release-bucket=$TEKTON_BUCKET_RESOURCE \
@@ -148,12 +148,12 @@ release.
 An example using `tkn`:
 
 ```
-TEKTON_RELEASE_GIT_RESOURCE=pipeline-git-v0-9-0
-TEKTON_BUCKET_RESOURCE=tekton-bucket
-TEKTON_PACKAGE=tektoncd/pipeline
-TEKTON_VERSION=v0.9.0
-TEKTON_OLD_VERSION=v0.8.0
-TEKTON_RELEASE_NAME="Bengal Bender"
+export TEKTON_RELEASE_GIT_RESOURCE=pipeline-git-v0-9-0
+export TEKTON_BUCKET_RESOURCE=pipeline-tekton-bucket
+export TEKTON_PACKAGE=tektoncd/pipeline
+export TEKTON_VERSION=v0.9.0
+export TEKTON_OLD_VERSION=v0.8.0
+export TEKTON_RELEASE_NAME="Bengal Bender"
 
 tkn task start \
   -i source=$TEKTON_RELEASE_GIT_RESOURCE \
@@ -167,20 +167,21 @@ tkn task start \
 
 The bucket resource:
 ```
-$ tkn resource describe tekton-bucket-nightly-4csms
-Name:                    tekton-bucket-nightly-4csms
+$ tkn resource describe pipeline-tekton-bucket
+Name:                    pipeline-tekton-bucket
 Namespace:               default
 PipelineResource Type:   storage
 
 Params
-NAME       VALUE
-type       gcs
-location   gs://tekton-release-nightly/pipeline/
-dir        y
+
+ NAME         VALUE
+ ∙ type       gcs
+ ∙ location   gs://tekton-releases/pipeline
+ ∙ dir        y
 
 Secret Params
-FIELDNAME                        SECRETNAME
-GOOGLE_APPLICATION_CREDENTIALS   xyz
+
+ No secret params
 ```
 
 


### PR DESCRIPTION
# Changes

Updated the env var lists to include `export` so you can copy paste the
commands into your terminal if you want.

Also while using the draft release task I looked at previous runs and it
looks like the bucket being used previously was actually the pipelines
specific bucket, the one in the example was at the root of the bucket
and so I panicked when I ran it initially and saw the dashboard bucket
being affected in the logs.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._