### PR TITLE
Fix check name for tekton-golang-lint

### DIFF
--- a/tekton/ci/plumbing-template.yaml
+++ b/tekton/ci/plumbing-template.yaml
@@ -497,7 +497,7 @@ spec:
         - name: fileFilterRegex
           value: ".*"
         - name: checkName
-          value: plumbing-images-build
+          value: tekton-golang-lint
         - name: gitHubCommand
           value: $(params.gitHubCommand)
       resources:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The check name is wrong for tekton-golang-lint so /test tekton-golang-lint
does not work. Fixing that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug