### PR TITLE
Bump buildx version to the latest one

### DIFF
--- a/tekton/images/buildx-gcloud/Dockerfile
+++ b/tekton/images/buildx-gcloud/Dockerfile
@@ -15,5 +15,5 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 RUN  mkdir -p ~/.docker/cli-plugins \
-     && curl -fsSL https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64 > ~/.docker/cli-plugins/docker-buildx \
+     && curl -fsSL https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx \
      && chmod u+x ~/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
# Changes

Use the latest buildx version can help with sporadic multi-arch image build failures connected to buildkit startup.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._