### PR TITLE
prow: fix query for stale, rotten and close issues

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1684,7 +1684,7 @@ periodics:
       - |-
         --query=org:tektoncd
         -label:lifecycle/frozen
-        -label:lifecycle/stale
+        label:lifecycle/stale
         -label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/github-token/oauth
@@ -1719,8 +1719,8 @@ periodics:
       - |-
         --query=org:tektoncd
         -label:lifecycle/frozen
-        -label:lifecycle/stale
-        -label:lifecycle/rotten
+        label:lifecycle/stale
+        label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/github-token/oauth
       - |-


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

As of today, an issue is close after 30 days (without necessarly been
rotten) because it does filter them out. Same for lifecycle/rotten, it
does not do 30 + 90 days, but only 90 days.

It seemed there was way too much issue being closed :sweat_smile: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

/cc @jerop @afrittoli @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._