### PR TITLE
Add git url to templates for nightlies

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -25,6 +25,8 @@
             params:
             - name: revision
               value: $(tt.params.gitrevision)
+            - name: url
+              value: https://$(tt.params.gitrepository)
         - name: bucket-for-dashboard
           resourceSpec:
             type: storage

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -23,8 +23,8 @@
             params:
             - name: revision
               value: $(tt.params.gitrevision)
-        - name: url
-          value: http://$(tt.params.gitrepository)
+            - name: url
+              value: https://$(tt.params.gitrepository)
         - name: bucket
           resourceSpec:
             type: storage

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -23,6 +23,8 @@
             params:
             - name: revision
               value: $(tt.params.gitrevision)
+            - name: url
+              value: https://$(tt.params.gitrepository)
         - name: bucket
           resourceSpec:
             type: storage


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The url for the git resources for each of the nightlies is
missing from the trigger template. The nightlies are
currently failing with errors like this:

```
Error running git [fetch --recurse-submodules=yes --depth=1 origin
--update-head-ok --force f39feca70117455dbd765cdb9a3c8fbcad134977]: exit
status 128\nfatal: no path specified; see 'git help pull' for valid url
syntax
```

This commit adds the url to the git resources from the
base trigger template's parameters.

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)