### PR TITLE
Record having given build cop access to @sthaha

### DIFF
--- a/buildbot/README.md
+++ b/buildbot/README.md
@@ -16,6 +16,10 @@ Current buildcops are:
 - Sharon Jerop Kipruto @jerop (jerop)
 - Vincent Demeester @vdemeester (vdemeest)
 
+Other folks who are not build cops but have build cop access:
+- Sunil Thaha @sthaha
+
+Build cop access is given with [addpermissions.py](../addpermissions.py).
 
 ## Rotation
 


### PR DESCRIPTION
# Changes

@vdemeester requested giving @sthaha access to the dogfood cluster to
setup the preview tekton hub instance (very exciting!!). The simplest
way to do this is to run this script, though it gives @sthaha access to
a bunch of unnecessary clusters as well. I wanted to record somewhere
who we have given access to and why so I'm adding that here. In the long
run it'd be cool to have automation grant this access based on a list of
names we commit here :D

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._