### PR TITLE
Makefile: make image build smarter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-images: test-runner skopeo tkn
+CONTAINER_RUNTIME=docker
+REPO =
+IMAGES = $(sort $(patsubst tekton/images/%/,%,$(dir $(wildcard tekton/images/*/))))
 
-skopeo:
-	docker build . -f tekton/images/skopeo/Dockerfile -t gcr.io/tekton-releases/dogfooding/skopeo
+images: $(IMAGES)
+	echo $(IMAGES)
 
-test-runner:
-	docker build . -f tekton/images/test-runner/Dockerfile -t gcr.io/tekton-releases/dogfooding/test-runner
+%: tekton/images/%
+	$(CONTAINER_RUNTIME) build $< -f $</Dockerfile -t $(REPO)$@
 
-tkn:
-	docker build . -f tekton/images/tkn/Dockerfile -t gcr.io/tekton-releases/dogfooding/tkn
+push: $(patsubst %,push-%,$(IMAGES))
 
-push: images
-	docker push gcr.io/tekton-releases/dogfooding/skopeo
-	docker push gcr.io/tekton-releases/dogfooding/test-runner
-	docker push gcr.io/tekton-releases/dogfooding/tkn
+push-%: %
+	$(CONTAINER_RUNTIME) push $(REPO)$<


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This will now support building any folder in `tekton/images`.

- `make images` build all images
- `make tkn` build only the `tkn` image (from `tekton/images/tkn`)
- `make push` build and push all images
- `make push-tkn` build and push the `tkn` image (from
  `tekton/images/tkn`)

It is possible to customize the prefix of the tag using the `REPO`
variable. `make REPO=docker.io/vdemeester tkn` will build
`docker.io/vdemeester/tkn`.

It is also possible to use another container runtime than `docker` as
long as it as a similar `build` command, using `CONTAINER_RUNTIME`.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind cleanup