### PR TITLE
Fix the task that extracts release notes

### DIFF
--- a/tekton/resources/release/github_release.yaml
+++ b/tekton/resources/release/github_release.yaml
@@ -127,7 +127,8 @@ spec:
         # First process pull requests that have release notes
         # Extract the release notes but drop lines that match an unmodified PR template
         # || true in case all PRs are "release-note-none"
-        grep -v "release-note-none" $HOME/pr.csv || true | while read pr; do
+        grep -v "release-note-none" $HOME/pr.csv > $HOME/pr-notes-tmp.csv || true
+        cat $HOME/pr-notes-tmp.csv | while read pr; do
           PR_NUM=$(echo $pr | cut -d';' -f2)
           PR_RELEASE_NOTES_B64=$(wget -O- https://api.github.com/repos/${PROJECT}/issues/${PR_NUM:1} | \
             jq .body -r | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | \
@@ -139,7 +140,7 @@ spec:
 
         # Copy pull requests without release notes to a dedicated file
         # || true in case no PRs have "release-note-none"
-        grep "release-note-none" $HOME/pr.csv || true > $HOME/pr-no-notes.csv
+        grep "release-note-none" $HOME/pr.csv > $HOME/pr-no-notes.csv || true
     - name: body
       image: busybox
       script: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix the task so that it extract release notes when available and
it does not fail if no release notes are available or if all PRs
do have release notes.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug