### PR TITLE
Fix github check status while pending 

### DIFF
--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -74,7 +74,7 @@ spec:
               check_status = "success"
             elif ("$(tt.params.checkResult)" == "False"):
               check_status = "failure"
-            else:
+            elif ("$(tt.params.checkResult)" != "Unknown")):
               check_status = "error"
             logs_url = 'https://dashboard.dogfooding.tekton.dev/#/namespaces/$(tt.params.taskRunNamespace)/' + resource_path
 
@@ -90,6 +90,7 @@ spec:
             try:
               with open(status_path, "r") as status:
                 old_status = json.load(status)
+                print("Previous status: {}".format(old_status))
             except FileNotFoundError:
               # There is no previous status. Just continue.
               old_status = dict(Label="", Desc="", Target="")
@@ -106,6 +107,8 @@ spec:
 
             with open(status_path, "w") as status:
               json.dump(status_body, status)
+
+            print("New status: {}".format(status_body))
       resources:
         inputs:
           - name: pr


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When the job is pending, we currently set it to error.
This issue was introduced in #531
Restore the correct behaviour.

Add more details to the github update log

Currently we do not log anything in the github update step log.
This makes it difficult to troubleshoot issues, so add some logging.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind cleanup