### PR TITLE
Handle the issue of labels with quotes within description

### DIFF
--- a/tekton/ci/checks/check-pr-has-kind-label.yaml
+++ b/tekton/ci/checks/check-pr-has-kind-label.yaml
@@ -82,7 +82,8 @@ spec:
             import yaml
             import sys
 
-            prLabels = json.loads('$(params.labels)')
+            prLabelsText = """$(params.labels)"""
+            prLabels = json.loads(prLabelsText)
             labelNames = list(map(lambda e: e["name"], prLabels))
             kindLabels = list(filter(lambda e: "kind" in e, labelNames))
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Labels are extracted from the JSON payload of the github
event, so they must be a valid JSON fragment. The problem
of labels with single quotes in the description begins when
we assign that JSON fragment to a variable so we can later
parse it with json.loads.

The solution to that is to use the triple-quotes syntax
to define the variable that holds the json.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug
/cc @vdemeester 