### PR TITLE
Setup slack notifications for failed configmap deploys

### DIFF
--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -121,12 +121,31 @@ spec:
   - name: keep
     value: $(body.params.cleanup.keep)
 ---
----
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
   name: configmap-deploy-details
 spec:
   params:
-  - name: gitSHA
-    value: $(body.taskRun.status.resourcesResult[?(@.key == 'commit')].resourceRef.name)
+  - name: gitResource
+    value: $(body.taskRun.spec.resources.inputs[?(@.name == 'source')].resourceRef.name)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: taskrun-meta
+spec:
+  params:
+  - name: taskRunName
+    value: $(body.taskRun.metadata.name)
+  - name: taskRunNamespace
+    value: $(body.taskRun.metadata.namespace)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: dashboard-url-dogfooding
+spec:
+  params:
+  - name: dashboardBaseURL
+    value: https://dashboard.dogfooding.tekton.dev

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -84,14 +84,16 @@ metadata:
 spec:
   serviceAccountName: tektoncd
   triggers:
-    - name: configmap-deploy-successful-slack
+    - name: configmap-deploy-failed
       interceptors:
         - cel:
             filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') &&
+              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1') &&
               body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-cd' &&
               body.taskRun.metadata.labels['triggers.tekton.dev/trigger'] == 'configmaps'
       bindings:
       - ref: configmap-deploy-details
+      - ref: taskrun-meta
+      - ref: dashboard-url-dogfooding
       template:
-        name: hello-world
+        name: configmap-deploy-failed-slack

--- a/tekton/resources/cd/notification-template.yaml
+++ b/tekton/resources/cd/notification-template.yaml
@@ -14,21 +14,29 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: hello-world
+  name: configmap-deploy-failed-slack
 spec:
   params:
-  - name: gitSHA
+  - name: taskRunName
+    description: The name of the TaskRun
+  - name: taskRunNamespace
+    description: The namespace of the TaskRun
+  - name: dashboardBaseURL
+    description: The base URL of the Tekton dashboard
+  - name: gitResource
     description: The git sha of the deployed resource
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: hello-world-$(uid)
+      name: send-to-webhook-slack-$(uid)
     spec:
-      taskSpec:
-        steps:
-        - name: hello-world
-          image: busybox
-          script: |
-            echo 'Hello, World!'
-            echo 'We deployed $(params.gitSHA)'
+      taskRef:
+        name: send-to-webhook-slack
+      params:
+        - name: webhook-secret
+          value: robocat-slack-app-webhook
+        - name: message
+          value: >-
+            :boom: The TaskRun <$(params.dashboardBaseURL)/#/namespaces/$(params.taskRunNamespace)/taskruns/$(params.taskRunName)|$(params.taskRunNamespace)/$(params.taskRunName)>
+            failed to deploy <$(params.dashboardBaseURL)/#/namespaces/$(params.taskRunNamespace)/pipelineresources/$(params.gitResource)|$(params.taskRunNamespace)/$(params.gitResource)>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace the hello world task with a slack notification that is
sent to the build-cop channel when a configmap deployment fails.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._


/kind feature