### PR TITLE
prow: Fix catalog periodic jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1171,9 +1171,6 @@ periodics:
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/e2e-tests-upgrade.sh"
-      env:
-      - name: TEST_RUN_ALL_TESTS
-        value: 1
 - cron: "6 3 * * *"
   name: periodic-tekton-catalog-integration-tests
   labels:
@@ -1203,6 +1200,9 @@ periodics:
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "./test/presubmit-tests.sh"
       - "--integration-tests"
+      env:
+      - name: TEST_RUN_ALL_TESTS
+        value: 1
 - name: periodic-tekton-stale
   interval: 1h
   decorate: true


### PR DESCRIPTION
# Changes

In #621 `TEST_RUN_ALL_TESTS` environment variable was added to `tektoncd/pipeline`
periodic job instead of `tektoncd/catalog`. This is to ensure we run
all the tests during the nightly tests of the catalog.

/cc @vdemeester @afrittoli 
/kind misc

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._