### PR TITLE
Add kind to test-runner image.

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -160,7 +160,8 @@ RUN GO111MODULE="on" go get github.com/google/ko/cmd/ko@v0.6.0 && \
     GO111MODULE="off" go get github.com/google/go-licenses && \
     GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \
     GO111MODULE="on" go get github.com/raviqqe/liche && \
-    GO111MODULE="off" go get github.com/golang/dep/cmd/dep
+    GO111MODULE="off" go get github.com/golang/dep/cmd/dep && \
+    GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
 ARG GOLANGCI_VERSION=1.30.0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Adds [Kubernetes-in-Docker (kind)](https://kind.sigs.k8s.io/) to test-runner image. This is being
used for e2e tests (see
https://github.com/tektoncd/experimental/tree/master/results/test/e2e).

Blocking https://github.com/tektoncd/experimental/pull/673

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._