### PR TITLE
Update infra monitoring role name to buildcaptain

### DIFF
--- a/bots/buildbot/README.md
+++ b/bots/buildbot/README.md
@@ -1,11 +1,11 @@
-# Tekton buildcop
+# Tekton buildcaptain
 
-This folder holds the Slack buildcop bot code and configuration.
+This folder holds the Slack buildcaptain bot code and configuration.
 
-* [Build Cop Runbook](https://docs.google.com/document/d/1QJV0z2bMXdz_BZOkBwfxIP1BiktUb8c1lcifwqxF5wg/edit)
-* [Build Cop Log](https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk/edit#)
+* [Build Captain Runbook](https://docs.google.com/document/d/1QJV0z2bMXdz_BZOkBwfxIP1BiktUb8c1lcifwqxF5wg/edit)
+* [Build Captain Log](https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk/edit#)
 
-Current buildcops are:
+Current buildcaptains are:
 - Andrea Frittoli @afrittoli (andrea.frittoli)
 - Billy Lynch @wlynch (wlynch)
 - Dibyo Mukherjee @dibyom (dibyo)
@@ -15,11 +15,11 @@ Current buildcops are:
 - Sharon Jerop Kipruto @jerop (jerop)
 - Vincent Demeester @vdemeester (vdemeest)
 
-Other folks who are not build cops but have build cop access:
+Other folks who are not build captains but have build captain access:
 - Sunil Thaha @sthaha
 - Priti Desai @pritidesai
 
-Build cop access is given with [addpermissions.py](../../addpermissions.py).
+Build captain access is given with [addpermissions.py](../../addpermissions.py).
 
 ## Rotation
 

--- a/bots/buildbot/cmd/buildbot/main.go
+++ b/bots/buildbot/cmd/buildbot/main.go
@@ -13,10 +13,10 @@ import (
 const rotationURL = "https://raw.githubusercontent.com/tektoncd/plumbing/master/bots/buildbot/rotation.csv"
 
 var (
-	currentCop string
-	botID      string
-	token      string
-	channelID  string
+	currentCaptain string
+	botID          string
+	token          string
+	channelID      string
 
 	vdemeest string
 )
@@ -43,20 +43,20 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	copsID := map[string]string{}
+	captainsID := map[string]string{}
 	for _, user := range users {
 		if user.Name == "vdemeest" {
 			vdemeest = user.ID
 		}
-		copsID[user.Name] = user.ID
+		captainsID[user.Name] = user.ID
 	}
 
 	r := NewRotation(FromURL(rotationURL))
-	currentCop = copsID[r.GetBuildCop(time.Now())]
+	currentCaptain = captainsID[r.GetBuildCaptain(time.Now())]
 
 	rtm := api.NewRTM()
 	go rtm.ManageConnection()
-	go dailyPing(rtm, copsID, r)
+	go dailyPing(rtm, captainsID, r)
 
 	for msg := range rtm.IncomingEvents {
 		switch ev := msg.Data.(type) {
@@ -88,11 +88,11 @@ func main() {
 func handleMessage(rtm *slack.RTM, message, channel string, direct bool) {
 	switch {
 	case statusMessage(message, botID, direct):
-		rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("<@%s> is the buildcop :cop:\nBuildcop log is here: https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk", currentCop), channel))
+		rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("<@%s> is the buildcaptain :cop:\nBuildcaptain log is here: https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk", currentCaptain), channel))
 	case easterEggMessage(message, botID, direct):
 		rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("<@%s> is my master :meow-wow:, and he is old :older_man:, grumpy :face_with_raised_eyebrow: but awesome :hooray: :meow-party:", vdemeest), channel))
 	case directMessage(message, botID, direct):
-		rtm.SendMessage(rtm.NewOutgoingMessage(":thinking_face: I ain't smart :zany_face:, I don't understand what you are telling me :robot_face: …\n Try to tell me `status` or `who is the buildcop ?` :sunglasses:", channel))
+		rtm.SendMessage(rtm.NewOutgoingMessage(":thinking_face: I ain't smart :zany_face:, I don't understand what you are telling me :robot_face: …\n Try to tell me `status` or `who is the buildcaptain ?` :sunglasses:", channel))
 	}
 }
 
@@ -127,7 +127,7 @@ func getEasterEggMessages(botID string, direct bool) []string {
 }
 
 func getStatusMessages(botID string, direct bool) []string {
-	return getMessages([]string{"who is the buildcop ?", "buildcop ?", "status"}, botID, direct)
+	return getMessages([]string{"who is the buildcaptain ?", "buildcaptain ?", "status"}, botID, direct)
 }
 
 func getMessages(messages []string, botID string, direct bool) []string {
@@ -141,14 +141,14 @@ func getMessages(messages []string, botID string, direct bool) []string {
 	return ms
 }
 
-func dailyPing(rtm *slack.RTM, copsID map[string]string, r Rotation) {
+func dailyPing(rtm *slack.RTM, captainsID map[string]string, r Rotation) {
 	jt := NewJobTicker()
 	for {
 		<-jt.t.C
-		currentCop = copsID[r.GetBuildCop(time.Now())]
-		if currentCop != "" {
-			// Only send the daily ping if there is actually a buildcop.
-			rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("Hello :wave: today's <@%s> is the buildcop :cop:\nBuildcop log is here: https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk", currentCop), channelID))
+		currentCaptain = captainsID[r.GetBuildCaptain(time.Now())]
+		if currentCaptain != "" {
+			// Only send the daily ping if there is actually a buildcaptain.
+			rtm.SendMessage(rtm.NewOutgoingMessage(fmt.Sprintf("Hello :wave: today's <@%s> is the buildcaptain :cop:\nBuildcaptain log is here: https://docs.google.com/document/d/1kUzH8SV4coOabXLntPA1QI01lbad3Y1wP5BVyh4qzmk", currentCaptain), channelID))
 		}
 		jt.updateJobTicker()
 	}

--- a/bots/buildbot/cmd/buildbot/rotation.go
+++ b/bots/buildbot/cmd/buildbot/rotation.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// The Rotation object which knows how to dynamically find the correct build cop from
+// The Rotation object which knows how to dynamically find the correct build captain from
 // the file getter f it is initialized with.
 type Rotation struct {
 	f GetFile
@@ -35,19 +35,19 @@ func NewRotation(f GetFile) Rotation {
 	return Rotation{f: f}
 }
 
-// GetBuildCop returns the name of the build cop for the requested time
-func (r Rotation) GetBuildCop(t time.Time) string {
+// GetBuildCaptain returns the name of the build captain for the requested time
+func (r Rotation) GetBuildCaptain(t time.Time) string {
 	tf := t.Format("2006-01-02") // Mon Jan 2 15:04:05 MST 2006
 	f, err := r.f()
 	if err != nil {
-		log.Printf("Could not read from build cop rotation: %v", err)
+		log.Printf("Could not read from build captain rotation: %v", err)
 		return "nobody"
 	}
 	defer f.Close()
 	rotation, err := parseRotation(f)
 
 	if err != nil {
-		log.Printf("Could not read rotation from build cop rotation: %v", err)
+		log.Printf("Could not read rotation from build captain rotation: %v", err)
 		return "nobody"
 	}
 	b, ok := rotation[tf]

--- a/bots/buildbot/cmd/buildbot/rotation_test.go
+++ b/bots/buildbot/cmd/buildbot/rotation_test.go
@@ -18,47 +18,47 @@ func fromFile(file string) GetFile {
 	}
 }
 
-func TestGetBuildCop(t *testing.T) {
+func TestGetBuildCaptain(t *testing.T) {
 	r := NewRotation(fromFile("testdata/rotation.csv"))
 
 	for _, c := range []struct {
-		desc        string
-		time        time.Time
-		expectedCop string
+		desc            string
+		time            time.Time
+		expectedCaptain string
 	}{{
-		desc:        "success",
-		time:        time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC),
-		expectedCop: "christiewilson",
+		desc:            "success",
+		time:            time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC),
+		expectedCaptain: "christiewilson",
 	}, {
-		desc:        "no one on the date",
-		time:        time.Date(2019, time.December, 15, 0, 0, 0, 0, time.UTC),
-		expectedCop: "",
+		desc:            "no one on the date",
+		time:            time.Date(2019, time.December, 15, 0, 0, 0, 0, time.UTC),
+		expectedCaptain: "",
 	}, {
-		desc:        "time not found",
-		time:        time.Date(2016, time.August, 15, 0, 0, 0, 0, time.UTC),
-		expectedCop: "nobody",
+		desc:            "time not found",
+		time:            time.Date(2016, time.August, 15, 0, 0, 0, 0, time.UTC),
+		expectedCaptain: "nobody",
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			cop := r.GetBuildCop(c.time)
-			if cop != c.expectedCop {
-				t.Errorf("Expected build cop %s for %s but got %s", c.expectedCop, c.time, cop)
+			captain := r.GetBuildCaptain(c.time)
+			if captain != c.expectedCaptain {
+				t.Errorf("Expected build captain %s for %s but got %s", c.expectedCaptain, c.time, captain)
 			}
 		})
 	}
 }
 
-func TestGetBuildCop_InvalidFile(t *testing.T) {
+func TestGetBuildCaptain_InvalidFile(t *testing.T) {
 	r := NewRotation(fromFile("testdata/rotation-invalid.csv"))
-	cop := r.GetBuildCop(time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC))
-	if cop != "nobody" {
-		t.Errorf("Expected build cop nobody when file is invalid but got %s", cop)
+	captain := r.GetBuildCaptain(time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC))
+	if captain != "nobody" {
+		t.Errorf("Expected build captain nobody when file is invalid but got %s", captain)
 	}
 }
 
-func TestGetBuildCop_MissingFile(t *testing.T) {
+func TestGetBuildCaptain_MissingFile(t *testing.T) {
 	r := NewRotation(fromFile("testdata/rotation-missing.csv"))
-	cop := r.GetBuildCop(time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC))
-	if cop != "nobody" {
-		t.Errorf("Expected build cop nobody when file is not found but got %s", cop)
+	captain := r.GetBuildCaptain(time.Date(2019, time.December, 4, 0, 0, 0, 0, time.UTC))
+	if captain != "nobody" {
+		t.Errorf("Expected build captain nobody when file is not found but got %s", captain)
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->


We recently surveyed folks on their preferred name for the infra
monitoring rotation we run to keep an eye on our nightlies and
PR infra. "BuildCaptain" won the day.

Updating as many references as I can find here. I haven't updated the deployment yet, just the
buildbot code.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._