### PR TITLE
Skip the common ancestor in release notes

### DIFF
--- a/tekton/resources/release/github_release.yaml
+++ b/tekton/resources/release/github_release.yaml
@@ -84,7 +84,7 @@ spec:
 
         # UPPER_THRESHOLD is the newest sha we are interested in
         UPPER_THRESHOLD=$(inputs.resources.source.revision)
-        # COMMON_ANCESTOR is the common ancestore between the OLD_VERSION and UPPER_THRESHOLD
+        # COMMON_ANCESTOR is the common ancestor between the OLD_VERSION and UPPER_THRESHOLD
         COMMON_ANCESTOR=$(git merge-base ${OLD_VERSION} ${UPPER_THRESHOLD})
         # OLD_RELEASE_SUBJECTS is the list of commit subjects cherry-picked (probably?) from master
         OLD_RELEASE_SUBJECTS=$HOME/old_subjects.txt
@@ -105,6 +105,10 @@ spec:
         hub pr list --state merged -L 300 -f "%sm;%au;%i;%t;%L%n" | \
           while read pr; do
             SHA=$(echo $pr | cut -d';' -f1)
+            # Skip the common ancestor has it has already been released
+            if [ "$SHA" == "$COMMON_ANCESTOR" ]; then
+              continue
+            fi
             SUBJECT=$(git log -1 --format="%s" $SHA || echo "__NOT_FOUND__")
             git merge-base --is-ancestor $SHA $UPPER_THRESHOLD && \
             git merge-base --is-ancestor $COMMON_ANCESTOR $SHA && \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When building release notes, the common ancestor between the
release SHA and the old release is a reference that has already
been included in a previous release, so skip it.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug