### PR TITLE
Catlin: Fixes warning for images having tag along with digest

### DIFF
--- a/catlin/pkg/validator/task_validator.go
+++ b/catlin/pkg/validator/task_validator.go
@@ -80,8 +80,8 @@ func (t *taskValidator) validateStep(s v1beta1.Step) Result {
 			return result
 		}
 
-		if tagHasDigest(rep.String()) {
-			result.Warn("Step %q uses image %q; consider using digest over tags as tags are mutable", step, img)
+		if !tagWithDigest(rep.String()) {
+			result.Warn("Step %q uses image %q; consider using a image tagged with specific version along with digest eg. abc.io/img:v1@sha256:abcde", step, img)
 		}
 
 		return result
@@ -116,7 +116,11 @@ func isValidRegistry(img string) bool {
 	return strings.Contains(repo, ".")
 }
 
-func tagHasDigest(img string) bool {
+// tagWithDigest validates if image has a specific tag along with digest
+func tagWithDigest(img string) bool {
 	withOutDigest := strings.Split(img, "@sha256")[0]
-	return strings.Contains(withOutDigest, ":")
+	if strings.Contains(withOutDigest, ":") && !strings.Contains(withOutDigest, ":latest") {
+		return true
+	}
+	return false
 }

--- a/catlin/pkg/validator/task_validator_test.go
+++ b/catlin/pkg/validator/task_validator_test.go
@@ -55,9 +55,9 @@ spec:
   - name: s5
     image: gcr.io/foo/bar/baz:bar
   - name: s6
-    image: abc.io/fedora@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+    image: abc.io/fedora:1.0@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
   - name: s7
-    image: abc.io/xyz/fedora@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+    image: abc.io/xyz/fedora:v123@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
   - name: s8
     image: 172.16.3.4:3000/foo/bar:baz
 `
@@ -99,7 +99,7 @@ spec:
   - name: s6
     image: gcr.io/foo/bar/baz:latest
   - name: s7
-    image: abc.io/fedora:1.0@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+    image: abc.io/fedora@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
   - name: s8
     image: abc.io/fedora:latest@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
   - name: s9
@@ -176,11 +176,11 @@ func TestTaskValidator_InvalidImageRef(t *testing.T) {
 
 	// image with digest and a tag
 	assert.Equal(t, Warning, lints[8].Kind)
-	assert.Equal(t, `Step "s7" uses image "abc.io/fedora:1.0@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f"; consider using digest over tags as tags are mutable`, result.Lints[8].Message)
+	assert.Equal(t, `Step "s7" uses image "abc.io/fedora@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f"; consider using a image tagged with specific version along with digest eg. abc.io/img:v1@sha256:abcde`, result.Lints[8].Message)
 
 	// image with digest and latest tag
 	assert.Equal(t, Warning, lints[9].Kind)
-	assert.Equal(t, `Step "s8" uses image "abc.io/fedora:latest@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f"; consider using digest over tags as tags are mutable`, result.Lints[9].Message)
+	assert.Equal(t, `Step "s8" uses image "abc.io/fedora:latest@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f"; consider using a image tagged with specific version along with digest eg. abc.io/img:v1@sha256:abcde`, result.Lints[9].Message)
 
 	// image with invalid digest
 	assert.Equal(t, Error, lints[10].Kind)

--- a/catlin/pkg/validator/validate_test.go
+++ b/catlin/pkg/validator/validate_test.go
@@ -47,7 +47,7 @@ spec:
       image: abc.io/ubuntu:1.0
       command: [sleep, infinity]
     - name: foo-bar
-      image: abc.io/fedora@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+      image: abc.io/fedora:1.0@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
 `
 
 	validPipeline = `


### PR DESCRIPTION
This allows images to have a specific tag along with digest. 
It will give a warning if an image doesn't have a tag or have the latest tag when it has a digest.

Fixes: #602 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


Valid Image 
```
docker.io/ansible/ansible-runner:1.4.6@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb
```
Now, Warns if the image has the `latest` or no tag along with the digest.

Invalid Images
```
WARN : Step "s2" uses image "docker.io/ansible/ansible-runner@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb"; consider using a image tagged with specific version along with digest eg. abc.io/img:v1@sha256:abcde
```
```
WARN : Step "s3" uses image "docker.io/ansible/ansible-runner:latest@sha256:bd09ef403f2f90f2c6bd133d7533e939058903f69223c5f12557a49e3aed14bb"; consider using a image tagged with specific version along with digest eg. abc.io/img:v1@sha256:abcde
```

cc @sthaha @vdemeester @vinamra28 