### PR TITLE
Document usage of workload-id node pool in dogfooding

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,17 @@ Secrets which have been applied to the dogfooding cluster but are not committed 
     to the image registry on GCP.
 - Lots of other secrets, hopefully we can add more documentation on them
   here as we go.
+
+#### Dogfooding Node Pools
+
+Dogfooding is comprised of two node pools. One is used for workloads that operate with Workload Identity,
+a feature of GKE which maps Kubernetes Service Accounts to Google Cloud IAM Service Accounts. The other
+is used for workloads that don't use Workload Identity and rely instead on mechanisms like mounted Secrets
+or that run unauthenticated. Choosing the correct pool for a workload should really only depend on whether
+it utilizes the Workload Identity feature or not.
+
+- `default-pool` is used for most workloads. It doesn't have the GKE Metadata Server enabled
+and therefore doesn't support workloads running with Workload Identity.
+- `workload-id` has the GKE Metadata Server enabled and is used for workloads operating with
+Workload Identity. The only workload that currently requires Workload Identity is "pipelinerun-logs"
+which shows Stackdriver log entries for PipelineRuns.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A while ago I added a workload-id node pool to support the pipelinerun-logs
app for watching stackdriver logs of pipelineruns.

This PR adds a few lines of documentation explaining the difference between
the default and workload-id node pools.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)