### PR TITLE
Annotate the tekton-all-ci-pipeline

### DIFF
--- a/tekton/ci/templates/all-template.yaml
+++ b/tekton/ci/templates/all-template.yaml
@@ -3,6 +3,8 @@ kind: TriggerTemplate
 metadata:
   name: tekton-all-ci-pipeline
   namespace: tektonci
+  annotations:
+    triggers.tekton.dev/old-escape-quotes: "true"
 spec:
   params:
   - name: buildUUID


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With v11, strings with quotes are not espaced anymore in trigger
templates, which breaks the all-comment-ci trigger template.
Add an annotation that restores the old behaviour for now, so that
CI may continue working. Eventually we should use marshalJSON or
some alternative to solve the issue without the annotation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug

/cc @dibyom @vdemeester 