### PR TITLE
Add needs-rebase external plugins…

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -40,3 +40,10 @@ plugins:
   - verify-owners
   - wip
   - yuks
+
+external_plugins:
+  tektoncd:
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This should make any pull-request that need a rebase to be marked as
such — and block tide trying to merge it. And when they are rebased,
the label should go away.

/cc @afrittoli @AlanGreene @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._