### PR TITLE
Change namespaces specification for kustomize in tekton resources

### DIFF
--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -1,11 +1,9 @@
-namespace: default
 commonAnnotations:
   managed-by: Tekton
 
 resources:
 - images
-- org-permissions/peribolos.yaml
-- org-permissions/peribolos-trigger.yaml
+- org-permissions
 - release
 - cd
 - ci

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: default
 resources:
 - overlays/dashboard
 - overlays/pipeline

--- a/tekton/resources/org-permissions/kustomization.yaml
+++ b/tekton/resources/org-permissions/kustomization.yaml
@@ -3,5 +3,5 @@ commonAnnotations:
   managed-by: Tekton
 
 resources:
-- bindings.yaml
-- github-template.yaml
+- peribolos.yaml
+- peribolos-trigger.yaml


### PR DESCRIPTION
# Changes

Several s390x test related resources should be created in `bastion-z` namespace. With default namespace specified in kustomize config of parent `tekton/resources` directory, all resources inside will be created in `default` namespace, see issue https://github.com/kubernetes-sigs/kustomize/issues/880

The idea is not to specify namespace value in `tekton/resources/kustomization.yaml`, but to do it in underlying directories(ci, nightly-release, etc)

/kind feature
/cc @afrittoli

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._