### PR TITLE
Run the GitHub check update task as non-root

### DIFF
--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -43,6 +43,10 @@ spec:
       namespace: tektonci
     spec:
       serviceAccountName: tekton-ci-jobs
+      podTemplate:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
       taskSpec:
         resources:
           inputs:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the trigger template that is responsible to update checks
in github so that the taskrun is run as non-root.
This ensures that the upload step of the resource has read access
to the content of the PR on file system.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug