### PR TITLE
Also disable go modules for go-licenses.

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -162,7 +162,7 @@ RUN apt update && apt install -y rubygems  # for mdl
 # Extra tools through go get
 RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.5.1 && \
     GO111MODULE="off" go get github.com/google/licenseclassifier && \
-    GO111MODULE="on" go get github.com/google/go-licenses && \
+    GO111MODULE="off" go get github.com/google/go-licenses && \
     GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \
     GO111MODULE="on" go get github.com/raviqqe/liche && \
     GO111MODULE="off" go get github.com/golang/dep/cmd/dep


### PR DESCRIPTION
# Changes

go-licenses save is still failing in CI across our repos. I missed this in
https://github.com/tektoncd/plumbing/pull/485

I'm still mostly just guessing at fixes because I don't have a great way to repro this locally.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._