### PR TITLE
Deploy dogfooding nightly

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -29,6 +29,13 @@ Secrets which have been applied to the dogfooding cluster but are not committed 
   - `release-secret` is used by Tekton Pipeline to push pipeline artifacts to a
     GCS bucket. It's also used to push images built by cron trigger (or [Mario](../mariobot])
     to the image registry on GCP.
+- K8s service account secrets. These secrets are used in pipeline resources of type cluster, to
+  give enabled Tekton pipelines to deploy to target clusters with specific service accounts:
+  - dogfooding-tekton-cd-token
+  - dogfooding-tekton-cleaner-token
+  - dogfooding-tektonci-default-token
+  - robocat-tekton-deployer-token
+  - robocat-tektoncd-cadmin-token
 - Lots of other secrets, hopefully we can add more documentation on them
   here as we go.
 
@@ -43,13 +50,16 @@ SSL Certificate are generated automatically using a `ClusterIssuer` managed by
 - To install `cert-manager` follow this
   [guide](https://docs.cert-manager.io/en/latest/getting-started/)
 - To deploy the `ClusterIssuer`:
-```
+
+```bash
 kubectl apply -f https://github.com/tektoncd/plumbing/blob/master/tekton/certificates/clusterissuer.yaml
 ```
+
 - Apply the ingress resources and update the `*.tekton.dev` DNS configuration.
   Ingress resources are deployed along with the corresponding service.
 
 The following DNS names and corresponding ingresses are defined:
+
 - `dashboard.dogfooding.tekton.dev`: [ingress](https://github.com/tektoncd/plumbing/blob/master/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml)
 
 To see the IP of the ingress in the new cluster:
@@ -71,3 +81,27 @@ and therefore doesn't support workloads running with Workload Identity.
 - `workload-id` has the GKE Metadata Server enabled and is used for workloads operating with
 Workload Identity. The only workload that currently requires Workload Identity is "pipelinerun-logs"
 which shows Stackdriver log entries for PipelineRuns.
+
+## Manifests
+
+Manifests for various resources are deployed to the dogfooding clusters from different repositories.
+For the plumbing repo, manifest are applied nightly through two cronjobs:
+
+- [tekton](https://github.com/tektoncd/plumbing/tree/master/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly)
+- [tekton-cronjobs](https://github.com/tektoncd/plumbing/tree/master/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly)
+
+Manifests from other repos (pipeline, dashboard and triggers) are applied manually for now.
+
+### Service Accounts
+
+Service accounts definitions are stored in git and are applied as part of CD, expect for the case of
+[Cluster Roles](https://github.com/tektoncd/plumbing/blob/master/tekton/resources/cd/serviceaccount.yaml)
+and related bindings, as they would require giving too broad access to the CD service account.
+
+## Tekton Services
+
+Tekton services are deployed using the [`deploy-release.sh`](https://github.com/tektoncd/plumbing/blob/master/scripts/deploy-release.sh)
+script, which submits a kubernets `Job` to the `robocat` cluster, to trigger a deployment on the
+`dogfooding` cluster. The `Job` triggers and event listener on the `robocat` cluster, and triggers
+a Tekton task that downloads a release from the release bucket, optionally applies overlays and
+deploys the result to the `dogfooding` cluster using a dedicated service account.

--- a/tekton/ci/checks/check-pr-has-kind-label.yaml
+++ b/tekton/ci/checks/check-pr-has-kind-label.yaml
@@ -21,11 +21,8 @@ spec:
   params:
   - name: labels
     description: List of labels currently on the Pull Request
-    type: string
   - name: gitRepository
-    type: string
   - name: pullRequestUrl
-    type: string
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun

--- a/tekton/ci/kustomization.yaml
+++ b/tekton/ci/kustomization.yaml
@@ -1,7 +1,6 @@
+namespace: tektonci
 commonAnnotations:
   managed-by: Tekton
-
-namespace: tektonci
 
 resources:
 - 0001_rbac.yaml

--- a/tekton/cronjobs/bases/folder/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/folder/trigger-resource-cd.yaml
@@ -69,7 +69,7 @@ spec:
               - name: CLUSTER_RESOURCE
                 value: "not-a-real-cluster"
               - name: FOLDER_METHOD
-                value: "apply"
+                value: "replace"
               - name: FOLDER_OVERLAY
                 value: "false"
               - name: FOLDER_PATH

--- a/tekton/cronjobs/dogfooding/manifests/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/kustomization.yaml
@@ -1,2 +1,3 @@
-# yamllint disable-line rule:empty-values
 resources:
+- plumbing-tekton-nightly
+- plumbing-tekton-cronjobs-nightly

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly/README.md
@@ -1,0 +1,4 @@
+# Tetkon Cronjobs CD - Dogfooding Cluster
+
+Cron Job to daily apply the Tekton cronjobs in the tekton/cronjobs/dogfooding folder,
+from the plumbing repo, to the dogfooding cluster.

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly/cronjob.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: folder-cd-trigger
+spec:
+  schedule: "30 9 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: GIT_REPOSITORY
+                value: "github.com/tektoncd/plumbing"
+              - name: GIT_REVISION
+                value: "master"
+              - name: NAMESPACE
+                value: "default"
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tekton-cd"
+              - name: FOLDER_PATH
+                value: "tekton/cronjobs/dogfooding"
+              - name: FOLDER_DESCRIPTION
+                value: "tekton-cronjobs-dogfooding"
+              - name: FOLDER_OVERLAY
+                value: "true"

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/folder
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-tekton-cronjobs"

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly/README.md
@@ -1,0 +1,4 @@
+# Tetkon Resources CD - Dogfooding Cluster
+
+Cron Job to daily apply the Tekton resources in the tekton folder (resources, mario and ci),
+from the plumbing repo, to the dogfooding cluster.

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly/cronjob.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: folder-cd-trigger
+spec:
+  schedule: "30 10 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: GIT_REPOSITORY
+                value: "github.com/tektoncd/plumbing"
+              - name: GIT_REVISION
+                value: "master"
+              - name: NAMESPACE
+                value: ""
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tekton-cd"
+              - name: FOLDER_PATH
+                value: "tekton"
+              - name: FOLDER_DESCRIPTION
+                value: "tekton"
+              - name: FOLDER_OVERLAY
+                value: "true"

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/folder
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-tekton"

--- a/tekton/images/kubectl/Dockerfile
+++ b/tekton/images/kubectl/Dockerfile
@@ -11,11 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.11
-LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+FROM golang:1.13-alpine3.12 as build
+LABEL description="Build container"
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache alpine-sdk ca-certificates
 RUN update-ca-certificates
 
 ARG KUBECTL_VERSION=1.16.2
 RUN wget -O/usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl; chmod +x /usr/local/bin/kubectl
+
+# Install Kustomize
+ENV GOBIN=/usr/local/go/bin
+ENV GO111MODULE on
+RUN go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4
+
+FROM alpine:3.12
+LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+
+# Get Kubectl and Kustomize from the build image
+COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=build /usr/local/go/bin/kustomize /usr/local/go/bin

--- a/tekton/images/kubectl/Dockerfile
+++ b/tekton/images/kubectl/Dockerfile
@@ -30,4 +30,4 @@ LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 # Get Kubectl and Kustomize from the build image
 COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=build /usr/local/go/bin/kustomize /usr/local/go/bin
+COPY --from=build /usr/local/go/bin/kustomize /usr/local/bin/kustomize

--- a/tekton/resources/cd/clusters.yaml
+++ b/tekton/resources/cd/clusters.yaml
@@ -150,3 +150,23 @@ spec:
     secretKey: ca.crt
     secretName: dogfooding-tekton-cleaner-token
   type: cluster
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: dogfooding-tekton-cd
+  namespace: default
+spec:
+  params:
+  - name: url
+    value: https://35.222.251.168
+  - name: username
+    value: tekton-cd
+  secrets:
+  - fieldName: token
+    secretKey: token
+    secretName: dogfooding-tekton-cd-token
+  - fieldName: cadata
+    secretKey: ca.crt
+    secretName: dogfooding-tekton-cd-token
+  type: cluster

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -79,16 +79,38 @@ spec:
             NAMESPACE_PARAM="-n $(params.namespace)"
             [[ "$(params.namespace)" == "" ]] && NAMESPACE_PARAM=""
 
-            # Run the deployment
+            # Handle overlays
+            TARGET=$(resources.inputs.source.path)/$(params.folderPath)
             if [[ "$(params.isOverlay)" == "true" ]]; then
-              kubectl "$(params.deployMethod)" \
-                $NAMESPACE_PARAM -f \
-                $(resources.inputs.source.path)/$(params.folderPath)
-            else
+              TARGET=target.yaml
               kustomize build \
-                $(resources.inputs.source.path)/$(params.folderPath) | \
-                kubectl "$(params.deployMethod)" $NAMESPACE_PARAM -f -
+                $(resources.inputs.source.path)/$(params.folderPath) > $TARGET
             fi
+
+            # Check if there is any diff
+            DIFF=diff.txt
+            kubectl diff $NAMESPACE_PARAM -f $TARGET | tee $DIFF
+
+            # If there is no diff, we don't need to update
+            if [ ! -s ${DIFF?} ]; then
+              echo "No change detected, nothing to be done."
+              exit 0
+            fi
+
+            # When deploying with replace, we need to do a create first,
+            # to ensure new resources are created
+            CREATE_OUTPUT=create.txt
+            if [[ "$(params.deployMethod)" == "replace" ]]; then
+              kubectl create $NAMESPACE_PARAM -f $TARGET  2> $CREATE_OUTPUT || true
+              # If there was some unexpected message in the error log, fail
+              if grep -v "already exists" $CREATE_OUTPUT; then
+                  echo "Something went wrong when creating resources"
+                  exit 1
+              fi
+            fi
+
+            # Run the actual deployment. If it fails, it will fail the step.
+            kubectl "$(params.deployMethod)" $NAMESPACE_PARAM -f $TARGET
       params:
       - name: folderPath
         value: $(params.folderPath)

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -75,18 +75,20 @@ spec:
             #!/bin/sh
             set -ex
 
-            # Determine whether to deploy a normal folder or a kustomize overlay
-            METHOD_PARAM="-f"
-            [[ "$(params.isOverlay)" == "true" ]] && METHOD_PARAM="-k"
-
             # Determine whether to enforce namespace across resources
             NAMESPACE_PARAM="-n $(params.namespace)"
             [[ "$(params.namespace)" == "" ]] && NAMESPACE_PARAM=""
 
             # Run the deployment
-            kubectl "$(params.deployMethod)" \
-              $NAMESPACE_PARAM $METHOD_PARAM \
-              $(resources.inputs.source.path)/$(params.folderPath)
+            if [[ "$(params.isOverlay)" == "true" ]]; then
+              kubectl "$(params.deployMethod)" \
+                $NAMESPACE_PARAM -f \
+                $(resources.inputs.source.path)/$(params.folderPath)
+            else
+              kustomize build \
+                $(resources.inputs.source.path)/$(params.folderPath) | \
+                kubectl "$(params.deployMethod)" $NAMESPACE_PARAM -f -
+            fi
       params:
       - name: folderPath
         value: $(params.folderPath)

--- a/tekton/resources/cd/kustomization.yaml
+++ b/tekton/resources/cd/kustomization.yaml
@@ -1,0 +1,14 @@
+namespace: default
+commonAnnotations:
+  managed-by: Tekton
+
+resources:
+- bindings.yaml
+- clusters.yaml
+- configmap-template.yaml
+- eventlistener.yaml
+- folder-template.yaml
+- helm-template.yaml
+- tekton-template.yaml
+- cleanup-template.yaml
+- notification-template.yaml

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -88,3 +88,75 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: delete-pr-tr
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-cd
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-admin
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccount", "namespace"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrole", "role", "rolebinding"]
+  verbs: ["*"]
+- apiGroups: ["tekton.dev"]
+  resources: ["task", "pipeline", "condition", "pipelineresources"]
+  verbs: ["*"]
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["eventlistener", "triggerbinding", "triggertemplate"]
+  verbs: ["*"]
+- apiGroups: ["extensions"]
+  resources: ["ingress"]
+  verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["cronjob"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cd-tekton-admin-default
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: tekton-cd
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cd-tekton-admin-tektonci
+  namespace: tektonci
+subjects:
+- kind: ServiceAccount
+  name: tekton-cd
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cd-tekton-admin-mario
+  namespace: mario
+subjects:
+- kind: ServiceAccount
+  name: tekton-cd
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-admin

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -101,22 +101,22 @@ metadata:
   name: tekton-admin
 rules:
 - apiGroups: [""]
-  resources: ["serviceaccount", "namespace"]
+  resources: ["serviceaccounts", "namespaces"]
   verbs: ["*"]
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterrole", "role", "rolebinding"]
+  resources: ["roles", "rolebindings"]
   verbs: ["*"]
 - apiGroups: ["tekton.dev"]
-  resources: ["task", "pipeline", "condition", "pipelineresources"]
+  resources: ["tasks", "pipelines", "conditions", "pipelineresources"]
   verbs: ["*"]
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlistener", "triggerbinding", "triggertemplate"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
   verbs: ["*"]
 - apiGroups: ["extensions"]
-  resources: ["ingress"]
+  resources: ["ingresses"]
   verbs: ["*"]
 - apiGroups: ["batch"]
-  resources: ["cronjob"]
+  resources: ["cronjobs"]
   verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 commonAnnotations:
   managed-by: Tekton
 

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -4,23 +4,8 @@ commonAnnotations:
 
 resources:
 - images/image-build-trigger.yaml
-- release/install_and_test_tekton_release.yaml
-- release/install_tekton_release.yaml
-- release/nightly-release-logs-trigger.yaml
-- release/prerelease_checks.yaml
-- release/save-release-logs.yaml
-- release/test_tekton_release.yaml
-- release/github_release.yaml
-- cd/bindings.yaml
-- cd/clusters.yaml
-- cd/configmap-template.yaml
-- cd/eventlistener.yaml
-- cd/folder-template.yaml
-- cd/helm-template.yaml
-- cd/tekton-template.yaml
-- cd/serviceaccount.yaml
-- cd/cleanup-template.yaml
-- cd/notification-template.yaml
 - org-permissions/peribolos.yaml
 - org-permissions/peribolos-trigger.yaml
+- release
+- cd
 - nightly-release

--- a/tekton/resources/release/kustomization.yaml
+++ b/tekton/resources/release/kustomization.yaml
@@ -1,0 +1,12 @@
+namespace: default
+commonAnnotations:
+  managed-by: Tekton
+
+resources:
+- install_and_test_tekton_release.yaml
+- install_tekton_release.yaml
+- nightly-release-logs-trigger.yaml
+- prerelease_checks.yaml
+- save-release-logs.yaml
+- test_tekton_release.yaml
+- github_release.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a tekton-cd account that is admin on default, tektonci and
mario namespaces (it can control all resource types that are
included in the deploy in those namespaces).
Add a pipeline resource associated to that service account.

Add a cron job that deploys resources from the tekton folder in
the plumbing repo to the dogfooding cluster, using the tektoncd
account. Runs at 10:30pm UTC daily.

Add a cron job that deploys cronjobs from the tekton folder in
the plumbing repo to the dogfooding cluster, using the tektoncd
account. Runs at 9:30pm UTC daily.

Since kubectl includes version v2.0.3 of kustomize, which still
uses bases instead of resources, add kustomize v3 to the kubectl
image, and change the folder trigger template to use kustomize
build for overlays instead of kubectl -k.

Improve the folder deployment template:
Fix the replace mode by adding create + replace, and switch the
default deploy mode to replace. Check for failures in create,
if any failure other than "already exists" is found, fail.
Never force replace, as that deletes and recrates, which can
cause all sort of issues when applied to resources like
service accounts or ingresses.

Improve efficiency by checking if any diff exists, and skip
deployment if not. This is possible now that Tekton resources
support diff.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature