### PR TITLE
Restore the namespace in mario's webhook

### DIFF
--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -117,6 +117,7 @@ spec:
               kind: Service
               name: mario
               apiVersion: v1
+              namespace: mario
       bindings:
         - ref: mario-trigger-to-build-and-push-image
       template:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When I deleted the namespace from the secret, I deleted it from the
webhook too incorrectly, restoring it now.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug