### PR TITLE
[experimental] Enable dind for integration tests.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -559,6 +559,9 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: "true"
   tektoncd/hub:
   - name: pull-tekton-hub-build-tests
     labels:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enables dind to allow usage of kind - this is currently blocking https://github.com/tektoncd/experimental/pull/673 with the following error:
```
ERROR: failed to create cluster: failed to list clusters: command "docker ps -a --filter label=io.x-k8s.kind.cluster=tekton-results --format '{{.Names}}'" failed with error: exit status 1

Command Output: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```
suggesting that docker is not available in the worker.

Looking at existing configs, it looks like the [`DOCKER_IN_DOCKER_ENABLED` environment variable](https://github.com/tektoncd/plumbing/blob/ac9002f78f97fd133d028378bce5748cd8be9f22/tekton/images/test-runner/runner.sh#L50) is used to configure this behavior, and based on [other Tekton project configs](https://github.com/tektoncd/plumbing/blob/74311f91f623633d491b170a4ff20dc8f561e93a/prow/config.yaml#L669) this needs to be set in the prow config (as opposed to in the test script).



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._