### PR TITLE
add prow job that enables cluster task auth webhook integration tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1144,6 +1144,49 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  # this test is the same as pull-tekton-pipeline-integration-tests except that it enables additional
+  # e2e testing of validation admission webhook for ClusterTask access
+  - name: pull-tekton-pipeline-integration-auth-webhook-tests
+    agent: kubernetes
+    always_run: false
+    decorate: true
+    rerun_command: "/test pull-tekton-pipeline-integration-auth-webhook-tests"
+    trigger: "(?m)^/test (all|pull-tekton-pipeline-integration-auth-webhook-tests),?(\\s+|$)"
+    spec:
+      containers:
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+          imagePullPolicy: Always
+          command:
+            - /usr/local/bin/entrypoint.sh
+          args:
+            - "--scenario=kubernetes_execute_bazel"
+            - "--clean"
+            - "--job=$(JOB_NAME)"
+            - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+            - "--root=/go/src"
+            - "--service-account=/etc/test-account/service-account.json"
+            - "--upload=gs://tekton-prow/pr-logs"
+            - "--" # end bootstrap args, scenario args below
+            - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+            - "./test/presubmit-tests.sh"
+            - "--integration-tests"
+          volumeMounts:
+            - name: test-account
+              mountPath: /etc/test-account
+              readOnly: true
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/test-account/service-account.json
+            - name: E2E_CLUSTER_REGION
+              value: us-central1
+            # then env triggers changes in tektoncd/pipeline's e2e-common.sh to enable the validation admission webhook
+            # for ClusterTask access
+            - name: TEST_CLUSTER_TASK_ACCESS_VALIDATION
+              value: true
+      volumes:
+        - name: test-account
+          secret:
+            secretName: test-account
   - name: pull-tekton-pipeline-go-coverage
     agent: kubernetes
     always_run: true


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As part of addressing https://github.com/tektoncd/pipeline/issues/2917 the PR creates a test job just like the existing integration test job, but with the difference of enabling the new validation webhook that enforces get permissions to ClusterTask's for the SAs associated with PipelineRuns and TaskRuns

The existing integration job will run with the new webhook disabled.

This new job turns it on.

At least initially, this will be an optional job, as we vet things in https://github.com/tektoncd/pipeline/pull/2797

As reviews progress, if deemed satisfactory by the community I will follow up with a PR that make this mandatory.

/assign @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n/a ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ / ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

