### PR TITLE
Add github action workflow to build pipeline base images

### DIFF
--- a/.github/workflows/pipeline_base_image_build.yml
+++ b/.github/workflows/pipeline_base_image_build.yml
@@ -1,0 +1,63 @@
+name: build pipeline base image
+
+on:
+  workflow_dispatch:
+    inputs:
+      pathToProject:
+        description: 'path to project'
+        required: true
+        default: 'github.com/tektoncd/pipeline'
+      imageRegistry:
+        description: 'image registry'
+        required: true
+        default: 'gcr.io/tekton-nightly'
+      url:
+        description: 'url'
+        required: true
+        default: 'build-base:latest'
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: github_actions_base_pipeline
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true
+
+      - name: Set up gcloud
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          service_account_key: ${{ secrets.GKE_SA_KEY }}
+          project_id: ${{ secrets.GKE_PROJECT }}
+
+      - name: Configure docker to use gcloud
+        run: |-
+          gcloud --quiet auth configure-docker
+
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v2
+        with:
+          repository: tektoncd/pipeline
+          path: pipeline
+
+      - name: Run Buildx
+        run: |
+          docker  build \
+            --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
+            --tag ${{ github.event.inputs.imageRegistry }}/${{ github.event.inputs.pathToProject }}/${{ github.event.inputs.url }} \
+            --push \
+            ./pipeline/images


### PR DESCRIPTION

# Changes

Currently pipeline [base image](https://github.com/tektoncd/pipeline/blob/master/.ko.yaml#L5) is built using [gcr.io/kaniko-project/executor:v0.17.1](https://github.com/tektoncd/pipeline/blob/master/tekton/publish.yaml#L53) which doesn't support multi-arch builds, so it is a stopper to get multi-arch pipeline releases.

This Github actions workflow can be used to build pipeline base image in multi-arch form with `docker buildx`.
Architectures for manifest are amd64, arm64, s390x, ppc64le.
The build runs on amd64 architecture, executing builds for other architectures using emulation.

The setup requires to have 2 secret parameters("GKE_SA_KEY" and "GKE_PROJECT")
to push images to Google Cloud registry.
There are also 3 input parameters to construct image name. The default values will create the `gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest` image.
Workflow can be start manually at github.com or via Github API.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._