### PR TITLE
Use generateName instead of $(uid) in templates

### DIFF
--- a/tekton/ci/README.md
+++ b/tekton/ci/README.md
@@ -227,7 +227,7 @@ downstream CEL filters to work correctly.
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: CHECK-NAME-$(uid) # uid *MUST* be used here. The name is for information only.
+      generateName: CHECK-NAME- # generateName *MUST* be used here. The name is for information only.
       labels:
         tekton.dev/kind: ci
         tekton.dev/check-name: CHECK-NAME # *MUST* be the GitHub check name

--- a/tekton/ci/templates/all-template.yaml
+++ b/tekton/ci/templates/all-template.yaml
@@ -33,7 +33,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: check-pr-labels-$(uid)
+      generateName: check-pr-labels-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: check-pr-has-kind-label

--- a/tekton/ci/templates/community-template.yaml
+++ b/tekton/ci/templates/community-template.yaml
@@ -31,7 +31,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: pull-community-teps-lint-$(uid)
+      generateName: pull-community-teps-lint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: pull-community-teps-lint

--- a/tekton/ci/templates/plumbing-template.yaml
+++ b/tekton/ci/templates/plumbing-template.yaml
@@ -31,7 +31,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-ko-build-$(uid)
+      generateName: plumbing-ko-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-ko-build
@@ -71,7 +71,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-ko-gcloud-build-$(uid)
+      generateName: plumbing-ko-gcloud-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-ko-gcloud-build
@@ -111,7 +111,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-hub-build-$(uid)
+      generateName: plumbing-hub-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-hub-build
@@ -151,7 +151,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-kubectl-build-$(uid)
+      generateName: plumbing-kubectl-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-kubectl-build
@@ -191,7 +191,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-skopeo-build-$(uid)
+      generateName: plumbing-skopeo-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-skopeo-build
@@ -231,7 +231,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-test-runner-build-$(uid)
+      generateName: plumbing-test-runner-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-test-runner-build
@@ -271,7 +271,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-tkn-build-$(uid)
+      generateName: plumbing-tkn-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-tkn-build
@@ -311,7 +311,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-coverage-build-$(uid)
+      generateName: plumbing-coverage-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-coverage-build
@@ -351,7 +351,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-openssh-server-build-$(uid)
+      generateName: plumbing-openssh-server-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-openssh-server-build
@@ -391,7 +391,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: tekton-yamllint-$(uid)
+      generateName: tekton-yamllint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-yamllint
@@ -431,7 +431,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: tekton-golang-lint-$(uid)
+      generateName: tekton-golang-lint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-golang-lint
@@ -469,7 +469,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: plumbing-alpine-git-nonroot-build-$(uid)
+      generateName: plumbing-alpine-git-nonroot-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/check-name: plumbing-alpine-git-nonroot-build

--- a/tekton/ci/templates/tekton-cd-template.yaml
+++ b/tekton/ci/templates/tekton-cd-template.yaml
@@ -25,7 +25,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: cd-echo-test-$(uid)
+      generateName: cd-echo-test-
       labels:
         tekton.dev/kind: cd
     spec:

--- a/tekton/ci/templates/website-template.yaml
+++ b/tekton/ci/templates/website-template.yaml
@@ -25,7 +25,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: tekton-python-test-pipelinerun-$(uid)
+      generateName: tekton-python-test-pipelinerun-
     spec:
       pipelineRef:
         name: tekton-python-test-pipeline

--- a/tekton/resources/cd/cleanup-template.yaml
+++ b/tekton/resources/cd/cleanup-template.yaml
@@ -28,7 +28,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: cleanup-runs-$(tt.params.clusterResource)-$(tt.params.namespace)-$(uid)
+      generateName: cleanup-runs-$(tt.params.clusterResource)-$(tt.params.namespace)-
     spec:
       taskSpec:
         params:

--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -38,7 +38,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: deploy-configmap-$(tt.params.configMapDescription)-$(uid)
+      generateName: deploy-configmap-$(tt.params.configMapDescription)-
     spec:
       taskSpec:
         params:

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -39,7 +39,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: deploy-resources-$(tt.params.folderDescription)-$(uid)
+      generateName: deploy-resources-$(tt.params.folderDescription)-
     spec:
       taskSpec:
         params:

--- a/tekton/resources/cd/helm-template.yaml
+++ b/tekton/resources/cd/helm-template.yaml
@@ -43,7 +43,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: deploy-helm-$(tt.params.chartDescription)-$(uid)
+      generateName: deploy-helm-$(tt.params.chartDescription)-
     spec:
       taskSpec:
         params:

--- a/tekton/resources/cd/notification-template.yaml
+++ b/tekton/resources/cd/notification-template.yaml
@@ -31,7 +31,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: send-to-webhook-slack-$(uid)
+      generateName: send-to-webhook-slack-
     spec:
       taskRef:
         name: send-to-webhook-slack

--- a/tekton/resources/cd/tekton-template.yaml
+++ b/tekton/resources/cd/tekton-template.yaml
@@ -44,7 +44,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: deploy-$(tt.params.tektonProject)-release-$(tt.params.targetCluster)-$(uid)
+      generateName: deploy-$(tt.params.tektonProject)-release-$(tt.params.targetCluster)-
     spec:
       taskRef:
         name: install-tekton-release

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -33,7 +33,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: $(tt.params.checkName)-pr-$(tt.params.gitHubCheckStatus)-$(uid)
+      generateName: $(tt.params.checkName)-pr-$(tt.params.gitHubCheckStatus)-
       namespace: tektonci
     spec:
       serviceAccountName: tekton-ci-jobs

--- a/tekton/resources/images/multi-arch-template.yaml
+++ b/tekton/resources/images/multi-arch-template.yaml
@@ -26,7 +26,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: build-and-push-$(tt.params.imageName)-$(uid)
+      generateName: build-and-push-$(tt.params.imageName)-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         plumbing.tekton.dev/image: $(tt.params.imageName)

--- a/tekton/resources/images/single-arch-template.yaml
+++ b/tekton/resources/images/single-arch-template.yaml
@@ -24,7 +24,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: build-and-push-$(tt.params.imageName)-$(uid)
+      generateName: build-and-push-$(tt.params.imageName)-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         plumbing.tekton.dev/image: $(tt.params.imageName)

--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -4,7 +4,7 @@
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: dashboard-release-nightly-$(uid)
+        generateName: dashboard-release-nightly-
       spec:
         pipelineRef:
           name: dashboard-release

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -4,7 +4,7 @@
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: pipeline-release-nightly-$(uid)
+        generateName: pipeline-release-nightly-
       spec:
         pipelineRef:
           name: pipeline-release-nightly

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -4,7 +4,7 @@
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: triggers-release-nightly-$(uid)
+        generateName: triggers-release-nightly-
       spec:
         pipelineRef:
           name: triggers-release

--- a/tekton/resources/release/nightly-release-logs-trigger.yaml
+++ b/tekton/resources/release/nightly-release-logs-trigger.yaml
@@ -44,7 +44,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      generateName: save-release-logs-$(uid)-
+      generateName: save-release-logs-
     spec:
       serviceAccountName: tekton-logs
       taskRef:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The event ID has changed to a UUID in triggers, which makes it
unfit to be part of resource names - it's too long.
Replace the $(uid) with generateName in all trigger templates

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc