### PR TITLE
Update golangci-lint CI Job Version to 1.27.0

### DIFF
--- a/tekton/ci/jobs.yaml
+++ b/tekton/ci/jobs.yaml
@@ -77,7 +77,7 @@ spec:
   params:
   - name: version
     description: golangci-lint version to use
-    default: "v1.26.0"
+    default: "v1.27.0"
   - name: flags
     description: flags to use for the golangci-lint run command
     default: --verbose


### PR DESCRIPTION
The pull request updates the golang-lint CI job running against the plumbing repo to using golangci-lint version 1.27.0. This is motivated by #430 to keep the golang-lint experience consistent across projects.

# Submitter Checklist

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
