### PR TITLE
scripts: Make sure `cat` params are quoted.

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -314,7 +314,7 @@ function setup_test_cluster() {
 # Gets the exit of the test script.
 # For more details, see set_test_return_code().
 function get_test_return_code() {
-  echo $(cat ${TEST_RESULT_FILE})
+  echo $(cat "${TEST_RESULT_FILE}")
 }
 
 # Set the return code that the test script will return.

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -295,7 +295,7 @@ function report_go_test() {
   # Install go-junit-report if necessary.
   run_go_tool github.com/jstemmer/go-junit-report go-junit-report --help > /dev/null 2>&1
   local xml=$(mktemp ${ARTIFACTS}/junit_XXXXXXXX.xml)
-  cat ${report} \
+  cat "${report}" \
       | go-junit-report \
       | sed -e "s#\"github.com/tektoncd/${REPO_NAME}/#\"#g" \
       > ${xml}

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -53,7 +53,7 @@ GOFLAGS=${GOFLAGS:-}
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
-  [[ -z "$(cat "${CHANGED_FILES}" | grep -v "\(${1// /\\|}\)$")" ]]
+  [[ -z "$(cat \"${CHANGED_FILES}\" | grep -v \"\(${1// /\\|}\)$\")" ]]
 }
 
 # List changed files in the current PR.
@@ -77,8 +77,8 @@ function initialize_environment() {
 
   WORK_DIR=$(mktemp -d)
   CHANGED_FILES="$(list_changed_files)"
-  if [[ -n "$(cat ${CHANGED_FILES})" ]]; then
-    echo -e "Changed files in commit ${PULL_PULL_SHA}:\n$(cat ${CHANGED_FILES})"
+  if [[ -n "$(cat \"${CHANGED_FILES}\")" ]]; then
+    echo -e "Changed files in commit ${PULL_PULL_SHA}:\n$(cat \"${CHANGED_FILES}\")"
     local no_presubmit_files="${NO_PRESUBMIT_FILES[*]}"
     pr_only_contains "${no_presubmit_files}" && IS_PRESUBMIT_EXEMPT_PR=1
     pr_only_contains "\.md ${no_presubmit_files}" && IS_DOCUMENTATION_PR=1
@@ -158,7 +158,7 @@ function yaml_build_tests() {
   subheader "Linting the yaml files"
   local yamlfiles=""
 
-  for file in $(cat ${CHANGED_FILES}); do
+  for file in $(cat "${CHANGED_FILES}"); do
     [[ -z $(echo "${file}" | grep '\.yaml$\|\.yml$' | grep -v '^vendor/' | grep -v '^third_party/') ]] && continue
 
     echo "found ${file}"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If `cat` is called with no params, it assumes that it needs to read from
stdin, and will block for user input. This is problematic if
${CHANGED_FILES} is unset (i.e. when not running in a PR), since it
looks like the script just hangs.

Long term we should probably look into modifying the ${CHANGED_FILES}
behavior to fallback to a local diff, but for now make sure params are
quoted so that the script fails fast.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._