### PR TITLE
Add a cronjob to deploy cronjobs that target robocat

### DIFF
--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/README.md
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/README.md
@@ -1,0 +1,5 @@
+# Tetkon Cronjobs CD - Dogfooding Cluster for Robocat
+
+Cron Job to daily apply the Tekton cronjobs in the tekton/cronjobs/robocat folder,
+from the plumbing repo, running on the dogfooding cluster, targeting the robocat
+cluster.

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/cronjob.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: folder-cd-trigger
+spec:
+  schedule: "50 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: GIT_REPOSITORY
+                value: "github.com/tektoncd/plumbing"
+              - name: GIT_REVISION
+                value: "master"
+              - name: NAMESPACE
+                value: "default"
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tekton-cd"
+              - name: FOLDER_PATH
+                value: "tekton/cronjobs/robocat"
+              - name: FOLDER_DESCRIPTION
+                value: "tekton-cronjobs-robocat"
+              - name: FOLDER_OVERLAY
+                value: "true"

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/folder
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-tekton-cronjobs-robocat"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We already have a cronjob to the deploy the definitions of
cronjobs that run on dogfooding and target dogfooding;
add one that deploys the definitions of cronjobs that run
on dogfooding and target robocat.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc