### PR TITLE
scripts: Fix list_changed_files in presubmit-tests

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -61,7 +61,7 @@ function pr_only_contains() {
 function list_changed_files() {
   local file="${WORK_DIR}/changed_files"
   if [[ ! -f ${file} ]]; then
-    git --no-pager diff --name-only ${PULL_BASE_SHA}..${PULL_SHA} > ${file}
+    git --no-pager diff --name-only ${PULL_BASE_SHA}..${PULL_PULL_SHA} > ${file}
   fi
   echo ${file}
 }


### PR DESCRIPTION
# Changes

In `git --no-pager diff --name-only 65dd35a5e8a7e63443b52df70ea5bbc0bc621dac..`
`${Pull_SHA}` doesn't gives `SHA` of the PR so fixed that to `${PULL_PULL_SHA}`.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._