### PR TITLE
Add ClusterTriggerBindings role for the nightly release service accounts.

### DIFF
--- a/tekton/resources/nightly-release/base/serviceaccount.yaml
+++ b/tekton/resources/nightly-release/base/serviceaccount.yaml
@@ -31,3 +31,24 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: release-minimal
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-cluster-minimal
+rules:
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["clustertriggerbindings"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: robot-release-cluster-minimal
+subjects:
+- kind: ServiceAccount
+  name: robot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-cluster-minimal


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Nightly release ELs are currently failing trying to list cluster level
bindings for ClusterTriggerBindings. Open question whether this is expected behavior in Triggers,
but this will at least fix our triggers short term.

It's unclear whether this will also fix the `unknown` errors we are
seeing - we are going to fix this first and see if this resolves all the
errors  (i.e. if this error just log-cascaded as the unknown errors).

For #693 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._