### PR TITLE
Setup the initial infra for dogfooding events

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/config-defaults.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/config-defaults.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  default-cloud-events-sink: http://el-tekton-events.default:8080

--- a/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
@@ -2,3 +2,4 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - config-artifact-bucket.yaml
+- config-defaults.yaml

--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -120,3 +120,13 @@ spec:
   params:
   - name: keep
     value: $(body.params.cleanup.keep)
+---
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: configmap-deploy-details
+spec:
+  params:
+  - name: gitSHA
+    value: $(body.taskRun.status.resourcesResult[?(@.key == 'commit')].resourceRef.name)

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -76,3 +76,22 @@ spec:
         - ref: cleanup-details
       template:
         name: cleanup-runs
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: tekton-events
+spec:
+  serviceAccountName: tektoncd
+  triggers:
+    - name: configmap-deploy-successful-slack
+      interceptors:
+        - cel:
+            filter: >-
+              header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-cd' &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/trigger'] == 'configmaps'
+      bindings:
+      - ref: configmap-deploy-details
+      template:
+        name: hello-world

--- a/tekton/resources/cd/notification-template.yaml
+++ b/tekton/resources/cd/notification-template.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: hello-world
+spec:
+  params:
+  - name: gitSHA
+    description: The git sha of the deployed resource
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: hello-world-$(uid)
+    spec:
+      taskSpec:
+        steps:
+        - name: hello-world
+          image: busybox
+          script: |
+            echo 'Hello, World!'
+            echo 'We deployed $(params.gitSHA)'

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
 - cd/tekton-template.yaml
 - cd/serviceaccount.yaml
 - cd/cleanup-template.yaml
+- cd/notification-template.yaml
 - org-permissions/peribolos.yaml
 - org-permissions/peribolos-trigger.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Configure tekton in the dogfooding cluster to send cloud events to an
event listener. Add the event listener along with an hello world
trigger template that reacts to tasktun from the configmaps tekton cd
service.

In future, we can use this service to send notifications upon successful
or failed completion of tasks and pipelines, for instance to the
build-cop slack channel, to github checks and more.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature