### PR TITLE
Add build of dogfooding images in multi-arch form

### DIFF
--- a/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
+++ b/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
@@ -64,7 +64,8 @@ spec:
                   "registry": "$REGISTRY",
                   "namespace": "$NAMESPACE",
                   "imageName": "$IMAGE",
-                  "imageTag": "$TAG"
+                  "imageTag": "$TAG",
+                  "platforms": "$PLATFORMS"
                 }
                 EOF
                 curl -d @/workspace/post-body.json $SINK_URL
@@ -80,4 +81,6 @@ spec:
                 value: "master"
               - name: TARGET_IMAGE
                 value: "gcr.io/tekton-releases/dogfooding/myimage:latest"
+              - name: PLATFORMS
+                value: ""
           restartPolicy: Never

--- a/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/cronjob.yaml
@@ -22,3 +22,5 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
             - name: CONTEXT_PATH
               value: tekton/images/alpine-git-nonroot
+            - name: PLATFORMS
+              value: "linux/amd64,linux/s390x,linux/ppc64le"

--- a/tekton/cronjobs/dogfooding/images/skopeo-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/skopeo-nightly/cronjob.yaml
@@ -22,3 +22,5 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/skopeo:latest
             - name: CONTEXT_PATH
               value: tekton/images/skopeo
+            - name: PLATFORMS
+              value: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"

--- a/tekton/cronjobs/dogfooding/images/tkn-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/tkn-nightly/cronjob.yaml
@@ -22,3 +22,5 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/tkn:latest
             - name: CONTEXT_PATH
               value: tekton/images/tkn
+            - name: PLATFORMS
+              value: "linux/amd64,linux/s390x,linux/ppc64le"

--- a/tekton/resources/images/bindings.yaml
+++ b/tekton/resources/images/bindings.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: trigger-to-build-and-push-image
+spec:
+  params:
+  - name: buildUUID
+    value: $(body.buildUUID)
+  - name: gitRepository
+    value: $(body.gitRepository)
+  - name: gitRevision
+    value: $(body.gitRevision)
+  - name: contextPath
+    value: $(body.contextPath)
+  - name: registry
+    value: $(body.registry)
+  - name: namespace
+    value: $(body.namespace)
+  - name: imageName
+    value: $(body.imageName)
+  - name: imageTag
+    value: $(body.imageTag)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: trigger-to-build-and-push-image-platform
+spec:
+  params:
+  - name: platforms
+    value: $(body.platforms)

--- a/tekton/resources/images/eventlistener.yaml
+++ b/tekton/resources/images/eventlistener.yaml
@@ -1,0 +1,28 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: image-builder
+spec:
+  serviceAccountName: release-right-meow
+  triggers:
+    - name: single-arch-build-trigger
+      interceptors:
+        - cel:
+            filter: >-
+              !('platforms' in body) ||
+              size(body['platforms']) == 0
+      bindings:
+        - ref: trigger-to-build-and-push-image
+      template:
+        name: build-and-push-image
+    - name: multi-arch-build-trigger
+      interceptors:
+        - cel:
+            filter: >-
+              'platforms' in body &&
+              size(body['platforms']) != 0
+      bindings:
+        - ref: trigger-to-build-and-push-image
+        - ref: trigger-to-build-and-push-image-platform
+      template:
+        name: build-and-push-image-multi-arch

--- a/tekton/resources/images/kustomization.yaml
+++ b/tekton/resources/images/kustomization.yaml
@@ -1,0 +1,9 @@
+namespace: default
+commonAnnotations:
+  managed-by: Tekton
+
+resources:
+- bindings.yaml
+- single-arch-template.yaml
+- eventlistener.yaml
+- multi-arch-template.yaml

--- a/tekton/resources/images/multi-arch-template.yaml
+++ b/tekton/resources/images/multi-arch-template.yaml
@@ -1,0 +1,122 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: build-and-push-image-multi-arch
+spec:
+  params:
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: contextPath
+    description: The path to the context within 'gitRepository'
+  - name: registry
+    description: The container registry *registry*/namespace/name tag
+  - name: namespace
+    description: The namespace (aka user, org, project) registry/*namespace*/name tag
+  - name: imageName
+    description: The image name (aka repository) registry/namespace/*name* tag
+  - name: imageTag
+    description: The image tag registry/namespace/name *tag*
+  - name: buildUUID
+    description: The build UUID is used for log collection
+  - name: platforms
+    description: Platforms for multi-arch build in form of `linux/amd64,linux/s390x`
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: build-and-push-$(tt.params.imageName)-$(uid)
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        plumbing.tekton.dev/image: $(tt.params.imageName)
+    spec:
+      taskSpec:
+        resources:
+          inputs:
+            - name: source
+              type: git
+          outputs:
+            - name: image
+              type: image
+        steps:
+        - env:
+          - name: DOCKER_HOST
+            value: tcp://localhost:2376
+          - name: DOCKER_TLS_VERIFY
+            value: "1"
+          - name: DOCKER_CERT_PATH
+            value: /certs/client
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/release.json
+          image: gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest
+          name: build-image-multi-arch
+          script: |
+            #!/usr/bin/env sh
+
+            gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+            gcloud auth configure-docker
+
+            docker run --rm --privileged tonistiigi/binfmt:latest --install all
+            ln -s /root/.docker/cli-plugins ~/.docker/cli-plugins
+
+            docker context create context1
+
+            docker buildx create context1 --name builder-buildx1 --driver docker-container --platform $(tt.params.platforms) --use
+            docker buildx inspect --bootstrap --builder builder-buildx1
+
+            cd $(resources.inputs.source.path)
+            docker buildx build \
+            --platform $(tt.params.platforms) \
+            --tag $(resources.outputs.image.url) \
+            --push \
+            $(tt.params.contextPath)
+          volumeMounts:
+          - mountPath: /certs/client
+            name: dind-certs
+          - mountPath: /secret
+            name: gcp-secret
+        volumes:
+        - name: gcp-secret
+          secret:
+            secretName: release-secret
+        - emptyDir: {}
+          name: dind-certs
+        sidecars:
+        - args:
+          - --storage-driver=vfs
+          - --userland-proxy=false
+          - --debug
+          env:
+          - name: DOCKER_TLS_CERTDIR
+            value: /certs
+          image: docker:dind
+          name: server-docker
+          readinessProbe:
+            exec:
+              command:
+              - ls
+              - /certs/client/ca.pem
+            periodSeconds: 1
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /certs/client
+            name: dind-certs
+      resources:
+        inputs:
+          - name: source
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(tt.params.gitRevision)
+              - name: url
+                value: https://$(tt.params.gitRepository)
+        outputs:
+          - name: image
+            resourceSpec:
+              type: image
+              params:
+              - name: url
+                value: $(tt.params.registry)/$(tt.params.namespace)/$(tt.params.imageName):$(tt.params.imageTag)

--- a/tekton/resources/images/single-arch-template.yaml
+++ b/tekton/resources/images/single-arch-template.yaml
@@ -1,40 +1,4 @@
 apiVersion: triggers.tekton.dev/v1alpha1
-kind: TriggerBinding
-metadata:
-  name: trigger-to-build-and-push-image
-spec:
-  params:
-  - name: buildUUID
-    value: $(body.buildUUID)
-  - name: gitRepository
-    value: $(body.gitRepository)
-  - name: gitRevision
-    value: $(body.gitRevision)
-  - name: contextPath
-    value: $(body.contextPath)
-  - name: registry
-    value: $(body.registry)
-  - name: namespace
-    value: $(body.namespace)
-  - name: imageName
-    value: $(body.imageName)
-  - name: imageTag
-    value: $(body.imageTag)
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: EventListener
-metadata:
-  name: image-builder
-spec:
-  serviceAccountName: release-right-meow
-  triggers:
-    - name: trigger
-      bindings:
-        - ref: trigger-to-build-and-push-image
-      template:
-        name: build-and-push-image
----
-apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
   name: build-and-push-image

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -3,7 +3,7 @@ commonAnnotations:
   managed-by: Tekton
 
 resources:
-- images/image-build-trigger.yaml
+- images
 - org-permissions/peribolos.yaml
 - org-permissions/peribolos-trigger.yaml
 - release


### PR DESCRIPTION
# Changes

Extend current cronjobs/triggers setup to build dogfooding images in multi-arch form when it's necessary:
- create 2 TriggerTemplates and TriggerBindings for single-arch and multi-arch cases
- extend eventlistener to decide which build to do (based on platforms parameter value)
- add PLATFORMS parameter to cronjobs to be able to specify for which platforms multi-arch image should be
- extend several image cronjobs to use multi-arch build (`tkn`, `alpine-git-nonroot`, `skopeo`)
- for multi-arch build `buildx` in main container and `dind` sidecar are used
- builds will be done on amd64 dogfooding cluster, not other native hardware is required.

Not every image can be built with this approach, so I suggest to use it only for images, which are required for the tests.
The build cronjobs were updated to those exact images.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._