### PR TITLE
Set correct git and hub versions

### DIFF
--- a/tekton/images/hub/Dockerfile
+++ b/tekton/images/hub/Dockerfile
@@ -14,9 +14,10 @@
 FROM alpine:3.11
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
-ARG HUB_VERSION=2.14.2
+ARG HUB_VERSION=2.14.2-r1
+ARG HUB_RELEASE=r1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk add --no-cache \
-    git=2.24.2-r0 \
+    git=2.24.3-r0 \
     bash=5.0.11-r1 \
-    hub=${HUB_VERSION}-r0
+    hub=${HUB_VERSION}


### PR DESCRIPTION
The only available versions in alpine 3.11 for git is 2.24.3-r0, and the only available hub package in the edge/testing repo is 2.14.2-r1.

Fixes #379.

Signed-off-by: Tom George <tg82490@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- install git 2.24.3-r0
- install hub 2.14.2-r1

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._