### PR TITLE
prow: add postgres sidecar and remove dind for hub

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -701,6 +701,16 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
+      - image: postgres:latest
+        command: ["docker-entrypoint.sh"]
+        args: ["postgres"]
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_DB
+          value: hub
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
         command:
@@ -722,8 +732,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -742,6 +750,16 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
+      - image: postgres:latest
+        command: ["docker-entrypoint.sh"]
+        args: ["postgres"]
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_DB
+          value: hub
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
         command:
@@ -763,8 +781,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -781,6 +797,16 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
+      - image: postgres:latest
+        command: ["docker-entrypoint.sh"]
+        args: ["postgres"]
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        - name: POSTGRES_DB
+          value: hub
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
         command:
@@ -802,8 +828,6 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION


### PR DESCRIPTION
This would start a container in the pod with postgres for the hub
testing need, and thus removing the requirement to depend on docker.

Let's get #451 in to unblock current tektoncd/hub PRs, and do that after :upside_down_face: 

/cc @sthaha @nikhil-thomas @afrittoli 
/hold

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._