### PR TITLE
Force GOROOT to /usr/local/go on images…

### DIFF
--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -32,6 +32,7 @@ LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 RUN curl https://dl.google.com/go/go1.15.linux-amd64.tar.gz > go1.15.tar.gz
 RUN tar -C /usr/local -xzf go1.15.tar.gz
 ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOROOT /usr/local/go
 
 # Install ko
 ARG KO_VERSION=0.7.0

--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -14,6 +14,7 @@
 FROM golang:1.15-alpine3.12
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
+ENV GOROOT /usr/local/go
 RUN apk add --no-cache curl ca-certificates
 RUN update-ca-certificates
 

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -149,6 +149,7 @@ ARG GO_VERSION=1.15.2
 RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz > go${GO_VERSION}.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.tar.gz && \
     rm go${GO_VERSION}.tar.gz
+ENV GOROOT /usr/local/go
 
 # Extra tools through apt
 RUN apt update && apt install -y uuid-runtime  # for uuidgen


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The main reason to do this is to make sure `ko` and other go tool
work as expected even if the go version used to build `ko` is
different from the version that is shipped in the image.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @afrittoli 

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._