### PR TITLE
add CI/CD pipeline for the tekton website

### DIFF
--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -157,3 +157,60 @@ spec:
         - ref: tekton-ci-webhook-tektoncd-comment
       template:
         name: tekton-cd-triggers
+    - name: website-pull-request-ci
+      interceptors:
+        - github:
+            secretRef:
+              secretName: ci-webhook
+              secretKey: secret
+            eventTypes:
+              - pull_request
+        - cel:
+            filter: >-
+              body.repository.full_name == 'tektoncd/website' &&
+              (body.action == 'opened' || body.action == 'synchronize')
+            overlays:
+            - key: extensions.git_clone_depth
+              expression: "string(body.pull_request.commits + 1.0)"
+      bindings:
+        - ref: tekton-ci-github-base
+        - ref: tekton-ci-webhook-pull-request
+        - ref: tekton-ci-clone-depth
+        - ref: tekton-ci-webhook-pr-labels
+      template:
+        name: tekton-website-ci-pipeline
+    - name: website-comment-ci
+      interceptors:
+        - github:
+            secretRef:
+              secretName: ci-webhook
+              secretKey: secret
+            eventTypes:
+              - issue_comment
+        - cel:
+            filter: >-
+              body.repository.full_name == 'tektoncd/website' &&
+              body.action == 'created' &&
+              'pull_request' in body.issue &&
+              body.issue.state == 'open' &&
+              body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
+            overlays:
+            - key: add_pr_body.pull_request_url
+              expression: "body.issue.pull_request.url"
+        - webhook:
+            objectRef:
+              kind: Service
+              name: add-pr-body
+              apiVersion: v1
+              namespace: tektonci
+        - cel:
+            overlays:
+            - key: extensions.git_clone_depth
+              expression: "string(body.add_pr_body.pull_request_body.commits + 1.0)"
+      bindings:
+        - ref: tekton-ci-github-base
+        - ref: tekton-ci-webhook-comment
+        - ref: tekton-ci-clone-depth
+        - ref: tekton-ci-webhook-issue-labels
+      template:
+        name: tekton-website-ci-pipeline

--- a/tekton/ci/jobs/kustomization.yaml
+++ b/tekton/ci/jobs/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - tekton-image-build.yaml
 - tekton-kind-label.yaml
 - tekton-yamllint.yaml
+- tekton-python-test.yaml

--- a/tekton/ci/jobs/tekton-python-test.yaml
+++ b/tekton/ci/jobs/tekton-python-test.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tekton-python-test-pipeline
+spec:
+  params:
+    - name: git-url
+    - name: git-revision
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: pytest
+      taskRef:
+        name: pytest
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: PYTHON
+          value: "3.7"
+        - name: ARGS
+          value: "-rfs"
+        - name: SOURCE_PATH
+          value: "sync/."

--- a/tekton/ci/templates/kustomization.yaml
+++ b/tekton/ci/templates/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - all-template.yaml
 - tekton-cd-template.yaml
 - bindings.yaml
+- website-template.yaml

--- a/tekton/ci/templates/website-template.yaml
+++ b/tekton/ci/templates/website-template.yaml
@@ -1,0 +1,45 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-website-ci-triggers
+  namespace: tektonci
+spec:
+  params:
+  - name: buildUUID
+    description: UUID used to track a CI Pipeline Run in logs
+  - name: package
+    description: org/repo
+  - name: pullRequestNumber
+    description: The pullRequestNumber
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: gitHubCommand
+    description: |
+      The GitHub command that was used a trigger. This is only available when
+      this template is triggered by a comment. The default value is for the
+      case of a pull_request event.
+    default: ""
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: tekton-python-test-pipelinerun
+    spec:
+      pipelineRef:
+        name: tekton-python-test-pipeline
+      params:
+        - name: git-url
+          value: $(tt.params.gitRepository)
+        - name: git-revision
+          value: $(tt.params.gitRevision)
+      workspaces:
+        - name: shared-workspace
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+              - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The tekton ci website has the responsibility of syncing the documentation and delivering this information in the form of a website. The sync script has tests to ensure that it is functioning as expected. This is a problem because we are not ensuring all the tests as part of our ci/cd pipeline for the tekton website. This issue can be solved by adding a task to the ci/cd netlify pipeline, adding a task to ci/cd in prow, or setting up a pipeline in tekton ci/cd. The best approach is to add the pipeline to tekton because it allows us to add other tests from the tekton catalog. This provides us greater flexibility. It also presents itself as a great opportunity to dog food tekton. These changes allow the tests to run as part of the ci process for the tekton website. Adding more tasks to the ci/cd pipeline to ensure that the pipeline is always functioning properly. Closes #612

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
/area testing