### PR TITLE
Handle the cases of many or no release notes

### DIFF
--- a/tekton/resources/release/github_release.yaml
+++ b/tekton/resources/release/github_release.yaml
@@ -122,7 +122,8 @@ spec:
 
         # First process pull requests that have release notes
         # Extract the release notes but drop lines that match an unmodified PR template
-        grep -v "release-note-none" $HOME/pr.csv | while read pr; do
+        # || true in case all PRs are "release-note-none"
+        grep -v "release-note-none" $HOME/pr.csv || true | while read pr; do
           PR_NUM=$(echo $pr | cut -d';' -f2)
           PR_RELEASE_NOTES_B64=$(wget -O- https://api.github.com/repos/${PROJECT}/issues/${PR_NUM:1} | \
             jq .body -r | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | \
@@ -133,7 +134,8 @@ spec:
         done
 
         # Copy pull requests without release notes to a dedicated file
-        grep "release-note-none" $HOME/pr.csv > $HOME/pr-no-notes.csv
+        # || true in case no PRs have "release-note-none"
+        grep "release-note-none" $HOME/pr.csv || true > $HOME/pr-no-notes.csv
     - name: body
       image: busybox
       script: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If no PR in the release has release notes, or all of them do, one
of the two greps will fail and fail the step. Fix that with || true.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug