### PR TITLE
Hub: remove DIND and privileged securityContext

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -802,14 +802,10 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-        securityContext:
-          privileged: true
       volumes:
       - name: test-account
         secret:
@@ -843,14 +839,10 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-        securityContext:
-          privileged: true
       volumes:
       - name: test-account
         secret:
@@ -884,14 +876,10 @@ presubmits:
           mountPath: /etc/test-account
           readOnly: true
         env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
           value: us-central1
-        securityContext:
-          privileged: true
       volumes:
       - name: test-account
         secret:


### PR DESCRIPTION
# Changes

https://github.com/tektoncd/hub/pull/30 removes the need for running
Docker in Docker, hence removing the flags 🤞

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [🙅 ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._