### PR TITLE
Update one commit status at the time

### DIFF
--- a/tekton/ci/README.md
+++ b/tekton/ci/README.md
@@ -234,6 +234,7 @@ downstream CEL filters to work correctly.
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
         prow.k8s.io/build-id: $(tt.params.buildUUID)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs

--- a/tekton/ci/templates/all-template.yaml
+++ b/tekton/ci/templates/all-template.yaml
@@ -38,6 +38,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       pipelineRef:

--- a/tekton/ci/templates/plumbing-template.yaml
+++ b/tekton/ci/templates/plumbing-template.yaml
@@ -38,6 +38,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -77,6 +78,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -116,6 +118,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -155,6 +158,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -194,6 +198,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -233,6 +238,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -272,6 +278,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -311,6 +318,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -350,6 +358,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -389,6 +398,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -428,6 +438,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -465,6 +476,7 @@ spec:
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       serviceAccountName: tekton-ci-jobs

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -106,55 +106,52 @@ spec:
               body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
-              !('ownerReferences' in body.taskRun.metadata)
-      bindings:
-        - ref: tekton-ci-taskrun-cloudevent
-        - ref: tekton-ci-check-pending
-      template:
-        name: tekton-ci-github-check-update
-    - name: github-check-done
-      interceptors:
-        - cel:
-            filter: >-
-              (header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') ||
-              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')) &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
-              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
-              !('ownerReferences' in body.taskRun.metadata)
-      bindings:
-        - ref: tekton-ci-taskrun-cloudevent
-        - ref: tekton-ci-check-complete
-      template:
-        name: tekton-ci-github-check-update
-    - name: github-check-start-with-owner
-      interceptors:
-        - cel:
-            filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.started.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
-              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               'ownerReferences' in body.taskRun.metadata
+            overlays:
+              - key: extensions.repo
+                expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
         - ref: tekton-ci-check-pending
         - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+        - ref: tekton-ci-overlays
       template:
         name: tekton-ci-github-check-update
-    - name: github-check-done-with-owner
+    - name: github-check-success
       interceptors:
         - cel:
             filter: >-
-              (header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') ||
-              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')) &&
+              header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') &&
               body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               'ownerReferences' in body.taskRun.metadata
+            overlays:
+              - key: extensions.repo
+                expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
-        - ref: tekton-ci-check-complete
+        - ref: tekton-ci-check-success
         - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+        - ref: tekton-ci-overlays
+      template:
+        name: tekton-ci-github-check-update
+    - name: github-check-failure
+      interceptors:
+        - cel:
+            filter: >-
+              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1') &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci-webhook' &&
+              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
+              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
+              'ownerReferences' in body.taskRun.metadata
+            overlays:
+              - key: extensions.repo
+                expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
+      bindings:
+        - ref: tekton-ci-taskrun-cloudevent
+        - ref: tekton-ci-check-failure
+        - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+        - ref: tekton-ci-overlays
       template:
         name: tekton-ci-github-check-update

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -6,14 +6,12 @@ spec:
   params:
   - name: pullRequestNumber
     value: $(body.taskRun.metadata.labels.tekton\.dev/pr-number)
-  - name: gitURL
-    value: $(body.taskRun.metadata.annotations.tekton\.dev/gitURL)
+  - name: gitRevision
+    value: $(body.taskRun.metadata.annotations.tekton\.dev/gitRevision)
   - name: buildUUID
     value: $(body.taskRun.metadata.labels.prow\.k8s\.io/build-id)
   - name: checkName
     value: $(body.taskRun.metadata.labels.tekton\.dev/check-name)
-  - name: checkResult
-    value: $(body.taskRun.status.conditions[?(@.type == 'Succeeded')].status)
   - name: taskRunName
     value: $(body.taskRun.metadata.name)
   - name: taskRunNamespace
@@ -25,21 +23,32 @@ metadata:
   name: tekton-ci-check-pending
 spec:
   params:
-  - name: checkStatus
+  - name: gitHubCheckStatus
     value: pending
-  - name: checkDescription
+  - name: gitHubCheckDescription
     value: "Job Triggered."
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
-  name: tekton-ci-check-complete
+  name: tekton-ci-check-success
 spec:
   params:
-  - name: checkStatus
-    value: complete
-  - name: checkDescription
-    value: "Job Finished."
+  - name: gitHubCheckStatus
+    value: success
+  - name: gitHubCheckDescription
+    value: "Job Successful."
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-check-failure
+spec:
+  params:
+  - name: gitHubCheckStatus
+    value: failure
+  - name: gitHubCheckDescription
+    value: "Job Failed."
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -51,3 +60,12 @@ spec:
     value: $(body.taskRun.metadata.ownerReferences[?(@.kind == 'PipelineRun')].name)
   - name: parentPipelineRunTaskName
     value: $(body.taskRun.metadata.labels.tekton\.dev/pipelineTask)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-overlays
+spec:
+  params:
+  - name: gitHubRepo
+    value: $(body.extensions.repo)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -9,16 +9,16 @@ spec:
     description: The pullRequestID to comment to
   - name: buildUUID
     description: The buildUUID for the logs link
-  - name: gitURL
-    description: The gitURL (https://org/repo)
+  - name: gitHubRepo
+    description: The gitHubRepo (org/repo)
+  - name: gitRevision
+    description: The sha of the HEAD commit in the PR
   - name: checkName
     description: Name of the CI Job (GitHub Check)
-  - name: checkStatus
-    description: Can be 'pending' or 'complete'
-  - name: checkDescription
+  - name: gitHubCheckStatus
+    description: Can be 'pending', 'success' or 'failure'
+  - name: gitHubCheckDescription
     description: A description to be displayed for the status of the check
-  - name: checkResult
-    description: Whether the triggering event was successful or not
   - name: taskRunName
     description: The name of the task run that triggered this
   - name: taskRunNamespace
@@ -33,7 +33,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: $(tt.params.checkName)-pr-$(tt.params.checkStatus)-$(uid)
+      name: $(tt.params.checkName)-pr-$(tt.params.gitHubCheckStatus)-$(uid)
       namespace: tektonci
     spec:
       serviceAccountName: tekton-ci-jobs
@@ -41,94 +41,22 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 1001
-      taskSpec:
-        resources:
-          inputs:
-            - name: pr
-              type: pullRequest
-          outputs:
-            - name: pr
-              type: pullRequest
-        steps:
-        - name: copy-pr-to-output
-          image: busybox
-          script: |
-            #!/bin/sh
-            mkdir -p $(resources.outputs.pr.path)
-            cp -r $(resources.inputs.pr.path)/* $(resources.outputs.pr.path)/
-        - name: update-check-status
-          image: python:3-alpine
-          script: |
-            #!/usr/bin/env python
-            import json
-            import random
-            import sys
-
-            check_status = "$(tt.params.checkStatus)"
-            if "$(tt.params.parentPipelineRunName)" == "":
-              resource_path = "taskruns/$(tt.params.taskRunName)"
-            else:
-              resource_path = "pipelineruns/$(tt.params.parentPipelineRunName)?pipelineTask=$(tt.params.parentPipelineRunTaskName)"
-
-            if ("$(tt.params.checkResult)" == "True"):
-              check_status = "success"
-            elif ("$(tt.params.checkResult)" == "False"):
-              check_status = "failure"
-            elif ("$(tt.params.checkResult)" != "Unknown"):
-              check_status = "error"
-            logs_url = 'https://dashboard.dogfooding.tekton.dev/#/namespaces/$(tt.params.taskRunNamespace)/' + resource_path
-
-            # Build Status
-            status_body = dict(
-              State=check_status,
-              Label="$(tt.params.checkName)",
-              Desc="$(tt.params.checkDescription)",
-              Target=logs_url)
-
-            # we may need to URLEncode the check name
-            status_path = "$(resources.outputs.pr.path)/status/$(tt.params.checkName).json"
-            try:
-              with open(status_path, "r") as status:
-                old_status = json.load(status)
-                print("Previous status: {}".format(old_status))
-            except FileNotFoundError:
-              # There is no previous status. Just continue.
-              old_status = dict(Label="", Desc="", Target="")
-
-            # Detect race condition. It may be that the "start" event is processed after
-            # the "complete" one. This does not eliminate the possibility of race as the two
-            # update jobs may still run in parallel, but it reduces the chances considerably.
-            if (status_body['State'] in ['success', 'failure', 'error'] and
-                  status_body['Label'] == old_status['Label'] and
-                  status_body['Desc'] == old_status['Desc'] and
-                  status_body['Target'] == old_status['Target']):
-                # A matching complete was already done, stop here.
-                sys.exit(0)
-
-            with open(status_path, "w") as status:
-              json.dump(status_body, status)
-
-            print("New status: {}".format(status_body))
-      resources:
-        inputs:
-          - name: pr
-            resourceSpec:
-              type: pullRequest
-              params:
-                - name: url
-                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestNumber)
-              secrets:
-                - fieldName: authToken
-                  secretName: bot-token-github
-                  secretKey: bot-token
-        outputs:
-          - name: pr
-            resourceSpec:
-              type: pullRequest
-              params:
-                - name: url
-                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestNumber)
-              secrets:
-                - fieldName: authToken
-                  secretName: bot-token-github
-                  secretKey: bot-token
+      taskRef:
+        name: github-set-status
+      params:
+        - name: REPO_FULL_NAME
+          value: $(tt.params.gitHubRepo)
+        - name: SHA
+          value: $(tt.params.gitRevision)
+        - name: TARGET_URL
+          value: https://dashboard.dogfooding.tekton.dev/#/namespaces/$(tt.params.taskRunNamespace)/pipelineruns/$(tt.params.parentPipelineRunName)?pipelineTask=$(tt.params.parentPipelineRunTaskName)
+        - name: DESCRIPTION
+          value: $(tt.params.gitHubCheckDescription)
+        - name: CONTEXT
+          value: $(tt.params.checkName)
+        - name: STATE
+          value: $(tt.params.gitHubCheckStatus)
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The PullRequestPipelineResource that is used today to update the
GitHub status tries to update all statuses for which it finds a
change - which causes the racy behaviour described in #589.

Stop using pipeline resources for pull requests, use a task from
the catalog instead to update a single status at the time.
This depends on v0.2 of the task defined in https://github.com/tektoncd/catalog/pull/516

Using the Tasks requires a little extra work in CEL filters and
bindings, but overall the new solution is simpler.

This drops support for CI jobs as tasks (instead of pipelines) as
now we documented that pipeline is the required format and the only
task CI job (check label) has now been migrated to pipeline.

Fixes #589

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug