### PR TITLE
Stop creating pipeline resources in trigger templates

### DIFF
--- a/tekton/ci/kustomization.yaml
+++ b/tekton/ci/kustomization.yaml
@@ -12,6 +12,5 @@ resources:
 - plumbing-template.yaml
 - tekton-golang-lint.yaml
 - tekton-image-build.yaml
-- tekton-noop-check.yaml
 - tekton-yamllint.yaml
 - checks

--- a/tekton/mario-bot/mario-github-comment.yaml
+++ b/tekton/mario-bot/mario-github-comment.yaml
@@ -49,19 +49,6 @@ spec:
   - name: passedOrFailed
     description: Whether the triggering event was successful or not
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: pr-$(uid)
-    spec:
-      type: pullRequest
-      params:
-        - name: url
-          value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestID)
-      secrets:
-        - fieldName: authToken
-          secretName: mario-github-token
-          secretKey: GITHUB_TOKEN
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
@@ -146,12 +133,26 @@ spec:
               - name: url
                 value: $(tt.params.gitURL)
           - name: pr
-            resourceRef:
-              name: pr-$(uid)
+            resourceSpec:
+              type: pullRequest
+              params:
+                - name: url
+                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestID)
+              secrets:
+                - fieldName: authToken
+                  secretName: mario-github-token
+                  secretKey: GITHUB_TOKEN
         outputs:
           - name: image
             resourceRef:
               name: $(tt.params.targetImageResourceName)
           - name: pr
-            resourceRef:
-              name: pr-$(uid)
+            resourceSpec:
+              type: pullRequest
+              params:
+                - name: url
+                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestID)
+              secrets:
+                - fieldName: authToken
+                  secretName: mario-github-token
+                  secretKey: GITHUB_TOKEN

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -128,15 +128,6 @@ spec:
   - name: targetImage
     description: The fully qualifie image target e.g. repo/name:tag.
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: target-image-$(uid)
-    spec:
-      type: image
-      params:
-      - name: url
-        value: $(tt.params.targetImage)
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
@@ -193,8 +184,11 @@ spec:
                 value: https://$(tt.params.gitRepository)
         outputs:
           - name: image
-            resourceRef:
-              name: target-image-$(uid)
+            resourceSpec:
+              type: image
+              params:
+              - name: url
+                value: $(tt.params.targetImage)
           - name: endtrigger
             resourceRef:
               name: github-feedback-trigger

--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -35,17 +35,6 @@ spec:
   - name: configMapDescription
     description: Used for a descriptive TaskRun name
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: git-source-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(tt.params.gitRevision)
-      - name: url
-        value: https://$(tt.params.gitRepository)
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
@@ -115,8 +104,13 @@ spec:
       resources:
         inputs:
           - name: source
-            resourceRef:
-              name: git-source-$(uid)
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(tt.params.gitRevision)
+              - name: url
+                value: https://$(tt.params.gitRepository)
           - name: targetCluster
             resourceRef:
               name: $(tt.params.clusterResource)

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -36,17 +36,6 @@ spec:
     description: Whether the folder is a kustomize overlay "true" or "false"
     default: "false"
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: git-source-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(tt.params.gitRevision)
-      - name: url
-        value: https://$(tt.params.gitRepository)
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
@@ -123,8 +112,13 @@ spec:
       resources:
         inputs:
           - name: source
-            resourceRef:
-              name: git-source-$(uid)
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(tt.params.gitRevision)
+              - name: url
+                value: https://$(tt.params.gitRepository)
           - name: targetCluster
             resourceRef:
               name: $(tt.params.clusterResource)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -22,20 +22,6 @@ spec:
   - name: taskRunName
     description: The name of the task run that triggered this
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: pr-$(tt.params.checkStatus)-$(uid)
-      namespace: tektonci
-    spec:
-      type: pullRequest
-      params:
-        - name: url
-          value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestNumber)
-      secrets:
-        - fieldName: authToken
-          secretName: bot-token-github
-          secretKey: bot-token
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
@@ -96,9 +82,23 @@ spec:
       resources:
         inputs:
           - name: pr
-            resourceRef:
-              name: pr-$(tt.params.checkStatus)-$(uid)
+            resourceSpec:
+              type: pullRequest
+              params:
+                - name: url
+                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestNumber)
+              secrets:
+                - fieldName: authToken
+                  secretName: bot-token-github
+                  secretKey: bot-token
         outputs:
           - name: pr
-            resourceRef:
-              name: pr-$(tt.params.checkStatus)-$(uid)
+            resourceSpec:
+              type: pullRequest
+              params:
+                - name: url
+                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestNumber)
+              secrets:
+                - fieldName: authToken
+                  secretName: bot-token-github
+                  secretKey: bot-token

--- a/tekton/resources/nightly-release/base/template.yaml
+++ b/tekton/resources/nightly-release/base/template.yaml
@@ -21,18 +21,7 @@ spec:
   - apiVersion: tekton.dev/v1alpha1
     kind: PipelineResource
     metadata:
-      name: git-source-$(tt.params.projectName)-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(tt.params.gitrevision)
-      - name: url
-        value: http://$(tt.params.gitrepository)
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
+      name: tekton-bucket-nightly-$(tt.params.projectName)
     spec:
       params:
       - name: type

--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -19,11 +19,14 @@
         value: latest
       resources:
       - name: dashboard-source-repo
-        resourceRef:
-          name: git-source-$(tt.params.projectName)-$(uid)
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(tt.params.gitrevision)
       - name: bucket-for-dashboard
         resourceRef:
-          name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
+          name: tekton-bucket-nightly-$(tt.params.projectName)
       - name: builtDashboardImage
         resourceRef:
           name: dashboard-image

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -17,11 +17,16 @@
         value: $(tt.params.versionTag)
       resources:
       - name: source-repo
-        resourceRef:
-          name: git-source-$(tt.params.projectName)-$(uid)
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(tt.params.gitrevision)
+      - name: url
+        value: http://$(tt.params.gitrepository)
       - name: bucket
         resourceRef:
-          name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
+          name: tekton-bucket-nightly-$(tt.params.projectName)
       - name: builtBaseImage
         resourceRef:
           name: base-image

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -17,11 +17,14 @@
         value: $(tt.params.versionTag)
       resources:
       - name: source-repo
-        resourceRef:
-          name: git-source-$(tt.params.projectName)-$(uid)
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(tt.params.gitrevision)
       - name: bucket
         resourceRef:
-          name: tekton-bucket-nightly-$(tt.params.projectName)-$(uid)
+          name: tekton-bucket-nightly-$(tt.params.projectName)
       - name: builtControllerImage
         resourceRef:
           name: triggers-controller-image

--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -22,17 +22,6 @@ spec:
     description: The git repository url
   resourcetemplates:
   - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: community-git-$(uid)
-    spec:
-      type: git
-      params:
-      - name: revision
-        value: $(tt.params.gitrevision)
-      - name: url
-        value: $(tt.params.gitrepositoryurl)
-  - apiVersion: tekton.dev/v1alpha1
     kind: TaskRun
     metadata:
       generateName: peribolos-run-
@@ -42,8 +31,13 @@ spec:
       resources:
         inputs:
           - name: repo
-            resourceRef:
-              name: community-git-$(uid)
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(tt.params.gitrevision)
+              - name: url
+                value: $(tt.params.gitrepositoryurl)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: EventListener


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Until we stop using pipeline resources alltogether,
stop creating pipeline resources in the cluster, embed them
instead wherever possible in the *run definitions.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind cleanup
/cc @vdemeester 