### PR TITLE
Fix the check conditions when no regex

### DIFF
--- a/tekton/ci/conditions.yaml
+++ b/tekton/ci/conditions.yaml
@@ -61,4 +61,4 @@ spec:
       # If a command was specified, the regex should match the checkName
       REGEX="$(echo $(params.gitHubCommand) | awk '{ print $2}')"
       [[ "$REGEX" == "" ]] && REGEX='.*'
-      echo "$(params.checkName)" | grep -E $REGEX
+      echo "$(params.checkName)" | grep -E "$REGEX"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add quotes around the default regex or else it's expanded.
This is used when '/test' is specified without parameters.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._