### PR TITLE
Use tt.params in resourceSpec

### DIFF
--- a/tekton/ci/plumbing-template.yaml
+++ b/tekton/ci/plumbing-template.yaml
@@ -62,7 +62,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -101,7 +101,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -140,7 +140,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -179,7 +179,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -218,7 +218,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -257,7 +257,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -296,7 +296,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -335,7 +335,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -374,7 +374,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -450,7 +450,7 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
@@ -489,4 +489,4 @@ spec:
           - name: url
             value: $(tt.params.gitRepository)
           - name: depth
-            value: $(params.gitCloneDepth)
+            value: $(tt.params.gitCloneDepth)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It looks like the pipeline params is not replace into resource specs
so use the trigger template tt.params instead.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug