### PR TITLE
Remove creds-init image from pipeline overlay

### DIFF
--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -50,9 +50,6 @@
         - name: builtKubeconfigWriterImage
           resourceRef:
             name: kubeconfigwriter-image
-        - name: builtCredsInitImage
-          resourceRef:
-            name: creds-init-image
         - name: builtGitInitImage
           resourceRef:
             name: git-init-image


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The pipelines overlay template still had mention of creds-init
image which was removed from the pipelines project.

See commit https://github.com/tektoncd/pipeline/commit/c8a1623def283939193cb3d1ec3ab7954f404e53
for the removal.

This commit removes mention of creds-init from the list of built images
in the pipeline overlay.



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._