### PR TITLE
test-runner: do not use -u on go get…

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -168,7 +168,7 @@ RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.5.1 && \
     GO111MODULE="off" go get github.com/golang/dep/cmd/dep
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
-ARG GOLANGCI_VERSION=1.27.0
+ARG GOLANGCI_VERSION=1.28.0
 RUN curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
 
 # Install Kustomize:

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -160,12 +160,12 @@ RUN apt update && apt install -y uuid-runtime  # for uuidgen
 RUN apt update && apt install -y rubygems  # for mdl
 
 # Extra tools through go get
-RUN GO111MODULE="on" go get -u github.com/google/ko/cmd/ko@v0.5.1 && \
-    go get -u github.com/golang/dep/cmd/dep && \
-    go get -u github.com/google/licenseclassifier && \
-    go get -u github.com/google/go-licenses && \
-    go get -u github.com/jstemmer/go-junit-report && \
-    GO111MODULE="on" go get -u github.com/raviqqe/liche
+RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.5.1 && \
+    GO111MODULE="on" go get github.com/google/licenseclassifier && \
+    GO111MODULE="on" go get github.com/google/go-licenses && \
+    GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \
+    GO111MODULE="on" go get github.com/raviqqe/liche && \
+    GO111MODULE="off" go get github.com/golang/dep/cmd/dep
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
 ARG GOLANGCI_VERSION=1.27.0


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Using `go get -u`, Go will try to update dependencies when getting the
package. This is bad with go modules as there is no guarantee the new
dependencies still work (especially when the dependency is 0.x). As we
are only installing the binaries, we need reproductible install, and…
using `go get -u` is the opposite of that 😅

*Also bump golangci-lint to 1.28.0*.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._