### PR TITLE
Automate Issues and Pull Requests Lifecycle

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1680,3 +1680,107 @@ periodics:
     - name: test-account
       secret:
         secretName: test-account
+- name: periodic-tekton-stale
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200727-9592e624ac
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:tektoncd
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=2160h
+      - --token=/etc/github-token/oauth
+      - |-
+        --comment=Issues go stale after 90d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle stale`.
+        Stale issues rot after an additional 30d of inactivity and eventually close.
+        If this issue is safe to close now please do so with `/close`.
+
+        /lifecycle stale
+
+        Send feedback to [tektoncd/plumbing](https://github.com/tektoncd/plumbing).
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+    volumes:
+      - name: github-token
+        secret:
+          secretName: oauth-token
+- name: periodic-tekton-rotten
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200727-9592e624ac
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:tektoncd
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/github-token/oauth
+      - |-
+        --comment=Stale issues rot after 30d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+        Rotten issues close after an additional 30d of inactivity.
+        If this issue is safe to close now please do so with `/close`.
+
+        /lifecycle rotten
+
+        Send feedback to [tektoncd/plumbing](https://github.com/tektoncd/plumbing).
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+    volumes:
+      - name: github-token
+        secret:
+          secretName: oauth-token
+- name: periodic-tekton-close
+  interval: 1h
+  decorate: true
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200727-9592e624ac
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:tektoncd
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/github-token/oauth
+      - |-
+        --comment=Rotten issues close after 30d of inactivity.
+        Reopen the issue with `/reopen`.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+        /close
+
+        Send feedback to [tektoncd/plumbing](https://github.com/tektoncd/plumbing).
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+    volumes:
+      - name: github-token
+        secret:
+          secretName: oauth-token


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Currently, Tekton Build Cops have to manually check issues and pull
requests then ping authors if they haven’t been updated in a while.
This is a cumbersome process that can be automated and save build cops
time.

In this PR, we have automated this Build Cop task by adding lifecycles
management to issues and pull requests across the tektoncd github org. 
The [prow lifecycle plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/lifecycle) is [already added](https://github.com/tektoncd/plumbing/blob/bd59601a4f2c0f1ce95a9ce0bb4342bfcf8d4489/prow/plugins.yaml#L35) in tektoncd org -- this PR enables 
it to handle the issues/prs lifecycle management and save build cops time.

The lifecycles states are:
- `active`: issue or PR actively being worked on by a contributor
- `frozen`: issue or PR should not be autoclosed due to rottenness
- `stale`:  issue or PR open with no activity and has become stale
- `rotten`: issue or PR is too old and will be auto-closed soon

The lifecycle transitions are:
- issue or PR becomes `stale` after 90 days of inactivity
- `stale` issue or PR becomes `rotten` after 30 days of inactivity
- `rotten` issues close after 30 days of inactivity

Example test on an issue opened on Nov 8th, 2018: https://github.com/tektoncd/pipeline/issues/230.

Closes issue https://github.com/tektoncd/plumbing/issues/492.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._