### PR TITLE
Remove Dashboard postsubmit job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1048,31 +1048,6 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-  tektoncd/dashboard:
-  - name: tekton-dashboard-publish-images
-    labels:
-      preset-postsubmit-sh: "true"
-    branches:
-    - master
-    always_run: true
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
-        imagePullPolicy: Always
-        command:
-        - /usr/local/bin/entrypoint.sh
-        args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/nightly-account/service-account.json"
-        - "--upload=gs://tekton-prow/logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-        - "./test/publish-images.sh"
   tektoncd/experimental:
   - name: tekton-dashboard-publish-images
     labels:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Remove the legacy postsubmit job for the Dashboard repo. It is no
longer necessary (or complete) as we have nightly releases running
on dogfooding for quite a while now with a different set of output
artifacts.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._