### PR TITLE
Add missing ko prefix to image

### DIFF
--- a/tekton/ci/interceptors/add-pr-body/config/add-pr-body.yaml
+++ b/tekton/ci/interceptors/add-pr-body/config/add-pr-body.yaml
@@ -31,6 +31,10 @@ spec:
       containers:
         - name: add-pr-body-interceptor
           image: ko://github.com/tektoncd/plumbing/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body
+          securityContext:
+            allowPrivilegeEscalation: false
+            # User 65532 is the distroless nonroot user ID
+            runAsUser: 65532
 ---
 apiVersion: v1
 kind: Service

--- a/tekton/ci/interceptors/add-pr-body/config/add-pr-body.yaml
+++ b/tekton/ci/interceptors/add-pr-body/config/add-pr-body.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: add-pr-body-bot
       containers:
         - name: add-pr-body-interceptor
-          image: github.com/tektoncd/plumbing/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body
+          image: ko://github.com/tektoncd/plumbing/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It seems like the `ko` prefix is missing in the `add-pr-body` `Deployment` manifest. I also set runAsUser uid for nonroot distroless image, otherwise I'd get `container has runAsNonRoot and image will run as root` when trying to deploy.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._