### PR TITLE
Fix the plumbing URL in the kubectl nightly

### DIFF
--- a/tekton/cronjobs/dogfooding/images/kubectl-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/kubectl-nightly/cronjob.yaml
@@ -15,7 +15,7 @@ spec:
             - name: SINK_URL
               value: el-image-builder.default.svc.cluster.local:8080
             - name: GIT_REPOSITORY
-              value: github.com/tekton/plumbing
+              value: github.com/tektoncd/plumbing
             - name: GIT_REVISION
               value: master
             - name: TARGET_IMAGE


### PR DESCRIPTION

# Changes

Fix the URL set in the cronjob to build the kubectl container
image nightly:

tekton/plumbing -> tektoncd/plumbing

Fixes #649

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug
/cc @vdemeester 