### PR TITLE
Remove emails from script example

### DIFF
--- a/addpermissions.py
+++ b/addpermissions.py
@@ -17,7 +17,7 @@ This script requires the `gcloud` command line tool and the python
 `PyYaml` library.
 
 Example usage:
-  python3 addpermissions.py --users "andrea.frittoli@gmail.com, andrew.bayer@gmail.com, vdemeest@redhat.com, dibyajyoti@google.com, sbws@google.com, jerop@google.com"
+  python3 addpermissions.py --users "foo@something.com,bar@something.com"
 """
 import argparse
 import shlex


### PR DESCRIPTION
# Changes

I'd been pasting in everyone's emails as I went for really no good
reason at all, esp. since there's no reason to re-run it for everyone
that already has permissions every time I add someone (and that is
sloooooow).

I re-ran this today for @savitaashture @nikhil-thomas and they are now
listed at https://github.com/tektoncd/plumbing/tree/master/buildbot#tekton-buildcop
so I felt like it made sense to remove this list.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._