### PR TITLE
Use lowercase project name in installation one-liner 🎣

### DIFF
--- a/tekton/resources/release/github_release.yaml
+++ b/tekton/resources/release/github_release.yaml
@@ -50,11 +50,10 @@ spec:
       script: |
         #!/bin/bash
         set -ex
-        p=$(basename $PROJECT)
-        TEKTON_PROJECT=${p^}
+        TEKTON_PROJECT=$(basename $PROJECT)
 
         cat <<EOF | tee $HOME/release.md
-        Tekton $TEKTON_PROJECT release ${VERSION} "$(params.release-name)"
+        Tekton ${TEKTON_PROJECT^} release ${VERSION} "$(params.release-name)"
 
         # 🎉 [Tag Line - to be done] 🎉
 


### PR DESCRIPTION
# Changes

In tektoncd/pipeline#2786 @ckadner pointed out that the one liner installation line
didn't work because "Pipeline" was capitalized in the path (kind of
surprising that the path is case-sensitive but that's another story!)
It seems that `TEKTON_PROJECT=${p^}` is a bash 5.0 syntax that
capitalizes the word and in the one liner we are using that value, so
instead we will use the uncapitalized value and only captialize in the
spot where we need it.

Closes tektoncd/pipeline#2786

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._