### PR TITLE
Don't send daily ping if there is no buildcop

### DIFF
--- a/buildbot/cmd/buildbot/main.go
+++ b/buildbot/cmd/buildbot/main.go
@@ -146,7 +146,10 @@ func dailyPing(rtm *slack.RTM, copsID map[string]string, r Rotation) {
 	for {
 		<-jt.t.C
 		currentCop = copsID[r.GetBuildCop(time.Now())]
-		rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("Hello :wave: today's <@%s> is the buildcop :cop:\nBuildcop log is here: https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk", currentCop), channelID))
+		if currentCop != "" {
+			// Only send the daily ping if there is actually a buildcop.
+			rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("Hello :wave: today's <@%s> is the buildcop :cop:\nBuildcop log is here: https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk", currentCop), channelID))
+		}
 		jt.updateJobTicker()
 	}
 }


### PR DESCRIPTION
Don't send a daily ping message like:

> Hello :wave: today's <@> is the buildcop :cop:

This message can still be sent if you ask buildcopbot directly and there is nobody currently assigned.

/assign @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [nope] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [yep] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._