### PR TITLE
Update boskos images to latest

### DIFF
--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -153,7 +153,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200213-a79910c4a
+        image: gcr.io/k8s-staging-boskos/boskos:v20200819-984516e
         args:
         - --storage=/store/boskos.json
         - --config=/etc/config/config
@@ -229,7 +229,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-prow/boskos/janitor:v20200213-1586d3041
+        image: gcr.io/k8s-staging-boskos/janitor:v20200819-984516e
         args:
         - --resource-type=gke-project
         - --pool-size=10
@@ -264,6 +264,6 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-prow/boskos/reaper:v20200213-1586d3041
+        image: gcr.io/k8s-staging-boskos/reaper:v20200819-984516e
         args:
         - --resource-type=gke-project


### PR DESCRIPTION
# Changes

The current boskos janitor was failing to clean up projects which seems to be
due to GCP adding two new logging sinks that cannot be deleted. The new boskos
image fixes this. See kubernetes-sigs/boskos#37 for more details.

I'm using the staging GCR like https://github.com/kubernetes/k8s.io/pull/1161 in order to unblock our tests. 

Fixes #534

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._