### PR TITLE
Add buildx-gcloud image to plumbing

### DIFF
--- a/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/README.md
@@ -1,0 +1,2 @@
+Cron Job to build a container image with `docker buildx` and `gcloud` installed.
+The image is published daily to [gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest](gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest).

--- a/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-build-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: el-image-builder.default.svc.cluster.local:8080
+            - name: GIT_REPOSITORY
+              value: github.com/tektoncd/plumbing
+            - name: GIT_REVISION
+              value: master
+            - name: TARGET_IMAGE
+              value: gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest
+            - name: CONTEXT_PATH
+              value: tekton/images/buildx-gcloud

--- a/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/image-build
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-buildx-gcloud"

--- a/tekton/images/buildx-gcloud/Dockerfile
+++ b/tekton/images/buildx-gcloud/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+
+RUN  mkdir -p ~/.docker/cli-plugins \
+     && curl -fsSL https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64 > ~/.docker/cli-plugins/docker-buildx \
+     && chmod u+x ~/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
# Changes

This image will be used to build multi-arch images with `docker buildx`
and push them to Google cloud.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._