### PR TITLE
Add missing tetkon-cd-template

### DIFF
--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -63,10 +63,10 @@ spec:
         - ref: tekton-ci-github-base
         - ref: tekton-ci-webhook-comment
         - ref: tekton-ci-clone-depth
-        - ref: tekton-ci-webhook-pr-labels
+        - ref: tekton-ci-webhook-issue-labels
       template:
-        name: tekton-plumbing-ci-pipeline
-    - name: all-pull-request-check-pr-labels
+        name: tekton-all-ci-pipeline
+    - name: all-pull-request-ci
       interceptors:
         - github:
             secretRef:
@@ -82,15 +82,12 @@ spec:
                body.action == 'synchronize' ||
                body.action == 'labeled' ||
                body.action == 'unlabeled')
-            overlays:
-            - key: extensions.pr_number
-              expression: body.pull_request.html_url.split('/')[size(body.pull_request.html_url.split('/'))-1]
       bindings:
         - ref: tekton-ci-github-base
-        - ref: tekton-ci-pr-number-extension
+        - ref: tekton-ci-webhook-pull-request
         - ref: tekton-ci-webhook-pr-labels
       template:
-        name: check-pull-request-labels
+        name: tekton-all-ci-pipeline
     - name: cd-trigger
       interceptors:
         - github:

--- a/tekton/ci/templates/bindings.yaml
+++ b/tekton/ci/templates/bindings.yaml
@@ -25,16 +25,6 @@ spec:
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
-  name: tekton-ci-pr-number-extension
-  namespace: tektonci
-spec:
-  params:
-  - name: pullRequestNumber
-    value: $(body.extensions.pr_number)
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: TriggerBinding
-metadata:
   name: tekton-ci-webhook-pull-request
   namespace: tektonci
 spec:
@@ -43,6 +33,8 @@ spec:
     value: $(body.pull_request.head.sha)
   - name: pullRequestNumber
     value: $(body.pull_request.number)
+  - name: pullRequestUrl
+    value: $(body.pull_request.html_url)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -56,7 +48,7 @@ spec:
   - name: pullRequestNumber
     value: $(body.add_pr_body.pull_request_body.number)
   - name: pullRequestUrl
-    value: $(body.pull_request.html_url)
+    value: $(body.issue.pull_request.html_url)
   - name: gitHubCommand
     value: $(body.comment.body)
 ---
@@ -79,3 +71,13 @@ spec:
   params:
   - name: labels
     value: $(body.pull_request.labels)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-webhook-issue-labels
+  namespace: tektonci
+spec:
+  params:
+  - name: labels
+    value: $(body.issue.labels)

--- a/tekton/ci/templates/tekton-cd-template.yaml
+++ b/tekton/ci/templates/tekton-cd-template.yaml
@@ -1,0 +1,38 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-cd-triggers
+  namespace: tektonci
+spec:
+  params:
+  - name: buildUUID
+    description: UUID used to track a CI Pipeline Run in logs
+  - name: package
+    description: org/repo
+  - name: pullRequestNumber
+    description: The pullRequestNumber
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: gitHubCommand
+    description: |
+      The GitHub command that was used a trigger. This is only available when
+      this template is triggered by a comment. The default value is for the
+      case of a pull_request event.
+    default: ""
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: cd-echo-test-$(uid)
+      labels:
+        tekton.dev/kind: cd
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      taskSpec:
+        steps:
+        - name: echo
+          image: busybox
+          script: |
+            echo "Executing $(tt.params.gitHubCommand)"


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

PR https://github.com/tektoncd/plumbing/pull/513 added a reference
to the tekton-cd-template but failed to include the file, which
is causing the resource deployment to fail.

Adding the file back and fixing the template used for the `all`
triggers.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug