### PR TITLE
Fix the name of the tekton website trigger template

### DIFF
--- a/tekton/ci/templates/website-template.yaml
+++ b/tekton/ci/templates/website-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-website-ci-triggers
+  name: tekton-website-ci-pipeline
   namespace: tektonci
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: tekton-python-test-pipelinerun
+      name: tekton-python-test-pipelinerun-$(uid)
     spec:
       pipelineRef:
         name: tekton-python-test-pipeline


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The name of the trigger template does not match the one
specified in the event listener and that of other trigger
templates, so fixing that.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug