### PR TITLE
Fix permission issue for all nightly jobs

### DIFF
--- a/tekton/resources/nightly-release/base/kustomizeconfig/eventlistener.yaml
+++ b/tekton/resources/nightly-release/base/kustomizeconfig/eventlistener.yaml
@@ -6,7 +6,7 @@ nameReference:
     kind: EventListener
 - kind: TriggerTemplate
   fieldSpecs:
-  - path: spec/triggers/template/name
+  - path: spec/triggers/template/ref
     kind: EventListener
 - kind: ServiceAccount
   fieldSpecs:

--- a/tekton/resources/nightly-release/base/serviceaccount.yaml
+++ b/tekton/resources/nightly-release/base/serviceaccount.yaml
@@ -11,14 +11,21 @@ metadata:
   name: release-minimal
 rules:
 - apiGroups: [""]
-  resources: ["configmaps"]
+  resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates"]
-  verbs: ["get", "list"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["impersonate"]
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["tekton-triggers"]
+  verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -39,7 +46,7 @@ metadata:
 rules:
 - apiGroups: ["triggers.tekton.dev"]
   resources: ["clustertriggerbindings"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes following issues for Pipeline, Triggers, Dashboard nightly job

* Triggering nightly job was failing because of permission issue
```
E0128 04:54:56.364871       1 reflector.go:383] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to watch *v1alpha1.EventListener: unknown (get eventlisteners.triggers.tekton.dev)
E0128 04:55:11.864806       1 reflector.go:383] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to watch *v1alpha1.TriggerTemplate: unknown (get triggertemplates.triggers.tekton.dev)
E0128 04:55:16.076674       1 reflector.go:383] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to watch *v1alpha1.ClusterTriggerBinding: unknown (get clustertriggerbindings.triggers.tekton.dev)
E0128 04:55:16.888153       1 reflector.go:178] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to list *v1alpha1.Trigger: triggers.triggers.tekton.dev is forbidden: User "system:serviceaccount:default:dashboard-nightly-release-robot" cannot list resource "triggers" in API group "triggers.tekton.dev" in the namespace "default"
E0128 04:55:17.437810       1 reflector.go:383] k8s.io/client-go@v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible/tools/cache/reflector.go:125: Failed to watch *v1alpha1.TriggerBinding: unknown (get triggerbindings.triggers.tekton.dev)
```
**Solution:** Added required roles in `serviceaccount.yaml`

* Job trigger was failing because of wrong template name 
```
{"level":"error","logger":"eventlistener","caller":"sink/sink.go:221","msg":"error getting TriggerTemplate template: triggertemplate.triggers.tekton.dev \"template\" not found","knative.dev/controller":"eventlistener","/triggers-eventid":"mdwnf","/trigger":"pipeline-nightly-release-cron-trigger","logging.googleapis.com/labels":{},"logging.googleapis.com/sourceLocation":{"file":"github.com/tektoncd/triggers/pkg/sink/sink.go","line":"221","function":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger"},"stacktrace":"github.com/tektoncd/triggers/pkg/sink.Sink.processTrigger\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:221\ngithub.com/tektoncd/triggers/pkg/sink.Sink.HandleEvent.func1\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:125"}
```
**Solution:** modified eventlistener.yaml from kustomizeconfig to point to correct template 

**Verification:**
* Verified using `kustomize build . | kubectl diff -f -` 
* Verified by changing those configuration manually for `pipeline` nightly and [job](https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns/pipeline-release-nightly-mxrxc) got created after re-trigger

/cc @dibyom @wlynch @vdemeester @afrittoli 

Lastly ran
```
kustomize build . | kubectl apply -f -
```
and re triggered all 3 nightly jobs 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._