### PR TITLE
Don't use go modules for licenseclassifier.

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -161,7 +161,7 @@ RUN apt update && apt install -y rubygems  # for mdl
 
 # Extra tools through go get
 RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.5.1 && \
-    GO111MODULE="on" go get github.com/google/licenseclassifier && \
+    GO111MODULE="off" go get github.com/google/licenseclassifier && \
     GO111MODULE="on" go get github.com/google/go-licenses && \
     GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \
     GO111MODULE="on" go get github.com/raviqqe/liche && \


### PR DESCRIPTION
# Changes

I think this is causing the current presubmit error:
  Error: cannot register licenses from archive: open /home/prow/go/pkg/mod/github.com/google/licenseclassifier@v0.0.0-20190926221455-842c0d70d702/licenses/licenses.db: no such file or directory

This was changed to use modules in https://github.com/tektoncd/plumbing/commit/fb80e6b4c5b88032c8cf6eadcf04d4b9532ac076

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._