### PR TITLE
Fixup apiVersion appearing in resourceTemplates

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -2,7 +2,7 @@
   path: "/spec"
   value:
     resourcetemplates:
-    - apiVersion: tekton.dev/v1beta
+    - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
         name: dashboard-release-nightly-$(uid)

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -2,7 +2,7 @@
   path: "/spec"
   value:
     resourcetemplates:
-    - apiVersion: tekton.dev/v1beta
+    - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
         name: pipeline-release-nightly-$(uid)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There's a typo in the apiVersions of the resourceTemplates for dashboard
and pipeline TriggerTemplates.

This commit fixes those typos. v1beta -> v1beta1

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
