### PR TITLE
GitHub Enterprise authentication for add-pr-body interceptor

### DIFF
--- a/tekton/ci/interceptors/add-pr-body/README.md
+++ b/tekton/ci/interceptors/add-pr-body/README.md
@@ -80,3 +80,23 @@ ko apply -P -f tekton/ci/interceptors/add-pr-body/config/
 ```
 
 Eventually it should be included in nightly releases and installed from there.
+
+## GitHub Enterprise
+
+The interceptor needs authentication if you are using GitHub Enterprise. 
+In order to authenticate to GitHub Enterprise API, you need to set `GITHUB_OAUTH_SECRET` environment variable.
+
+Add GitHub OAuth secret to the deployment like below.
+```yaml
+    spec:
+      serviceAccountName: add-pr-body-bot
+      containers:
+        - name: add-pr-body-interceptor
+          image: github.com/tektoncd/plumbing/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body
+          env:
+            - name: GITHUB_OAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: github-secret
+                  key: oauth
+```

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
@@ -39,15 +39,15 @@ const (
 )
 
 func main() {
-	http.HandleFunc("/", makeAddPRBodyHandler(getPrBody, getGitHubAuth("GITHUB_OAUTH_SECRET", "")))
+	http.HandleFunc("/", makeAddPRBodyHandler(getPrBody, getGitHubAuth("GITHUB_OAUTH_SECRET")))
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", 8080), nil))
 }
 
-func getGitHubAuth(key, fallback string) string {
+func getGitHubAuth(key string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
-	return fallback
+	return ""
 }
 
 func makeAddPRBodyHandler(urlFetcherDecoder urlToMap, token string) http.HandlerFunc {

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
@@ -116,8 +116,6 @@ func makeAddPRBodyHandler(urlFetcherDecoder urlToMap, token string) http.Handler
 			}
 		}
 
-		log.Printf(string(responseBytes))
-
 		// Write the response
 		n, err := w.Write(responseBytes)
 		if err != nil {
@@ -183,7 +181,7 @@ func getPrBody(prUrl string, token string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
@@ -115,7 +115,6 @@ func makeAddPRBodyHandler(urlFetcherDecoder urlToMap, token string) http.Handler
 				w.Header().Add(k, v)
 			}
 		}
-
 		// Write the response
 		n, err := w.Write(responseBytes)
 		if err != nil {

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
@@ -165,7 +165,6 @@ func getPrUrl(body map[string]interface{}) (string, error) {
 }
 
 func getPrBody(prUrl string, token string) (map[string]interface{}, error) {
-	var oauth = "token " + token
 	req, err := http.NewRequest("GET", prUrl, nil)
 	if err != nil {
 		return nil, err
@@ -173,7 +172,7 @@ func getPrBody(prUrl string, token string) (map[string]interface{}, error) {
 
 	// If token isn't an empty string add GitHub Enterprise OAuth header
 	if token != "" {
-		req.Header.Add("Authorization: ", oauth)
+		req.Header.Add("Authorization", "token " + token)
 	}
 
 	client := &http.Client{}

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main_test.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestEmptyBody(t *testing.T) {
 	r := createRequest("POST", "/", "issue_comment", nil)
-	h := makeAddPRBodyHandler(getTestPrBody)
+	h := makeAddPRBodyHandler(getTestPrBody, "")
 	w := httptest.NewRecorder()
 
 	h(w, r)
@@ -42,7 +42,7 @@ func TestEmptyBody(t *testing.T) {
 func TestNoAddPrBody(t *testing.T) {
 	body := marshalEvent(t, makePrBody(false, ""))
 	r := createRequest("POST", "/", "issue_comment", body)
-	h := makeAddPRBodyHandler(getTestPrBody)
+	h := makeAddPRBodyHandler(getTestPrBody, "")
 	w := httptest.NewRecorder()
 
 	h(w, r)
@@ -53,7 +53,7 @@ func TestNoAddPrBody(t *testing.T) {
 func TestNoPullRequestUrlFound(t *testing.T) {
 	body := marshalEvent(t, makePrBody(true, ""))
 	r := createRequest("POST", "/", "issue_comment", body)
-	h := makeAddPRBodyHandler(getTestPrBody)
+	h := makeAddPRBodyHandler(getTestPrBody, "")
 	w := httptest.NewRecorder()
 
 	h(w, r)
@@ -64,7 +64,7 @@ func TestNoPullRequestUrlFound(t *testing.T) {
 func TestCannotFetchURL(t *testing.T) {
 	body := marshalEvent(t, makePrBody(true, "foo://some_url"))
 	r := createRequest("POST", "/", "issue_comment", body)
-	h := makeAddPRBodyHandler(getTestPrBodyError)
+	h := makeAddPRBodyHandler(getTestPrBodyError, "")
 	w := httptest.NewRecorder()
 
 	h(w, r)
@@ -75,13 +75,13 @@ func TestCannotFetchURL(t *testing.T) {
 func TestFetchURL(t *testing.T) {
 	body := marshalEvent(t, makePrBody(true, "foo://some_url"))
 	r := createRequest("POST", "/", "issue_comment", body)
-	h := makeAddPRBodyHandler(getTestPrBody)
+	h := makeAddPRBodyHandler(getTestPrBody, "")
 	w := httptest.NewRecorder()
 
 	h(w, r)
 
 	want := makePrBody(true, "foo://some_url")
-	wantPrBody, _ := getTestPrBody("foo://some_url")
+	wantPrBody, _ := getTestPrBody("foo://some_url", "")
 	(*want)[rootPrBodyKey].(map[string]interface{})[prBodyContentKey] = wantPrBody
 
 	resp := w.Result()
@@ -127,13 +127,13 @@ func makePrBody(base bool, url string) *map[string]interface{} {
 	return &prAddBody
 }
 
-func getTestPrBody(prURL string) (map[string]interface{}, error) {
+func getTestPrBody(prURL string, token string) (map[string]interface{}, error) {
 	retrievedPrBody := make(map[string]interface{})
 	retrievedPrBody["foo"] = map[string]interface{}{}
 	return retrievedPrBody, nil
 }
 
-func getTestPrBodyError(prURL string) (map[string]interface{}, error) {
+func getTestPrBodyError(prURL string, token string) (map[string]interface{}, error) {
 	return nil, errors.New("something went wrong")
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

`add-pr-body` interceptor only works with the public GitHub. This PR simply adds the GitHub OAuth authentication feature to the `add-pr-body` interceptor.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._