### PR TITLE
Revert "prow: add postgres sidecar and remove dind for hub"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -781,16 +781,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: postgres:latest
-        command: ["docker-entrypoint.sh"]
-        args: ["postgres"]
-        env:
-        - name: POSTGRES_USER
-          value: postgres
-        - name: POSTGRES_PASSWORD
-          value: postgres
-        - name: POSTGRES_DB
-          value: hub
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
         command:
@@ -812,6 +802,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -830,16 +822,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: postgres:latest
-        command: ["docker-entrypoint.sh"]
-        args: ["postgres"]
-        env:
-        - name: POSTGRES_USER
-          value: postgres
-        - name: POSTGRES_PASSWORD
-          value: postgres
-        - name: POSTGRES_DB
-          value: hub
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
         command:
@@ -861,6 +843,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
@@ -879,16 +863,6 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: postgres:latest
-        command: ["docker-entrypoint.sh"]
-        args: ["postgres"]
-        env:
-        - name: POSTGRES_USER
-          value: postgres
-        - name: POSTGRES_PASSWORD
-          value: postgres
-        - name: POSTGRES_DB
-          value: hub
       - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
         imagePullPolicy: Always
         command:
@@ -910,6 +884,8 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This reverts commit 8203b6fd95d12222134ff31233a052a579535e3c.

Adding the postgres sidecars appears to have put `hook` into a bad state:
"Invalid presubmit job pull-tekton-hub-build-tests: pod spec must specify
exactly 1 container, found: 2"

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)