### PR TITLE
Add a custom interceptor for team members

### DIFF
--- a/tekton/ci/bindings.yaml
+++ b/tekton/ci/bindings.yaml
@@ -57,3 +57,13 @@ spec:
     value: $(body.add_pr_body.pull_request_body.number)
   - name: gitHubCommand
     value: $(body.comment.body)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-webhook-tektoncd-comment
+  namespace: tektonci
+spec:
+  params:
+  - name: gitHubCommand
+    value: $(body.comment.body)

--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -88,3 +88,37 @@ spec:
         - ref: tekton-ci-pr-number-extension
       template:
         name: check-pull-request-labels
+    - name: cd-trigger
+      interceptors:
+        - github:
+            secretRef:
+              secretName: ci-webhook
+              secretKey: secret
+            eventTypes:
+              - issue_comment
+        - cel:
+            filter: >-
+              body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'catalog', 'hub'] &&
+              body.action == 'created' &&
+              'pull_request' in body.issue &&
+              body.issue.state == 'open' &&
+              body.comment.body.matches('^/tektoncd($| [^ ]*[ ]*$)')
+            overlays:
+            - key: add_team_members.org_base_url
+              expression: "body.organization.url"
+            - key: add_team_members.team
+              expression: "body.repository.name"
+        - webhook:
+            objectRef:
+              kind: Service
+              name: add-team-member
+              apiVersion: v1
+              namespace: tektonci
+        - cel:
+            filter: >-
+              body.comment.user.login in body.add_team_members.maintainers_team_members
+      bindings:
+        - ref: tekton-ci-github-base
+        - ref: tekton-ci-webhook-tektoncd-comment
+      template:
+        name: tekton-cd-triggers

--- a/tekton/ci/interceptors/add-team-members/README.md
+++ b/tekton/ci/interceptors/add-team-members/README.md
@@ -1,0 +1,81 @@
+# Add Team Members
+
+`add-team-members` is a custom interceptor for Tekton Triggers that enriches the
+payload of an incoming request with the list of public members of the org as well
+as the list of maintainers for the project.
+
+## Interface
+
+`add-team-members` expects the URL to the PR representation to be included in the
+incoming JSON as follows:
+
+```json
+{
+  "add_team_members":
+  {
+    "org_base_url": "https://api.github.com/repos/tektoncd/",
+    "team": "plumbing"
+  },
+  "other-keys": "other=values"
+}
+```
+
+It returns the original JSON payload untouched, with the addition of the PR:
+
+```json
+{
+  "add_team_members":
+  {
+    "org_base_url": "https://api.github.com/repos/tektoncd/",
+    "team": "plumbing",
+    "public_org_members": ["a", "b", "c"],
+    "maintainers_team_members": ["a", "b"],
+  },
+  "other-keys": "other=values"
+}
+```
+
+HTTP Headers are left untouched.
+
+## Example usage:
+
+A trigger in an event listener:
+
+```yaml
+- name: comment-trigger
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - issue_comment
+    - cel:
+        filter: >-
+          body.action == 'created' &&
+          in('pull_request', body.issue) &&
+          && body.issue.state == 'open' &&
+          body.comment.body.matches('^/test($| [^ ]*$)')
+        overlays:
+        - key: add_team_members.org_base_url
+          expression: "body.organization.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-team-member
+          apiVersion: v1
+          namespace: tektonci
+    - cel:
+        filter: >-
+          body.comment.user.login in body.add_team_members.maintainers_team_members
+```
+
+## Installation
+
+The interceptor is installed via `ko`:
+```
+export KO_DOCKER_REPO=gcr.io/tekton-releases/dogfooding
+ko apply -P -f tekton/ci/interceptors/add-team-members/config/
+```
+
+Eventually it should be included in nightly releases and installed from there.

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/kodata/LICENSE
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/kodata/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main.go
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main.go
@@ -1,0 +1,261 @@
+/*
+ Copyright 2020 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+type triggerErrorPayload struct {
+	Error string `json:"errorMessage,omitempty"`
+}
+
+type urlToList func(string, string) ([]string, error)
+
+const (
+	rootAddTeamMembersKey = "add_team_members"
+	orgUrlKey             = "org_base_url"
+	teamKey               = "team"
+	orgMembersKey         = "public_org_members"
+	teamMembersKey        = "maintainers_team_members"
+	publicMembersPath     = "%s/public_members"
+	teamPath              = "%s/teams/%s-maintainers/members"
+)
+
+func main() {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		fmt.Println("missing required environment variable GITHUB_TOKEN")
+		os.Exit(1)
+	}
+	http.HandleFunc("/", makeAddTeamMembersHandler(fetchMembers, fetchMembers, token))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", 8080), nil))
+}
+
+func makeAddTeamMembersHandler(orgMembersFetcher, teamMembersFetcher urlToList, token string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		var payload []byte
+		var err error
+
+		// Get the payload
+		if r.Body != nil {
+			defer r.Body.Close()
+			payload, err = ioutil.ReadAll(r.Body)
+			if err != nil {
+				log.Printf("failed to read request body: %q", err)
+				marshalError(err, w)
+				return
+			}
+			if len(payload) == 0 {
+				bodyError := errors.New("empty body, cannot add team members")
+				log.Printf("No body received: %q", bodyError)
+				marshalError(bodyError, w)
+				return
+			}
+		} else {
+			bodyError := errors.New("empty body, cannot add team members")
+			log.Printf("failed to read request body: %q", err)
+			marshalError(bodyError, w)
+			return
+		}
+
+		// Get the json body
+		jsonBody, err := decodeMapBody(payload)
+		if err != nil {
+			log.Printf("failed to decode the body: %q", err)
+			marshalError(err, w)
+			return
+		}
+		// Get the org URL from the body
+		orgUrl, err := getOrgUrl(jsonBody)
+		if err != nil {
+			log.Printf("failed to extract the Org URL from the body: %q", err)
+			marshalError(err, w)
+			return
+		}
+		// Get the list of org members from the URL
+		orgMembers, err := orgMembersFetcher(orgUrl, "")
+		if err != nil {
+			log.Printf("failed to get the list of org members: %q", err)
+			marshalError(err, w)
+			return
+		}
+		// Add the PR body to the original body
+		jsonBody[rootAddTeamMembersKey].(map[string]interface{})[orgMembersKey] = orgMembers
+		// Get the team URL from the body
+		teamUrl, err := getTeamUrl(jsonBody)
+		if err != nil {
+			log.Printf("failed to extract the Team URL from the body: %q", err)
+			marshalError(err, w)
+			return
+		}
+		// Get the list of org members from the URL
+		teamMembers, err := teamMembersFetcher(teamUrl, token)
+		if err != nil {
+			log.Printf("failed to get the list of team members: %q", err)
+			marshalError(err, w)
+			return
+		}
+		// Add the PR body to the original body
+		jsonBody[rootAddTeamMembersKey].(map[string]interface{})[teamMembersKey] = teamMembers
+
+		// Marshal the body
+		responseBytes, err := json.Marshal(jsonBody)
+		if err != nil {
+			log.Printf("failed marshal the response body: %q", err)
+			marshalError(err, w)
+			return
+		}
+		// Set all the original headers
+		for k, values := range r.Header {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+		// Write the response
+		n, err := w.Write(responseBytes)
+		if err != nil {
+			log.Printf("Failed to write response. Bytes written: %d. Error: %q", n, err)
+		}
+	}
+}
+
+func marshalError(err error, w http.ResponseWriter) {
+	if err != nil {
+		triggerBody := triggerErrorPayload{
+			Error: err.Error(),
+		}
+		tPayload, err := json.Marshal(triggerBody)
+		if err != nil {
+			log.Printf("Failed to marshal the trigger body. Error: %q", err)
+			http.Error(w, "{}", http.StatusBadRequest)
+			return
+		}
+		http.Error(w, string(tPayload[:]), http.StatusBadRequest)
+	}
+}
+
+func decodeMapBody(body []byte) (map[string]interface{}, error) {
+	var jsonMap map[string]interface{}
+	err := json.Unmarshal(body, &jsonMap)
+	if err != nil {
+		return nil, err
+	}
+	return jsonMap, nil
+}
+
+func decodeListBody(body []byte) ([]interface{}, error) {
+	var jsonList []interface{}
+	err := json.Unmarshal(body, &jsonList)
+	if err != nil {
+		return nil, err
+	}
+	return jsonList, nil
+}
+
+func getTeamMemberValue(key string, body map[string]interface{}) (string, error) {
+	addTeamMember, ok := body[rootAddTeamMembersKey]
+	if !ok {
+		return "", errors.New("no 'add-team-member' found in the body")
+	}
+	value, ok := addTeamMember.(map[string]interface{})[key]
+	if !ok {
+		return "", fmt.Errorf("no '%s' found", key)
+	}
+	valueString, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("'%s' found, but not a string", key)
+	}
+	return valueString, nil
+}
+
+func getOrgBaseUrl(body map[string]interface{}) (string, error) {
+	return getTeamMemberValue(orgUrlKey, body)
+}
+
+func getTeam(body map[string]interface{}) (string, error) {
+	return getTeamMemberValue(teamKey, body)
+}
+
+func getOrgUrl(body map[string]interface{}) (string, error) {
+	baseUrl, err := getOrgBaseUrl(body)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(publicMembersPath, baseUrl), nil
+}
+
+func getTeamUrl(body map[string]interface{}) (string, error) {
+	baseUrl, err := getOrgBaseUrl(body)
+	if err != nil {
+		return "", err
+	}
+	teamName, err := getTeam(body)
+	if err != nil {
+		return "", err
+	}
+	// Pipeline's maintainer team is called "core-maintainers"
+	if teamName == "pipeline" {
+		teamName = "core"
+	}
+	return fmt.Sprintf(teamPath, baseUrl, teamName), nil
+}
+
+func fetchMembers(membersUrl, token string) ([]string, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", membersUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("token %s", token))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	decodedBody, err := decodeListBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("Error decoding body %v to a list: %q", string(body[:]), err)
+	}
+
+	members := []string{}
+	for _, member := range decodedBody {
+		value, ok := member.(map[string]interface{})["login"]
+		if !ok {
+			return nil, fmt.Errorf("no \"login\" found in %v", member)
+		}
+		login, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("\"login\" %s found in %v, but not a string", value, member)
+		}
+		members = append(members, login)
+	}
+	return members, nil
+}

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main_test.go
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main_test.go
@@ -1,0 +1,213 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEmptyBody(t *testing.T) {
+	r := createRequest("POST", "/", "issue_comment", nil)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBody, getTestAddTeamMemberBody, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	assertBadRequestResponse(t, w, "empty body, cannot add team members")
+}
+
+func TestNoAddTeamMemberBody(t *testing.T) {
+	body := marshalEvent(t, makeTeamBody(false, "", ""))
+	r := createRequest("POST", "/", "issue_comment", body)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBody, getTestAddTeamMemberBody, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	assertBadRequestResponse(t, w, "no 'add-team-member' found in the body")
+}
+
+func TestNoOrgUrlFound(t *testing.T) {
+	body := marshalEvent(t, makeTeamBody(true, "", ""))
+	r := createRequest("POST", "/", "issue_comment", body)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBody, getTestAddTeamMemberBody, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	assertBadRequestResponse(t, w, "no 'org_base_url' found")
+}
+
+func TestNoTeamUrlFound(t *testing.T) {
+	body := marshalEvent(t, makeTeamBody(true, "foo://some_url", ""))
+	r := createRequest("POST", "/", "issue_comment", body)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBody, getTestAddTeamMemberBody, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	assertBadRequestResponse(t, w, "no 'team' found")
+}
+
+func TestCannotFetchOrgURL(t *testing.T) {
+	body := marshalEvent(t, makeTeamBody(true, "foo://some_url", ""))
+	r := createRequest("POST", "/", "issue_comment", body)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBodyError, getTestAddTeamMemberBody, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	assertBadRequestResponse(t, w, "something went wrong")
+}
+
+func TestCannotTeamURL(t *testing.T) {
+	body := marshalEvent(t, makeTeamBody(true, "foo://some_url", "team1"))
+	r := createRequest("POST", "/", "issue_comment", body)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBody, getTestAddTeamMemberBodyError, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	assertBadRequestResponse(t, w, "something went wrong")
+}
+
+func TestFetchURL(t *testing.T) {
+	body := marshalEvent(t, makeTeamBody(true, "foo://some_url", "team1"))
+	r := createRequest("POST", "/", "issue_comment", body)
+	h := makeAddTeamMembersHandler(getTestAddTeamMemberBody, getTestAddTeamMemberBody, "token")
+	w := httptest.NewRecorder()
+
+	h(w, r)
+
+	want := makeTeamBody(true, "foo://some_url", "team1")
+	wantTeamBody := []interface{}{string("foo"), string("bar")}
+	(*want)[rootAddTeamMembersKey].(map[string]interface{})[orgMembersKey] = wantTeamBody
+	(*want)[rootAddTeamMembersKey].(map[string]interface{})[teamMembersKey] = wantTeamBody
+
+	resp := w.Result()
+
+	assertResponsePayload(t, resp, &want)
+}
+
+func TestDecodeListBody(t *testing.T) {
+	body := marshalEvent(t, []string{"foo", "bar"})
+	want := []interface{}{string("foo"), string("bar")}
+	got, err := decodeListBody(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("compare failed: %s\n", diff)
+	}
+}
+
+// creates a GitHub hook type request - no secret is provided in testing.
+func createRequest(method, url, event string, body []byte, opts ...requestOption) *http.Request {
+	req := httptest.NewRequest(method, url, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Github-Event", event)
+	req.Header.Set("X-Github-Delivery", "testing-123")
+	for _, o := range opts {
+		o(req)
+	}
+	return req
+}
+
+type requestOption func(*http.Request)
+
+func marshalEvent(t *testing.T, evt interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func makeTeamBody(base bool, url, team string) *map[string]interface{} {
+	teamAddBody := make(map[string]interface{})
+	if !base {
+		return &teamAddBody
+	}
+	var teamAddBodyContent map[string]interface{}
+	if url == "" {
+		teamAddBodyContent = map[string]interface{}{"foo": "bar"}
+	} else {
+		teamAddBodyContent = map[string]interface{}{orgUrlKey: url}
+	}
+	if team == "" {
+		teamAddBodyContent["foo2"] = "bar2"
+	} else {
+		teamAddBodyContent[teamKey] = team
+	}
+	teamAddBody[rootAddTeamMembersKey] = teamAddBodyContent
+	return &teamAddBody
+}
+
+func getTestAddTeamMemberBody(url, token string) ([]string, error) {
+	return []string{"foo", "bar"}, nil
+}
+
+func getTestAddTeamMemberBodyError(url, token string) ([]string, error) {
+	return nil, errors.New("something went wrong")
+}
+
+func assertResponseStatus(t *testing.T, resp *http.Response, want int) {
+	t.Helper()
+	if resp.StatusCode != want {
+		t.Fatalf("incorrect response: got %v, want %v", resp.StatusCode, want)
+	}
+}
+
+func assertResponsePayload(t *testing.T, resp *http.Response, v interface{}, opts ...cmp.Option) {
+	t.Helper()
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This assumes that v is a pointer to a type, and unmarshals to a new value
+	// of that type for the purposes of comparison.
+	objType := reflect.TypeOf(v).Elem()
+	obj := reflect.New(objType).Interface()
+	err = json.Unmarshal(body, &obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(obj, v, opts...); diff != "" {
+		t.Fatalf("compare failed: %s\n", diff)
+	}
+}
+
+func assertBadRequestResponse(t *testing.T, rr *httptest.ResponseRecorder, s string) {
+	resp := rr.Result()
+	assertResponseStatus(t, resp, http.StatusBadRequest)
+	assertResponsePayload(t, resp, makeErrorResponse(s))
+}
+
+func makeErrorResponse(s string) *triggerErrorPayload {
+	return &triggerErrorPayload{Error: s}
+}

--- a/tekton/ci/interceptors/add-team-members/config/100-namespace.yaml
+++ b/tekton/ci/interceptors/add-team-members/config/100-namespace.yaml
@@ -1,0 +1,18 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tektonci

--- a/tekton/ci/interceptors/add-team-members/config/200-serviceaccount.yaml
+++ b/tekton/ci/interceptors/add-team-members/config/200-serviceaccount.yaml
@@ -1,0 +1,19 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: add-team-member-bot
+  namespace: tektonci

--- a/tekton/ci/interceptors/add-team-members/config/add-team-members.yaml
+++ b/tekton/ci/interceptors/add-team-members/config/add-team-members.yaml
@@ -1,0 +1,53 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: add-team-member
+  namespace: tektonci
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: add-team-member
+  template:
+    metadata:
+      labels:
+        app: add-team-member
+    spec:
+      serviceAccountName: add-team-member-bot
+      containers:
+        - name: add-team-member-interceptor
+          image: ko://github.com/tektoncd/plumbing/tekton/ci/interceptors/add-team-members/cmd/add-team-members
+          env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: bot-token-github
+                key: bot-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: add-team-member
+  namespace: tektonci
+spec:
+  type: ClusterIP
+  selector:
+    app: add-team-member
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/tekton/ci/kustomization.yaml
+++ b/tekton/ci/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ingress.yaml
 - jobs.yaml
 - plumbing-template.yaml
+- tekton-cd-template.yaml
 - tekton-golang-lint.yaml
 - tekton-image-build.yaml
 - tekton-yamllint.yaml

--- a/tekton/ci/tekton-cd-template.yaml
+++ b/tekton/ci/tekton-cd-template.yaml
@@ -1,0 +1,38 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-cd-triggers
+  namespace: tektonci
+spec:
+  params:
+  - name: buildUUID
+    description: UUID used to track a CI Pipeline Run in logs
+  - name: package
+    description: org/repo
+  - name: pullRequestNumber
+    description: The pullRequestNumber
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: gitHubCommand
+    description: |
+      The GitHub command that was used a trigger. This is only available when
+      this template is triggered by a comment. The default value is for the
+      case of a pull_request event.
+    default: ""
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: cd-echo-test-$(uid)
+      labels:
+        tekton.dev/kind: cd
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      taskSpec:
+        steps:
+        - name: echo
+          image: busybox
+          script: |
+            echo "Executing $(tt.params.gitHubCommand)"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a custom interceptor for team members

Add a custom interceptor that fetches the public list of members
and private least of maintainer team members for the org/project
in the payload.

The interceptor can be used in combination with existing event
listener to add filters that only allow certain pipeline to be
executed by owners or org members.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature