### PR TITLE
Bump ko version to v0.6.0

### DIFF
--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -36,7 +36,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 # Install ko
 ENV GOBIN=/usr/local/go/bin
 ENV GO111MODULE on
-RUN go get github.com/google/ko/cmd/ko@v0.5.1
+RUN go get github.com/google/ko/cmd/ko@v0.6.0
 
 # Get Kubectl and Kustomize from the build image
 COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl

--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -15,7 +15,7 @@ FROM golang:1.14-alpine3.12
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 ENV GO111MODULE on
-RUN go get github.com/google/ko/cmd/ko@v0.5.1
+RUN go get github.com/google/ko/cmd/ko@v0.6.0
 
 RUN apk add --no-cache musl-dev gcc git
 RUN go get sigs.k8s.io/kustomize/kustomize/v3@v3.8.1

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -160,7 +160,7 @@ RUN apt update && apt install -y uuid-runtime  # for uuidgen
 RUN apt update && apt install -y rubygems  # for mdl
 
 # Extra tools through go get
-RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.5.1 && \
+RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.6.0 && \
     GO111MODULE="off" go get github.com/google/licenseclassifier && \
     GO111MODULE="off" go get github.com/google/go-licenses && \
     GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Bump `ko` version to be able to use new `--platform=all` feature to build multi-arch images.
Part of work to build multi-arch Tekton images using `--platform=all`, see https://github.com/tektoncd/pipeline/pull/3314

Verified that [pipeline](https://github.com/tektoncd/pipeline/commit/f51e09ed1bf5b6b31a9df120292b5d3439911899), [triggers](https://github.com/tektoncd/triggers/commit/be425738ab62582ba28045efc8a91b37dcb4ab98), [operator](https://github.com/tektoncd/operator/commit/183659a26b9d832aeba851322084581a193b6be6) and [dashboard](https://github.com/tektoncd/dashboard/commit/e43ff02ebafaa0da491e6628e05b17cfeb6aff79) use now `ko://` prefix, as for `v0.6.0` it's a requirement.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._