### PR TITLE
Fix json patch path for templates

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -1,5 +1,5 @@
 - op: add
-  path: "/spec/"
+  path: "/spec"
   value:
     resourcetemplates:
     - apiVersion: tekton.dev/v1beta

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -1,5 +1,5 @@
 - op: add
-  path: "/spec/"
+  path: "/spec"
   value:
     resourcetemplates:
     - apiVersion: tekton.dev/v1beta

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -1,5 +1,5 @@
 - op: add
-  path: "/spec/"
+  path: "/spec"
   value:
     resourcetemplates:
     - apiVersion: tekton.dev/v1beta1


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The earlier path ("/spec/") would mean that resources would contain an
"" field i.e.

```
spec:
  "":
    resourcetemplates:
```

Thanks @sbwsg for finding this!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._