### PR TITLE
Add nightly pipeline tests for s390x

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -22,6 +22,8 @@ Secrets which have been applied to the dogfooding cluster but are not committed 
     - `mario-github-secret` contains the secret used to verify comment webhook requests to
       the mario service are coming from github
     - `mario-github-token` used for updating PRs
+  - In the bastion-z namespace:
+    - `s390x-kubeconfig` used to access s390x remote k8s cluster to run s390x tests there
 - `GCP` secrets:
   - `nightly-account` is used by nightly releases to push releases
   to the nightly bucket. It's a token for service account

--- a/tekton/cronjobs/bases/nightly-tests/README.md
+++ b/tekton/cronjobs/bases/nightly-tests/README.md
@@ -1,0 +1,1 @@
+Cron Job template to run nightly tests.

--- a/tekton/cronjobs/bases/nightly-tests/kustomization.yaml
+++ b/tekton/cronjobs/bases/nightly-tests/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- trigger-nightly-test.yaml

--- a/tekton/cronjobs/bases/nightly-tests/trigger-nightly-test.yaml
+++ b/tekton/cronjobs/bases/nightly-tests/trigger-nightly-test.yaml
@@ -1,0 +1,67 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 0 1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: workspace
+            emptyDir: {}
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            command:
+              - /bin/sh
+            args:
+              - -ce
+              - |
+                cat <<EOF > /workspace/post-body.json
+                {
+                  "trigger-template": "$TARGET_PROJECT",
+                  "params": {
+                    "target": {
+                      "registry": "$REGISTRY",
+                      "targetArch": "$TARGET_ARCH",
+                      "kubeconfigSecret": "$KUBECONFIG_SECRET"
+                    },
+                    "run": {
+                      "namespace": "$NAMESPACE"
+                    }
+                  }
+                }
+                EOF
+                curl -d @/workspace/post-body.json $SINK_URL
+            volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            env:
+              - name: SINK_URL
+                value: "sink-url"
+              - name: TARGET_PROJECT
+                value: "pipeline"
+              - name: NAMESPACE
+                value: "bastion-z"
+              - name: REGISTRY
+                value: "registry"
+              - name: TARGET_ARCH
+                value: "s390x"
+              - name: KUBECONFIG_SECRET
+                value: "secret"
+          restartPolicy: Never

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/README.md
@@ -1,0 +1,1 @@
+Cron Job to daily cleanup pr/tr from the default namespace in the dogfooding cluster

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+spec:
+  schedule: "0 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: NAMESPACE
+                value: "bastion-z"
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tektoncd-cleaner"
+              - name: CLEANUP_KEEP
+                value: "200"

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/cleanup
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-bastion-z"

--- a/tekton/cronjobs/dogfooding/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - manifests
 - releases
 - tekton
+- nightly-tests

--- a/tekton/cronjobs/dogfooding/nightly-tests/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/kustomization.yaml
@@ -1,0 +1,3 @@
+namespace: default
+resources:
+- pipeline-nightly-test

--- a/tekton/cronjobs/dogfooding/nightly-tests/pipeline-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/pipeline-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly pipeline e2e tests.

--- a/tekton/cronjobs/dogfooding/nightly-tests/pipeline-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/pipeline-nightly-test/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 1 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "pipeline"
+            - name: NAMESPACE
+              value: "bastion-z"
+            - name: REGISTRY
+              value: "sshd.bastion-z.svc.cluster.local:4000"
+            - name: TARGET_ARCH
+              value: "s390x"
+            - name: KUBECONFIG_SECRET
+              value: "s390x-kubeconfig"

--- a/tekton/cronjobs/dogfooding/nightly-tests/pipeline-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/pipeline-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-pipeline"

--- a/tekton/resources/nightly-tests/bastion-z/deploy_test_cleanup.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/deploy_test_cleanup.yaml
@@ -1,0 +1,165 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-tekton-project-nightly
+spec:
+  params:
+  - name: package
+    description: package to install
+  - name: container-registry
+    description: container registry used to publish build images
+  - name: kubeconfig-secret
+    description: secret with kubeconfig for remote cluster
+  - name: target-arch
+    description: target architecture for tests (s390x, ppc64le, arm64)
+  resources:
+    inputs:
+    - name: tekton-project-source
+      type: git
+      targetPath: src/$(params.package)
+  steps:
+  - name: deploy
+    workingdir: /workspace/src/$(params.package)
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: KO_DOCKER_REPO
+      value: $(params.container-registry)
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      ko apply --platform=linux/$(params.target-arch) -f config/
+      kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s
+    volumeMounts:
+    - name: kubeconfig-secret
+      mountPath: /root/.kube
+  volumes:
+  - name: kubeconfig-secret
+    secret:
+      secretName: $(params.kubeconfig-secret)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: e2e-tests
+spec:
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: tests-path
+    description: path to the tests within "tests" git resource
+    default: ./test
+  - name: timeout
+    description: timeout for the go test runner
+    default: 30m
+  - name: container-registry
+    description: container registry used to push images during tests e.g. gcr.io/tekton-e2e-tests or icr.io/tekton-e2e-tests
+  - name: tags
+    default: e2e
+  - name: target-arch
+    description: target architecture for tests (s390x, ppc64le, arm64)
+  - name: kubeconfig-secret
+    description: secret with kubeconfig for remote cluster
+  resources:
+    inputs:
+    - name: plumbing-source
+      type: git
+    - name: tekton-project-source
+      type: git
+      targetPath: src/$(params.package)
+  steps:
+  - name: run-e2e-tests
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    workingdir: /workspace/src/$(params.package)
+    env:
+    - name: REPO_ROOT_DIR
+      value: $(resources.inputs.tekton-project-source.path)
+    - name: GOPATH
+      value: /workspace
+    - name: KO_DOCKER_REPO
+      value: $(params.container-registry)
+    - name: TEST_RUNTIME_ARCH
+      value: $(params.target-arch)
+    - name: SYSTEM_NAMESPACE
+      value: tekton-pipelines
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      source $(resources.inputs.plumbing-source.path)/scripts/library.sh
+      # extend test timeout (from 10 minutes to 20 minutes) to resolve https://github.com/tektoncd/pipeline/issues/3627
+      sed -i 's/timeout  = 10/timeout  = 20/g' test/wait.go
+      header "Running Go $(params.tags) tests"
+      report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path) -kubeconfig /root/.kube/config
+    volumeMounts:
+    - name: kubeconfig-secret
+      mountPath: /root/.kube
+  volumes:
+  - name: kubeconfig-secret
+    secret:
+      secretName: $(params.kubeconfig-secret)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup-tekton-nightly
+spec:
+  params:
+  - name: package
+  - name: resources
+    description: space separated list of resources to be deleted
+    default: "conditions pipelineresources tasks pipelines taskruns pipelineruns"
+  - name: kubeconfig-secret
+    description: secret with kubeconfig for remote cluster
+  resources:
+    inputs:
+    - name: plumbing-source
+      type: git
+    - name: tekton-project-source
+      type: git
+      targetPath: src/$(params.package)
+  steps:
+  - name: cleanup-resources
+    image: gcr.io/tekton-releases/dogfooding/kubectl:latest
+    env:
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    command:
+    - /bin/sh
+    args:
+    - -ce
+    - |
+      kubectl delete ns -l tekton.dev/test-e2e=true
+      for res in $(params.resources); do
+        kubectl delete --ignore-not-found=true ${res}.tekton.dev --all || return true
+      done
+    volumeMounts:
+    - name: kubeconfig-secret
+      mountPath: /root/.kube
+  - name: uninstall-tekton-project
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    workingdir: /workspace/src/$(params.package)
+    env:
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      source $(resources.inputs.plumbing-source.path)/scripts/library.sh
+      ko delete --ignore-not-found=true -f config/
+      wait_until_object_does_not_exist namespace tekton-pipelines
+    volumeMounts:
+    - name: kubeconfig-secret
+      mountPath: /root/.kube
+  volumes:
+  - name: kubeconfig-secret
+    secret:
+      secretName: $(params.kubeconfig-secret)

--- a/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
@@ -1,0 +1,6 @@
+namespace: bastion-z
+commonAnnotations:
+  managed-by: Tekton
+
+resources:
+- deploy_test_cleanup.yaml

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -1,0 +1,32 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: test-nightly
+spec:
+  serviceAccountName: tekton-test-nightly
+  triggers:
+  - name: pipeline-nightly-test-trigger
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'pipeline'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      name: tekton-pipeline-nightly-test
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: trigger-to-deploy-test-tekton-project
+spec:
+  params:
+  - name: namespace
+    value: $(body.params.run.namespace)
+  - name: containerRegistry
+    value: $(body.params.target.registry)
+  - name: targetArch
+    value: $(body.params.target.targetArch)
+  - name: kubeconfigSecret
+    value: $(body.params.target.kubeconfigSecret)

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -1,0 +1,8 @@
+commonAnnotations:
+  managed-by: Tekton
+
+resources:
+- bastion-z
+- eventlistener.yaml
+- pipeline-deploy-test-template.yaml
+- serviceaccount.yaml

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-template.yaml
@@ -1,0 +1,123 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-pipeline-nightly-test
+spec:
+  params:
+  - name: containerRegistry
+  - name: kubeconfigSecret
+  - name: targetArch
+  - name: namespace
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-pipeline-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      pipelineSpec:
+        resources:
+        - name: plumbing-source
+          type: git
+        - name: tekton-pipeline-source
+          type: git
+        params:
+        - name: package
+        - name: container-registry
+        - name: kubeconfig-secret
+        - name: target-arch
+        - name: resources
+        tasks:
+        - name: deploy-pipeline
+          taskRef:
+            name: deploy-tekton-project-nightly
+          params:
+          - name: package
+            value: $(params.package)
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: kubeconfig-secret
+            value: $(params.kubeconfig-secret)
+          - name: target-arch
+            value: $(params.target-arch)
+          resources:
+            inputs:
+            - name: tekton-project-source
+              resource: tekton-pipeline-source
+        - name: e2e-test-pipeline
+          runAfter: [deploy-pipeline]
+          taskRef:
+            name: e2e-tests
+          params:
+          - name: package
+            value: $(params.package)
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: kubeconfig-secret
+            value: $(params.kubeconfig-secret)
+          - name: target-arch
+            value: $(params.target-arch)
+          resources:
+            inputs:
+            - name: plumbing-source
+              resource: plumbing-source
+            - name: tekton-project-source
+              resource: tekton-pipeline-source
+        finally:
+        - name: cleanup
+          taskRef:
+            name: cleanup-tekton-nightly
+          params:
+          - name: package
+            value: $(params.package)
+          - name: resources
+            value: $(params.resources)
+          - name: kubeconfig-secret
+            value: $(params.kubeconfig-secret)
+          resources:
+            inputs:
+            - name: plumbing-source
+              resource: plumbing-source
+            - name: tekton-project-source
+              resource: tekton-pipeline-source
+      params:
+      - name: package
+        value: github.com/tektoncd/pipeline
+      - name: resources
+        value: "conditions pipelineresources tasks pipelines taskruns pipelineruns"
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: kubeconfig-secret
+        value: $(tt.params.kubeconfigSecret)
+      - name: target-arch
+        value: $(tt.params.targetArch)
+      resources:
+      - name: tekton-pipeline-source
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: master
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+      - name: plumbing-source
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: master
+          - name: url
+            value: https://github.com/tektoncd/plumbing

--- a/tekton/resources/nightly-tests/serviceaccount.yaml
+++ b/tekton/resources/nightly-tests/serviceaccount.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-test-nightly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-test-nightly-trigger-default
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: tekton-test-nightly
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-test-triggers-nightly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-test-nightly-trigger-bastion-z
+  namespace: bastion-z
+subjects:
+- kind: ServiceAccount
+  name: tekton-test-nightly
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-test-triggers-nightly
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-test-triggers-nightly-clusterrole
+rules:
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["clustertriggerbindings"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-test-triggers-nigthly-clusterbinding
+subjects:
+- kind: ServiceAccount
+  name: tekton-test-nightly
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-test-triggers-nightly-clusterrole
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-test-triggers-nightly
+rules:
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "pipelineresources", "taskruns"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["impersonate"]


### PR DESCRIPTION
# Changes

Add cronjob, trigger and pipeline to run s390x pipeline repo e2e tests on remote s390x cluster. Access to s390x cluster is already available on top of dogfooding cluster in bastion-z namespace.
Cronjob allows to specify:
- registry to be used for ko builds
- namespace where pipelinerun should be executed
- name of secret with kubeconfig for s390x cluster
- architectire for code build and tests
Pipeline consists of:
- pipeline code deployment via `ko apply`
- e2e test
- cleanup, which will be performed despite success of failure of previous steps

This setup expects to have kubeconfig for s390x cluster available as secret.
The source code to test is always from master branch.
Cleanup cronjob is extended to control number of stored pipelineruns in bastion-z
namespace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
/cc @afrittoli 