### PR TITLE
prow: disable go-coverage jobs on tektoncd/hub

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -798,36 +798,6 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
-  - name: pull-tekton-hub-go-coverage
-    agent: kubernetes
-    always_run: true
-    decorate: true
-    rerun_command: "/test pull-tekton-hub-go-coverage"
-    trigger: "(?m)^/test (all|pull-tekton-hub-go-coverage),?(\\s+|$)"
-    optional: true
-    clone_uri: "https://github.com/tektoncd/hub.git"
-    spec:
-      containers:
-      - image: gcr.io/knative-tests/test-infra/coverage:latest
-        imagePullPolicy: Always
-        command:
-        - "/coverage"
-        args:
-        - "--postsubmit-gcs-bucket=tekton-prow"
-        - "--postsubmit-job-name=post-tekton-hub-go-coverage"
-        - "--artifacts=$(ARTIFACTS)"
-        - "--profile-name=coverage_profile.txt"
-        - "--cov-target=."
-        - "--cov-threshold-percentage=0"
-        - "--github-token=/etc/github-token/oauth"
-        volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
-          readOnly: true
-      volumes:
-      - name: github-token
-        secret:
-          secretName: oauth-token
   tektoncd/operator:
   - name: pull-tekton-operator-build-tests
     agent: kubernetes


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The coverage tool doesn't handle very well when the go code is not on
the root of the repository, so disabling it on the hub. This is temporary.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sthaha @afrittoli @bobcatfish @chmouel @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._