### PR TITLE
Add nightly release for tekton website docs for master version

### DIFF
--- a/tekton/cronjobs/dogfooding/tekton/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - dashboard-to-robocat-nightly
 - pipeline-to-robocat-nightly
 - triggers-to-robotcat-nightly
+- website-to-netlify-nightly

--- a/tekton/cronjobs/dogfooding/tekton/website-to-netlify-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/tekton/website-to-netlify-nightly/README.md
@@ -1,0 +1,1 @@
+Cron Job to nightly deploy the latest nightly release of tekton website.

--- a/tekton/cronjobs/dogfooding/tekton/website-to-netlify-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/website-to-netlify-nightly/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- website-sync-cronjob.yaml

--- a/tekton/cronjobs/dogfooding/tekton/website-to-netlify-nightly/website-sync-cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/website-to-netlify-nightly/website-sync-cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: website-netlify-build-trigger
+spec:
+  schedule: '15 3 * * *'
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            command:
+              - /bin/sh
+            args:
+              - -ce
+              - |
+                curl -X POST -d {} $NETLIFY_BUILD_HOOK
+          env:
+          - name: NETLIFY_BUILD_HOOK
+            valueFrom:
+              secretKeyRef:
+                name: netlify_build_hook
+                key: url
+          restartPolicy: Never


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Tekton Website uses github actions to sync the master version of the docs. We should have this sync on the tekton plumbing repo. The reason why this is the best approach is because it consolidates our infra and gives us an opportunity to dogfood. We currently sync on github actions as of https://github.com/tektoncd/website/commit/428238c3e9b42834ba663f76179e1cffc7b3243a. This website will only sync at 3:15AM UTC. This means that master version of the docs will not get updated until that time. A secret with the netlify build hook needs to be added to the cluster for the cronjob to work properly.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/area testing
/kind misc