### PR TITLE
fix issues when setup tekton with kind

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,6 +70,8 @@ kubectl create secret generic ci-webhook -n tektonci --from-literal=secret=$GITH
 # Expose the event listener via Smee
 kubectl port-forward service/el-tekton-ci-webhook -n tektonci 9999:8080 &> el-tekton-ci-webhook-pf.log &
 smee --target http://127.0.0.1:9999/ &> smee.log &
+# Wait for smee target ready
+sleep 2
 SMEE_TARGET=$(tail -1 smee.log | cut -d'/' -f3-)
 
 # Install a Task to create the webhook, create a secret used by it

--- a/hack/tekton_in_kind.sh
+++ b/hack/tekton_in_kind.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu -o pipefail
+set -e -o pipefail
 
 declare TEKTON_PIPELINE_VERSION TEKTON_TRIGGERS_VERSION TEKTON_DASHBOARD_VERSION
 
@@ -67,6 +67,6 @@ kubectl apply -f https://github.com/tektoncd/dashboard/releases/download/${TEKTO
 
 # Wait until all pods are ready
 sleep 10
-kubectl wait -n tekton-pipelines --for=condition=ready pods --all
+kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s
 kubectl port-forward service/tekton-dashboard -n tekton-pipelines 9097:9097 &> kind-tekton-dashboard.log &
 echo “Tekton Dashboard available at http://localhost:9097”


### PR DESCRIPTION
# Changes

fix issues when setup tekton with kind:

1. remove -u: if no arguments are specified when executing hack/tekton_in_kind.sh, it reports error './tekton_in_kind.sh: line 50: TEKTON_PIPELINE_VERSION: unbound variable'
2. set 120 seconds as the timeout value for 'kubectl wait'
3. sleep 2 seconds to get smee client ready


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._