### PR TITLE
Update TriggerTemplate overlays to use different path

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -1,7 +1,6 @@
 - op: add
-  path: "/spec"
+  path: /spec/resourcetemplates
   value:
-    resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -1,7 +1,6 @@
 - op: add
-  path: "/spec"
+  path: /spec/resourcetemplates
   value:
-    resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -1,7 +1,6 @@
 - op: add
-  path: "/spec"
+  path: /spec/resourcetemplates
   value:
-    resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #526 

Problem statement: At the moment our nightly TriggerTemplates are
built without a crucial `params` field that is defined in the base TriggerTemplate.
This means our nightlies aren't building - the params include information like
the correct git repo to fetch.

The current path in the nightly TriggerTemplate overlays is
"/spec". Using this path causes the spec field of the base
template to be completely replaced. The spec field of the base
includes a "params" field that we want to keep in each built
TriggerTemplate. Replacing "/spec" means we lose the "params" field.

This commit changes the path to "/spec/resourcetemplates" and
updates the value to be an array entry. The result is that the
final built document includes both the base template's params
field as well as the overlay's resourcetemplates entry.

HOWEVER, this effectively rolls back a change made in 46137f0
and I'm not entirely sure that this is therefore a good idea.
I might be re-introducing a broken behaviour from before that
commit was made. Therefore I'm creating this PR to seek input
from others on whether this is incorrect since my knowledge of
JSON Patching and of these templates is somewhat limited.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/kind bug