### PR TITLE
Add bef args as valid to deploy-release script

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -13,7 +13,7 @@ declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELE
 # - cluster gke_tekton-nightly_europe-north1-a_robocat defined in the local kubeconfig
 
 # Read command line options
-while getopts ":p:v:" opt; do
+while getopts ":p:v:b:e:f:" opt; do
   case ${opt} in
     p )
       TEKTON_PROJECT=$OPTARG


### PR DESCRIPTION

# Changes


We were calling `getopts` with only `:p:v:` which means
only the -p and -v flags were considered valid.

This commit expands the set of valid flags to include b,e,f.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)