### PR TITLE
Automatically delete old pr and tr on dogfooding

### DIFF
--- a/tekton/cronjobs/cleanup-cd-cron-base/README.md
+++ b/tekton/cronjobs/cleanup-cd-cron-base/README.md
@@ -1,0 +1,1 @@
+Cron Job template to cleanup runs from a cluster.

--- a/tekton/cronjobs/cleanup-cd-cron-base/kustomization.yaml
+++ b/tekton/cronjobs/cleanup-cd-cron-base/kustomization.yaml
@@ -1,0 +1,17 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+commonLabels:
+  app: tekton.plumbing
+resources:
+- trigger-resource-cd.yaml

--- a/tekton/cronjobs/cleanup-cd-cron-base/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/cleanup-cd-cron-base/trigger-resource-cd.yaml
@@ -1,0 +1,62 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+spec:
+  schedule: "12 * * * *" # Houly at *:12
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: workspace
+            emptyDir: {}
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            command:
+              - /bin/sh
+            args:
+              - -ce
+              - |
+                cat <<EOF > /workspace/post-body.json
+                {
+                  "trigger-template": "cleanup",
+                  "params": {
+                    "target": {
+                      "namespace": "$NAMESPACE",
+                      "cluster-resource": "$CLUSTER_RESOURCE"
+                    },
+                    "cleanup": {
+                        "keep": "$CLEANUP_KEEP"
+                    }
+                  }
+                }
+                EOF
+                curl -d @/workspace/post-body.json $SINK_URL
+            volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            env:
+              - name: SINK_URL
+                value: "http://el-tekton-cd.default.svc.cluster.local:8080"
+              - name: NAMESPACE
+                value: "default"
+              - name: CLUSTER_RESOURCE
+                value: "not-a-real-cluster"
+              - name: CLEANUP_KEEP
+                value: "200"
+          restartPolicy: Never

--- a/tekton/cronjobs/dogfooding-cleanup-default-cron/README.md
+++ b/tekton/cronjobs/dogfooding-cleanup-default-cron/README.md
@@ -1,0 +1,1 @@
+Cron Job to daily cleanup pr/tr from the default namespace in the dogfooding cluster

--- a/tekton/cronjobs/dogfooding-cleanup-default-cron/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding-cleanup-default-cron/cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+spec:
+  schedule: "0 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: NAMESPACE
+                value: "default"
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tektoncd-cleaner"
+              - name: CLEANUP_KEEP
+                value: "200"

--- a/tekton/cronjobs/dogfooding-cleanup-default-cron/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding-cleanup-default-cron/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../cleanup-cd-cron-base
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-default"

--- a/tekton/cronjobs/dogfooding-cleanup-tektonci-cron/README.md
+++ b/tekton/cronjobs/dogfooding-cleanup-tektonci-cron/README.md
@@ -1,0 +1,1 @@
+Cron Job to daily cleanup pr/tr from the default namespace in the dogfooding cluster

--- a/tekton/cronjobs/dogfooding-cleanup-tektonci-cron/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding-cleanup-tektonci-cron/cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+spec:
+  schedule: "0 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: NAMESPACE
+                value: "tektonci"
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tektoncd-cleaner"
+              - name: CLEANUP_KEEP
+                value: "200"

--- a/tekton/cronjobs/dogfooding-cleanup-tektonci-cron/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding-cleanup-tektonci-cron/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../cleanup-cd-cron-base
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-tektonci"

--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -111,3 +111,12 @@ spec:
     value: $(body.params.plumbing.repository)
   - name: plumbingRevision
     value: $(body.params.plumbing.revision)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: cleanup-details
+spec:
+  params:
+  - name: keep
+    value: $(body.params.cleanup.keep)

--- a/tekton/resources/cd/cleanup-template.yaml
+++ b/tekton/resources/cd/cleanup-template.yaml
@@ -1,0 +1,72 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: cleanup-runs
+spec:
+  params:
+  - name: namespace
+    description: Namespace to cleanup to in the target cluster
+  - name: clusterResource
+    description: Name of the cluster resource that points to the target cluster
+  - name: keep
+    description: Amount of old resources to keep
+    default: "200"
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: cleanup-runs-$(params.clusterResource)-$(params.namespace)-$(uid)
+    spec:
+      taskSpec:
+        params:
+        - name: keep
+        - name: namespace
+        resources:
+          inputs:
+            - name: targetCluster
+              type: cluster
+        stepTemplate:
+          env:
+          - name: KUBECONFIG
+            value: /workspace/$(resources.inputs.targetCluster.name)/kubeconfig
+        steps:
+        - name: cleanup-pr-tr
+          image: gcr.io/tekton-releases/dogfooding/tkn
+          script: |
+            #!/bin/sh
+            set -ex
+
+            # A safety check, to avoid deleting too much!
+            if [[ $(params.keep) -eq 0 || $(params.keep) == "" ]]; then
+              echo "This task cannot be used to delete *all* resources from a cluster" >&2
+              echo "Please specifcy a value for keep > 0"
+              exit 1
+            fi
+
+            # Cleanup pipelineruns first, as this will delete tasksruns too
+            tkn pr delete -n $(params.namespace) --all --keep $(params.keep)
+            # Keep double the amount of tr, for standalone trs
+            tkn tr delete -n $(params.namespace) --all --keep $(( $(params.keep) * 2 ))
+      params:
+      - name: keep
+        value: $(params.keep)
+      - name: namespace
+        value: $(params.namespace)
+      resources:
+        inputs:
+          - name: targetCluster
+            resourceRef:
+              name: $(params.clusterResource)

--- a/tekton/resources/cd/clusters.yaml
+++ b/tekton/resources/cd/clusters.yaml
@@ -130,3 +130,23 @@ spec:
     secretKey: ca.crt
     secretName: dogfooding-tektonci-default-token
   type: cluster
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: dogfooding-tektoncd-cleaner
+  namespace: default
+spec:
+  params:
+  - name: url
+    value: https://35.222.251.168
+  - name: username
+    value: tekton-cleaner
+  secrets:
+  - fieldName: token
+    secretKey: token
+    secretName: dogfooding-tekton-cleaner-token
+  - fieldName: cadata
+    secretKey: ca.crt
+    secretName: dogfooding-tekton-cleaner-token
+  type: cluster

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -65,3 +65,14 @@ spec:
         - ref: plumbing-git
       template:
         name: deploy-tekton-release
+    - name: cleanup
+      interceptors:
+        - cel:
+            filter: >-
+              'trigger-template' in body &&
+              body['trigger-template'] == 'cleanup'
+      bindings:
+        - ref: deploy-target-details
+        - ref: cleanup-details
+      template:
+        name: cleanup-runs

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -42,3 +42,49 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: trigger
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-cleaner
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-pr-tr
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "taskruns"]
+  verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-default
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-tektonci
+  namespace: tektonci
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
 - cd/helm-template.yaml
 - cd/tekton-template.yaml
 - cd/serviceaccount.yaml
+- cd/cleanup-template.yaml
 - org-permissions/peribolos.yaml
 - org-permissions/peribolos-trigger.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Add a new trigger to the tekoncd event listener, for cleanup.
The triggers runs tkn pr|tr delete --all with a --keep param,
to keep the latest N runs.

Add a cluster role and a service account bound to it in the
default and tektonci namespaces. The cluster role gives
permission to list and delete prs and trs.

Add a cluster resource that uses the new service account.
This is used by the cleanup task to direct tkn to the
dogfooding cluster.

Add a new cronjob base for cleanup jobs, and a two jobs
based out of it, to cleanup in the default and tektonci
namespaces on the dogfooding cluster,

Once this is in place, it will be easy to add more cronjobs
to cleanup other namespaces / clusters if needed.
It will also be possiblo iterate on the cleanup task adding
more features and nobs to it.

The secret used by the pipeline resources must be created
manually once this is provisioned for it to work.

Fixes #439

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature