### PR TITLE
Stop using log app in CI links and improve dashboard link

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -105,7 +105,8 @@ spec:
               header.match('ce-type', 'dev.tekton.event.taskrun.started.v1') &&
               body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels)
+              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
+              !('ownerReferences' in body.taskRun.metadata)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
         - ref: tekton-ci-check-pending
@@ -119,9 +120,41 @@ spec:
               header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')) &&
               body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels)
+              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
+              !('ownerReferences' in body.taskRun.metadata)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
         - ref: tekton-ci-check-complete
+      template:
+        name: tekton-ci-github-check-update
+    - name: github-check-start-with-owner
+      interceptors:
+        - cel:
+            filter: >-
+              header.match('ce-type', 'dev.tekton.event.taskrun.started.v1') &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
+              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
+              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
+              'ownerReferences' in body.taskRun.metadata
+      bindings:
+        - ref: tekton-ci-taskrun-cloudevent
+        - ref: tekton-ci-check-pending
+        - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+      template:
+        name: tekton-ci-github-check-update
+    - name: github-check-done-with-owner
+      interceptors:
+        - cel:
+            filter: >-
+              (header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') ||
+              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')) &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
+              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
+              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
+              'ownerReferences' in body.taskRun.metadata
+      bindings:
+        - ref: tekton-ci-taskrun-cloudevent
+        - ref: tekton-ci-check-complete
+        - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
       template:
         name: tekton-ci-github-check-update

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -16,6 +16,8 @@ spec:
     value: $(body.taskRun.status.conditions[?(@.type == 'Succeeded')].status)
   - name: taskRunName
     value: $(body.taskRun.metadata.name)
+  - name: taskRunNamespace
+    value: $(body.taskRun.metadata.namespace)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -38,3 +40,14 @@ spec:
     value: complete
   - name: checkDescription
     value: "Job Finished."
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-taskrun-from-pipelinerun-cloudevent
+spec:
+  params:
+  - name: parentPipelineRunName
+    value: $(body.taskRun.metadata.ownerReferences[?(@.kind == 'PipelineRun')].name)
+  - name: parentPipelineRunTaskName
+    value: $(body.taskRun.metadata.labels.tekton\.dev/pipelineTask)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -21,6 +21,14 @@ spec:
     description: Whether the triggering event was successful or not
   - name: taskRunName
     description: The name of the task run that triggered this
+  - name: taskRunNamespace
+    description: The namespace where the CI job was executed
+  - name: parentPipelineRunName
+    description: The name of the parent pipeline run - if any
+    default: ""
+  - name: parentPipelineRunTaskName
+    description: The name of the task in the parent pipeline run - if any
+    default: ""
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
@@ -48,7 +56,7 @@ spec:
             #!/bin/sh
             mkdir -p $(resources.outputs.pr.path)
             cp -r $(resources.inputs.pr.path)/* $(resources.outputs.pr.path)/
-        - name: setup-comment
+        - name: update-check-status
           image: python:3-alpine
           script: |
             #!/usr/bin/env python
@@ -56,17 +64,18 @@ spec:
             import random
 
             check_status = "$(tt.params.checkStatus)"
-
-            if (check_status == "complete"):
-              logs_url = 'http://logs.dogfooding.tekton.dev/?buildid=$(tt.params.buildUUID)&namespace=tektonci'
-              if ("$(tt.params.checkResult)" == "True"):
-                check_status = "success"
-              elif ("$(tt.params.checkResult)" == "False"):
-                check_status = "failure"
-              else:
-                check_status = "error"
+            if "$(params.parentPipelineRunName)" == "":
+              resource_path = "taskruns/$(params.taskRunName)"
             else:
-              logs_url = 'https://dashboard.dogfooding.tekton.dev/#/namespaces/tektonci/taskruns/$(tt.params.taskRunName)'
+              resource_path = "pipelineruns/$(params.parentPipelineRunName)?pipelineTask=$(params.parentPipelineRunTaskName)"
+
+            if ("$(tt.params.checkResult)" == "True"):
+              check_status = "success"
+            elif ("$(tt.params.checkResult)" == "False"):
+              check_status = "failure"
+            else:
+              check_status = "error"
+            logs_url = 'https://dashboard.dogfooding.tekton.dev/#/namespaces/$(params.taskRunNamespace)/' + resource_path
 
             # Build Status
             status_body = dict(


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The log app is taking too much time to load, so revert to
the dashboard even after a CI job is completed, at least
until we have a working alternative.

Improve the link to the dashboard to point to a pipelinerun
(when available) and to the specific pipeline task instead
of always pointing to the the taskrun directly.

This gives visibility into the checks that were executed too.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind cleanup