### PR TITLE
[Catlin] Add a script linter command

### DIFF
--- a/catlin/go.mod
+++ b/catlin/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/tektoncd/pipeline v0.15.2
 	go.uber.org/zap v1.15.0
+	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.0.2
-
 	k8s.io/api v0.17.6
 	k8s.io/apimachinery v0.17.6
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible

--- a/catlin/pkg/cmd/linter/linter.go
+++ b/catlin/pkg/cmd/linter/linter.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Tekton Authors.
+// Copyright © 2021 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package linter
 
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/plumbing/catlin/pkg/app"
-	"github.com/tektoncd/plumbing/catlin/pkg/cmd/linter"
-	"github.com/tektoncd/plumbing/catlin/pkg/cmd/validate"
 )
 
-func Root(cli app.CLI) *cobra.Command {
-	var cmd = &cobra.Command{
-		Use:          "catlin",
-		Short:        "Lints Tekton Resources and Catalogs",
-		Long:         ``,
-		SilenceUsage: true,
+func Command(p app.CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Lint resources",
 	}
 
 	cmd.AddCommand(
-		validate.Command(cli),
-		linter.Command(cli),
+		scriptCommand(p),
 	)
-
 	return cmd
 }

--- a/catlin/pkg/cmd/linter/script.go
+++ b/catlin/pkg/cmd/linter/script.go
@@ -1,0 +1,112 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linter
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/plumbing/catlin/pkg/app"
+	"github.com/tektoncd/plumbing/catlin/pkg/linter"
+	"github.com/tektoncd/plumbing/catlin/pkg/parser"
+	"github.com/tektoncd/plumbing/catlin/pkg/validator"
+)
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func validResourcePath() cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("requires at least 1 path to tekton resource yaml but received none")
+		}
+
+		if !fileExists(args[0]) {
+			return fmt.Errorf("no such file - %s", args[0])
+		}
+		return nil
+	}
+}
+
+func scriptCommand(cli app.CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "script",
+		Args:  validResourcePath(),
+		Short: "Validate script with installed linter",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return scriptLint(cli, args)
+		},
+	}
+}
+
+func scriptLint(cli app.CLI, paths []string) error {
+	errors := []string{}
+	for _, path := range paths {
+		r, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		// parse
+		parser := parser.ForReader(r)
+		res, err := parser.Parse()
+		if err != nil {
+			return err
+		}
+
+		linters := []linter.Linter{
+			linter.NewScriptLinter(res),
+		}
+
+		result := validator.Result{}
+		for _, v := range linters {
+			result.Append(v.Validate())
+		}
+
+		// print result
+		out := cli.Stream().Out
+		for _, v := range result.Lints {
+			switch v.Kind {
+			case validator.Error:
+				fmt.Fprintf(out, "ERROR: %s\n", v.Message)
+			case validator.Warning:
+				fmt.Fprintf(out, "WARN : %s\n", v.Message)
+			case validator.Recommendation:
+				fmt.Fprintf(out, "HINT : %s\n", v.Message)
+			case validator.Info:
+				fmt.Fprintf(out, "INFO : %s\n", v.Message)
+			default:
+				level := strings.ToUpper(fmt.Sprint(v.Kind))
+				fmt.Fprintf(out, "%s : %s\n", level, v.Message)
+			}
+		}
+		if result.Errors != 0 {
+			errors = append(errors, path)
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("Files \"%s\" has failed validation", strings.Join(errors, ", "))
+	}
+
+	return nil
+}

--- a/catlin/pkg/cmd/validate/validate.go
+++ b/catlin/pkg/cmd/validate/validate.go
@@ -97,7 +97,7 @@ func validate(cli app.CLI, path string) error {
 		case validator.Info:
 			fmt.Fprintf(out, "INFO : %s\n", v.Message)
 		default:
-			level := strings.ToUpper(string(v.Kind))
+			level := strings.ToUpper(fmt.Sprint(v.Kind))
 			fmt.Fprintf(out, "%s : %s\n", level, v.Message)
 		}
 	}

--- a/catlin/pkg/linter/linter.go
+++ b/catlin/pkg/linter/linter.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Tekton Authors.
+// Copyright © 2021 The Tekton Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package linter
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/tektoncd/plumbing/catlin/pkg/app"
-	"github.com/tektoncd/plumbing/catlin/pkg/cmd/linter"
-	"github.com/tektoncd/plumbing/catlin/pkg/cmd/validate"
+	"github.com/tektoncd/plumbing/catlin/pkg/validator"
 )
 
-func Root(cli app.CLI) *cobra.Command {
-	var cmd = &cobra.Command{
-		Use:          "catlin",
-		Short:        "Lints Tekton Resources and Catalogs",
-		Long:         ``,
-		SilenceUsage: true,
-	}
-
-	cmd.AddCommand(
-		validate.Command(cli),
-		linter.Command(cli),
-	)
-
-	return cmd
+type Linter interface {
+	Validate() validator.Result
 }

--- a/catlin/pkg/linter/script.go
+++ b/catlin/pkg/linter/script.go
@@ -1,0 +1,170 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linter
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/plumbing/catlin/pkg/parser"
+	"github.com/tektoncd/plumbing/catlin/pkg/validator"
+)
+
+type taskLinter struct {
+	res     *parser.Resource
+	configs []config
+}
+
+type linter struct {
+	cmd  string
+	args []string
+}
+
+type config struct {
+	regexp  string
+	linters []linter
+}
+
+// NewConfig construct default config
+func NewConfig() []config {
+	return []config{
+		// Default one is the first one
+		config{regexp: `(/usr/bin/env |.*/bin/)sh`,
+			linters: []linter{
+				linter{
+					cmd:  "shellcheck",
+					args: []string{"-s", "sh"},
+				},
+				linter{
+					cmd:  "sh",
+					args: []string{"-n"},
+				},
+			}},
+		config{regexp: `(/usr/bin/env |.*/bin/)bash`,
+			linters: []linter{
+				linter{
+					cmd:  "shellcheck",
+					args: []string{"-s", "bash"},
+				},
+				linter{
+					cmd:  "bash",
+					args: []string{"-n"},
+				},
+			}},
+		config{regexp: `(/usr/bin/env\s|.*/bin/|/usr/libexec/platform-)python(23)?`,
+			linters: []linter{
+				linter{
+					cmd:  "pylint",
+					args: []string{"-dC0103"}, // Disabling C0103 which is invalid name convention
+				},
+			}},
+	}
+}
+
+// NewScriptLinter construct a new task lister struct
+func NewScriptLinter(r *parser.Resource) *taskLinter {
+	return &taskLinter{res: r, configs: NewConfig()}
+}
+
+func (t *taskLinter) validateScript(taskName string, s v1beta1.Step, configs []config) validator.Result {
+	result := validator.Result{}
+
+	// use /bin/sh by default if no shbang
+	if s.Script[0:2] != "#!" {
+		s.Script = "#!/usr/bin/env sh\n" + s.Script
+	} else { // using a shbang, check if we have /usr/bin/env
+		if s.Script[0:14] != "#!/usr/bin/env" {
+			result.Warn("step: %s is not using #!/usr/bin/env ", taskName)
+		}
+	}
+
+	for _, config := range configs {
+		matched, err := regexp.MatchString(`^#!`+config.regexp+`\n`, s.Script)
+
+		if err != nil {
+			result.Error("Invalid regexp: %s", config.regexp)
+			return result
+		}
+
+		if !matched {
+			continue
+		}
+
+		for _, linter := range config.linters {
+			execpath, err := exec.LookPath(linter.cmd)
+			if err != nil {
+				result.Warn("Couldn't find the linter %s in the path", linter.cmd)
+				continue
+			}
+			tmpfile, err := ioutil.TempFile("", "catlin-script-linter")
+			if err != nil {
+				result.Error("Cannot create temporary files")
+				return result
+			}
+			defer os.Remove(tmpfile.Name()) // clean up
+			if _, err := tmpfile.Write([]byte(s.Script)); err != nil {
+				result.Error("Cannot write to temporary files")
+				return result
+			}
+			if err := tmpfile.Close(); err != nil {
+				result.Error("Cannot close temporary files")
+				return result
+			}
+
+			// TODO: perhaps the filename is not necessary will be at the end of
+			// a command, may need some variable interpolation so the linter can
+			// specify where the filaname is into the command line.
+			cmd := exec.Command(execpath, append(linter.args, tmpfile.Name())...)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				outt := strings.ReplaceAll(string(out), tmpfile.Name(), taskName+"-"+s.Name)
+				result.Error("%s, %s failed:\n%s", execpath, linter.args, outt)
+			}
+		}
+	}
+
+	return result
+}
+
+func (t *taskLinter) collectOverSteps(steps []v1beta1.Step, name string, result *validator.Result) {
+	for _, step := range steps {
+		if step.Script != "" {
+			result.Append(t.validateScript(name, step, t.configs))
+		}
+	}
+}
+
+func (t *taskLinter) Validate() validator.Result {
+	result := validator.Result{}
+	res, err := t.res.ToType()
+	if err != nil {
+		result.Error("Failed to decode to a Task - %s", err)
+		return result
+	}
+
+	switch strings.ToLower(t.res.Kind) {
+	case "task":
+		task := res.(*v1beta1.Task)
+		t.collectOverSteps(task.Spec.Steps, task.ObjectMeta.Name, &result)
+	case "clustertask":
+		task := res.(*v1beta1.ClusterTask)
+		t.collectOverSteps(task.Spec.Steps, task.ObjectMeta.Name, &result)
+	}
+	return result
+}

--- a/catlin/pkg/linter/script_test.go
+++ b/catlin/pkg/linter/script_test.go
@@ -1,0 +1,156 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/plumbing/catlin/pkg/parser"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+const taskScriptValidatorGood = `
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: hello-moto
+spec:
+  steps:
+  - name: s1
+    image: image1
+    script: |
+      #!/usr/bin/env sh
+      echo "Hello world"
+    script: |
+      #!/bin/sh
+      echo "hello moto"
+`
+
+const taskScriptValidatorNoGood = `
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: hello-moto
+spec:
+  steps:
+  - name: nogood
+    image: image1
+    script: |
+      #!/usr/bin/env sh
+      '
+  - name: warn
+    image: image1
+    script: |
+      #!/bin/sh
+      echo "hello world"
+`
+
+const clusterTaskTest = `
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: hello-moto
+spec:
+  steps:
+  - name: nogood
+    image: image1
+    script: |
+      #!/usr/bin/env sh
+      '
+`
+
+const pipelineWithTaskRef = `
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipelien-1
+spec:
+  tasks:
+  - name: pipeline-1
+    taskRef:
+      name: task-1`
+
+var configSh = []config{
+	config{regexp: `(/usr/bin/env |/bin/)sh`,
+		linters: []linter{
+			linter{
+				cmd:  "sh", // Should always be everywhere
+				args: []string{"-n"},
+			},
+		},
+	},
+}
+
+func TestTaskLint_Script_good(t *testing.T) {
+	r := strings.NewReader(taskScriptValidatorGood)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	tl := &taskLinter{
+		res:     res,
+		configs: configSh,
+	}
+	result := tl.Validate()
+	assert.Equal(t, 0, result.Errors)
+}
+
+func TestTaskLint_Script_no_good(t *testing.T) {
+	r := strings.NewReader(taskScriptValidatorNoGood)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	tl := &taskLinter{
+		res:     res,
+		configs: configSh,
+	}
+	result := tl.Validate()
+	assert.Equal(t, 1, result.Errors)
+}
+
+func Test_Pipeline_skip(t *testing.T) {
+	r := strings.NewReader(pipelineWithTaskRef)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	tl := &taskLinter{
+		res:     res,
+		configs: configSh,
+	}
+	result := tl.Validate()
+	assert.Assert(t, is.Nil(result.Lints))
+}
+
+func Test_ClusterTaskParse(t *testing.T) {
+	r := strings.NewReader(clusterTaskTest)
+	parser := parser.ForReader(r)
+
+	res, err := parser.Parse()
+	assert.NilError(t, err)
+
+	tl := &taskLinter{
+		res:     res,
+		configs: configSh,
+	}
+	result := tl.Validate()
+	assert.Equal(t, 1, result.Errors)
+}

--- a/catlin/pkg/validator/result.go
+++ b/catlin/pkg/validator/result.go
@@ -50,8 +50,9 @@ type Lint struct {
 
 type Result struct {
 	//Status Status
-	Lints  []Lint
-	Errors int
+	Lints    []Lint
+	Errors   int
+	Warnings int
 }
 
 func (r *Result) add(k Kind, format string, args ...interface{}) {
@@ -68,6 +69,7 @@ func (r *Result) Error(format string, args ...interface{}) {
 }
 
 func (r *Result) Warn(format string, args ...interface{}) {
+	r.Warnings++
 	r.add(Warning, format, args...)
 }
 


### PR DESCRIPTION
# Changes

This add a command to catlin to launch a language linter on a script field :

`catlin lint script`

Assuming a task as argument it will go over all the tasks and validate according
to a linter.

Configuration is pretty static and in code at the moment, and only has linter
for posix shell/bash and python, will expand on this in further version to be
able to provide a configuration file.

This doesn't handle TaskSpec from taskRuns and pipeline/pipelineRuns


Output would look like this : 

```sh
$ catlin lint script $GOPATH/src/github.com/tektoncd/catalog/task/*/*/*.yaml
WARN : step: ansible-runner is not using #!/usr/bin/env 
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : Couldn't find the linter shellcheck in the path
WARN : step: git-clone is not using #!/usr/bin/env 
WARN : Couldn't find the linter shellcheck in the path
WARN : step: github-add-comment is not using #!/usr/bin/env 
ERROR: /usr/bin/pylint, [-dC0103] failed:
************* Module catlin-script-linter501955988
github-add-comment-add-comment:27:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
github-add-comment-add-comment:29:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
github-add-comment-add-comment:44:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
github-add-comment-add-comment:1:0: C0114: Missing module docstring (missing-module-docstring)

-----------------------------------
Your code has been rated at 7.89/10


WARN : step: github-add-comment is not using #!/usr/bin/env 
ERROR: /usr/bin/pylint, [-dC0103] failed:
************* Module catlin-script-linter971370467
github-add-comment-add-comment:27:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
github-add-comment-add-comment:29:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
github-add-comment-add-comment:44:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
github-add-comment-add-comment:1:0: C0114: Missing module docstring (missing-module-docstring)

-----------------------------------
Your code has been rated at 7.89/10
[...]
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._