### PR TITLE
Add nop-image resource to pipline trigger template

### DIFF
--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -28,6 +28,9 @@
       - name: builtEntrypointImage
         resourceRef:
           name: entrypoint-image
+      - name: builtNopImage
+        resourceRef:
+          name: nop-image
       - name: builtKubeconfigWriterImage
         resourceRef:
           name: kubeconfigwriter-image


### PR DESCRIPTION
Add nop-image resource to pipelinerun as the referred pipeline has a new
`builtNopImage` param (https://github.com/tektoncd/pipeline/pull/3041)

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._