### PR TITLE
Update params to tt.params in missed files

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -10,20 +10,20 @@
         name: dashboard-release
       params:
       - name: package
-        value: $(params.gitrepository)
+        value: $(tt.params.gitrepository)
       - name: imageRegistry
         value: gcr.io/tekton-nightly
       - name: versionTag
-        value: $(params.versionTag)
+        value: $(tt.params.versionTag)
       - name: bucketName
         value: latest
       resources:
       - name: dashboard-source-repo
         resourceRef:
-          name: git-source-$(params.projectName)-$(uid)
+          name: git-source-$(tt.params.projectName)-$(uid)
       - name: bucket-for-dashboard
         resourceRef:
-          name: tekton-bucket-nightly-$(params.projectName)-$(uid)
+          name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
       - name: builtDashboardImage
         resourceRef:
           name: dashboard-image

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -10,18 +10,18 @@
         name: pipeline-release-nightly
       params:
       - name: package
-        value: $(params.gitrepository)
+        value: $(tt.params.gitrepository)
       - name: imageRegistry
         value: gcr.io/tekton-nightly
       - name: versionTag
-        value: $(params.versionTag)
+        value: $(tt.params.versionTag)
       resources:
       - name: source-repo
         resourceRef:
-          name: git-source-$(params.projectName)-$(uid)
+          name: git-source-$(tt.params.projectName)-$(uid)
       - name: bucket
         resourceRef:
-          name: tekton-bucket-nightly-$(params.projectName)-$(uid)
+          name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
       - name: builtBaseImage
         resourceRef:
           name: base-image

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -10,18 +10,18 @@
         name: triggers-release
       params:
       - name: package
-        value: $(params.gitrepository)
+        value: $(tt.params.gitrepository)
       - name: imageRegistry
         value: gcr.io/tekton-nightly
       - name: versionTag
-        value: $(params.versionTag)
+        value: $(tt.params.versionTag)
       resources:
       - name: source-repo
         resourceRef:
-          name: git-source-$(params.projectName)-$(uid)
+          name: git-source-$(tt.params.projectName)-$(uid)
       - name: bucket
         resourceRef:
-          name: tekton-bucket-nightly-$(params.projectName)-$(uid)
+          name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
       - name: builtControllerImage
         resourceRef:
           name: triggers-controller-image


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Missed some files to update to use $(tt.params) while doing this PR https://github.com/tektoncd/plumbing/pull/494
And it caught after upgrading triggers version to 0.7.0 on dogfooding cluster and now all nightlies are failing because of this with below error

```
Warning  Failed         4m12s  PipelineRun  PipelineRun default/triggers-release-nightly-ppwl6 can't be Run; it tries to bind Resources that don't exist: error following resource reference for source-repo: pipelineresource.tekton.dev "git-source-$(params.projectName)-ppwl6" not found
``` 

/cc @afrittoli

Signed-off-by: Savita Ashture sashture@redhat.com

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._