### PR TITLE
Fix the deployer role to deploy hpa and disruption budget

### DIFF
--- a/robocat/cadmin/200-rbac.yaml
+++ b/robocat/cadmin/200-rbac.yaml
@@ -32,13 +32,13 @@ rules:
     resources: [clusterroles, clusterrolebindings]
     verbs: ["*"]
   - apiGroups: [policy]
-    resources: [podsecuritypolicies, poddisruptionbudget]
+    resources: [podsecuritypolicies, poddisruptionbudgets]
     verbs: ["*"]
   - apiGroups: [extensions]
     resources: [ingresses]
     verbs: ["*"]
   - apiGroups: [autoscaling]
-    resources: [horizontalpodautoscaler]
+    resources: [horizontalpodautoscalers]
     verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Tekton deployer role should be able to deploy HPA and
disruption budgets. They're in the role already, but missing
and "s".

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug