### PR TITLE
Change the kustomise setup to use bindings ref

### DIFF
--- a/tekton/resources/nightly-release/base/eventlistener.yaml
+++ b/tekton/resources/nightly-release/base/eventlistener.yaml
@@ -7,6 +7,6 @@ spec:
   triggers:
     - name: cron-trigger
       bindings:
-        - name: binding
+        - ref: binding
       template:
         name: template

--- a/tekton/resources/nightly-release/base/kustomizeconfig/eventlistener.yaml
+++ b/tekton/resources/nightly-release/base/kustomizeconfig/eventlistener.yaml
@@ -2,7 +2,7 @@
 nameReference:
 - kind: TriggerBinding
   fieldSpecs:
-  - path: spec/triggers/bindings/name
+  - path: spec/triggers/bindings/ref
     kind: EventListener
 - kind: TriggerTemplate
   fieldSpecs:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Triggers v5 changed bindings.name to bindings.ref, which breaks the
kustomise configuration. Fixing that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._