### PR TITLE
Fix release deployment

### DIFF
--- a/tekton/cronjobs/ko-gcloud-image-nightly-build-cron/README.md
+++ b/tekton/cronjobs/ko-gcloud-image-nightly-build-cron/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `ko` and `gcloud` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/ko:gcloud-latest](gcr.io/tekton-releases/dogfooding/ko:gcloud-latest).
+The image is published daily to [gcr.io/tekton-releases/dogfooding/ko:gcloud-latest](gcr.io/tekton-releases/dogfooding/ko-gcloud:latest).

--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -14,7 +14,11 @@
 FROM golang:1.13-alpine3.12 as build
 LABEL description="Build container"
 
-RUN apk update && apk add --no-cache alpine-sdk
+RUN apk update && apk add --no-cache alpine-sdk ca-certificates
+RUN update-ca-certificates
+
+ARG KUBECTL_VERSION=1.16.2
+RUN wget -O/usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl; chmod +x /usr/local/bin/kubectl
 
 # Install Kustomize
 ENV GOBIN=/usr/local/go/bin
@@ -34,5 +38,6 @@ ENV GOBIN=/usr/local/go/bin
 ENV GO111MODULE on
 RUN go get github.com/google/ko/cmd/ko@v0.5.0
 
-# Get Kustomize from the build image
+# Get Kubectl and Kustomize from the build image
+COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=build /usr/local/go/bin/kustomize /usr/local/go/bin

--- a/tekton/resources/release/install_tekton_release.yaml
+++ b/tekton/resources/release/install_tekton_release.yaml
@@ -83,7 +83,7 @@ spec:
       kubectl apply --kubeconfig $KUBECONFIG $APPLY_MODE
 
   - name: wait-until-pods-running
-    image: gcr.io/tekton-releases/dogfooding/ko:gcloud-latest
+    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
     script: |
       #!/usr/bin/env bash
       set -exo pipefail


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The latest version of the ko-gcloud image does not include kubectl
anymore, so adding it back. This allows running deployments with that
image and restore the CD to the robocat cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug