### PR TITLE
Use embedded storage resources for nightly releases

### DIFF
--- a/tekton/resources/nightly-release/base/template.yaml
+++ b/tekton/resources/nightly-release/base/template.yaml
@@ -17,21 +17,3 @@ spec:
     default: gcr.io/tekton-nightly
   - name: projectName
     description: Name of the Tekton project to release (e.g. pipeline, triggers, etc).
-  resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: PipelineResource
-    metadata:
-      name: tekton-bucket-nightly-$(tt.params.projectName)
-    spec:
-      params:
-      - name: type
-        value: gcs
-      - name: location
-        value: gs://tekton-releases-nightly/$(tt.params.projectName)
-      - name: dir
-        value: "y"
-      type: storage
-      secrets:
-      - fieldName: GOOGLE_APPLICATION_CREDENTIALS
-        secretKey: service-account.json
-        secretName: nightly-account

--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -1,32 +1,44 @@
 - op: add
-  path: "/spec/resourcetemplates/-"
+  path: "/spec/"
   value:
-    apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
-    metadata:
-      name: dashboard-release-nightly-$(uid)
-    spec:
-      pipelineRef:
-        name: dashboard-release
-      params:
-      - name: package
-        value: $(tt.params.gitrepository)
-      - name: imageRegistry
-        value: gcr.io/tekton-nightly
-      - name: versionTag
-        value: $(tt.params.versionTag)
-      - name: bucketName
-        value: latest
-      resources:
-      - name: dashboard-source-repo
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: $(tt.params.gitrevision)
-      - name: bucket-for-dashboard
-        resourceRef:
-          name: tekton-bucket-nightly-$(tt.params.projectName)
-      - name: builtDashboardImage
-        resourceRef:
-          name: dashboard-image
+    resourcetemplates:
+    - apiVersion: tekton.dev/v1beta   
+      kind: PipelineRun
+      metadata:
+        name: dashboard-release-nightly-$(uid)
+      spec:
+        pipelineRef:
+          name: dashboard-release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: imageRegistry
+          value: gcr.io/tekton-nightly
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        - name: bucketName
+          value: latest
+        resources:
+        - name: dashboard-source-repo
+          resourceSpec:
+            type: git
+            params:
+            - name: revision
+              value: $(tt.params.gitrevision)
+        - name: bucket-for-dashboard
+          resourceSpec:
+            type: storage
+            params:
+            - name: type
+              value: gcs
+            - name: location
+              value: gs://tekton-releases-nightly/$(tt.params.projectName)
+            - name: dir
+              value: "y"
+            secrets:
+            - fieldName: GOOGLE_APPLICATION_CREDENTIALS
+              secretKey: service-account.json
+              secretName: nightly-account
+        - name: builtDashboardImage
+          resourceRef:
+            name: dashboard-image

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -1,65 +1,77 @@
 - op: add
-  path: "/spec/resourcetemplates/-"
+  path: "/spec/"
   value:
-    apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
-    metadata:
-      name: pipeline-release-nightly-$(uid)
-    spec:
-      pipelineRef:
-        name: pipeline-release-nightly
-      params:
-      - name: package
-        value: $(tt.params.gitrepository)
-      - name: imageRegistry
-        value: gcr.io/tekton-nightly
-      - name: versionTag
-        value: $(tt.params.versionTag)
-      resources:
-      - name: source-repo
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: $(tt.params.gitrevision)
-      - name: url
-        value: http://$(tt.params.gitrepository)
-      - name: bucket
-        resourceRef:
-          name: tekton-bucket-nightly-$(tt.params.projectName)
-      - name: builtBaseImage
-        resourceRef:
-          name: base-image
-      - name: builtEntrypointImage
-        resourceRef:
-          name: entrypoint-image
-      - name: builtNopImage
-        resourceRef:
-          name: nop-image
-      - name: builtKubeconfigWriterImage
-        resourceRef:
-          name: kubeconfigwriter-image
-      - name: builtCredsInitImage
-        resourceRef:
-          name: creds-init-image
-      - name: builtGitInitImage
-        resourceRef:
-          name: git-init-image
-      - name: builtControllerImage
-        resourceRef:
-          name: controller-image
-      - name: builtWebhookImage
-        resourceRef:
-          name: webhook-image
-      - name: builtDigestExporterImage
-        resourceRef:
-          name: digest-exporter-image
-      - name: builtPullRequestInitImage
-        resourceRef:
-          name: pull-request-init-image
-      - name: builtGcsFetcherImage
-        resourceRef:
-          name: gcs-fetcher-image
-      - name: notification
-        resourceRef:
-          name: post-nightly-release-trigger
+    resourcetemplates:
+    - apiVersion: tekton.dev/v1beta
+      kind: PipelineRun
+      metadata:
+        name: pipeline-release-nightly-$(uid)
+      spec:
+        pipelineRef:
+          name: pipeline-release-nightly
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: imageRegistry
+          value: gcr.io/tekton-nightly
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        resources:
+        - name: source-repo
+          resourceSpec:
+            type: git
+            params:
+            - name: revision
+              value: $(tt.params.gitrevision)
+        - name: url
+          value: http://$(tt.params.gitrepository)
+        - name: bucket
+          resourceSpec:
+            type: storage
+            params:
+            - name: type
+              value: gcs
+            - name: location
+              value: gs://tekton-releases-nightly/$(tt.params.projectName)
+            - name: dir
+              value: "y"
+            secrets:
+            - fieldName: GOOGLE_APPLICATION_CREDENTIALS
+              secretKey: service-account.json
+              secretName: nightly-account
+        - name: builtBaseImage
+          resourceRef:
+            name: base-image
+        - name: builtEntrypointImage
+          resourceRef:
+            name: entrypoint-image
+        - name: builtNopImage
+          resourceRef:
+            name: nop-image
+        - name: builtKubeconfigWriterImage
+          resourceRef:
+            name: kubeconfigwriter-image
+        - name: builtCredsInitImage
+          resourceRef:
+            name: creds-init-image
+        - name: builtGitInitImage
+          resourceRef:
+            name: git-init-image
+        - name: builtControllerImage
+          resourceRef:
+            name: controller-image
+        - name: builtWebhookImage
+          resourceRef:
+            name: webhook-image
+        - name: builtDigestExporterImage
+          resourceRef:
+            name: digest-exporter-image
+        - name: builtPullRequestInitImage
+          resourceRef:
+            name: pull-request-init-image
+        - name: builtGcsFetcherImage
+          resourceRef:
+            name: gcs-fetcher-image
+        - name: notification
+          resourceRef:
+            name: post-nightly-release-trigger

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -1,39 +1,51 @@
 - op: add
-  path: "/spec/resourcetemplates/-"
+  path: "/spec/"
   value:
-    apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
-    metadata:
-      name: triggers-release-nightly-$(uid)
-    spec:
-      pipelineRef:
-        name: triggers-release
-      params:
-      - name: package
-        value: $(tt.params.gitrepository)
-      - name: imageRegistry
-        value: gcr.io/tekton-nightly
-      - name: versionTag
-        value: $(tt.params.versionTag)
-      resources:
-      - name: source-repo
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: $(tt.params.gitrevision)
-      - name: bucket
-        resourceRef:
-          name: tekton-bucket-nightly-$(tt.params.projectName)
-      - name: builtControllerImage
-        resourceRef:
-          name: triggers-controller-image
-      - name: builtWebhookImage
-        resourceRef:
-          name: triggers-webhook-image
-      - name: builtEventListenerSinkImage
-        resourceRef:
-          name: event-listener-sink-image
-      - name: notification
-        resourceRef:
-          name: post-nightly-release-trigger
+    resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        name: triggers-release-nightly-$(uid)
+      spec:
+        pipelineRef:
+          name: triggers-release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: imageRegistry
+          value: gcr.io/tekton-nightly
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        resources:
+        - name: source-repo
+          resourceSpec:
+            type: git
+            params:
+            - name: revision
+              value: $(tt.params.gitrevision)
+        - name: bucket
+          resourceSpec:
+            type: storage
+            params:
+            - name: type
+              value: gcs
+            - name: location
+              value: gs://tekton-releases-nightly/$(tt.params.projectName)
+            - name: dir
+              value: "y"
+            secrets:
+            - fieldName: GOOGLE_APPLICATION_CREDENTIALS
+              secretKey: service-account.json
+              secretName: nightly-account
+        - name: builtControllerImage
+          resourceRef:
+            name: triggers-controller-image
+        - name: builtWebhookImage
+          resourceRef:
+            name: triggers-webhook-image
+        - name: builtEventListenerSinkImage
+          resourceRef:
+            name: event-listener-sink-image
+        - name: notification
+          resourceRef:
+            name: post-nightly-release-trigger


### PR DESCRIPTION
# Changes

The nightly releases were previously creating a new storage resource for each
run.  This was changed in #514 to re-use the same per project bucket for each
run. However, we still had the PipelineResource in the nightly TriggerTemplate
which means Triggers will try to create the same PipelineResource on each run
-- and in the process fail because the resource already existed.

This commit fixes the error by changing the nightly pipelinerun templates to
use an embedded storage resource.

Found while investigating #516

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._