### PR TITLE
Remove unused git resource from label check

### DIFF
--- a/tekton/ci/jobs/tasks.yaml
+++ b/tekton/ci/jobs/tasks.yaml
@@ -150,8 +150,6 @@ metadata:
 spec:
   resources:
     inputs:
-      - name: source
-        type: git
       - name: pr
         type: pullRequest
     outputs:

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -12,8 +12,6 @@ spec:
     - name: labels
       description: The labels attached to the Pull Request
   resources:
-    - name: source
-      type: git
     - name: pr
       type: pullRequest
   tasks:
@@ -32,8 +30,6 @@ spec:
       value: $(params.labels)
     resources:
       inputs:
-      - name: source
-        resource: source
       - name: pr
         resource: pr
       outputs:

--- a/tekton/ci/templates/all-template.yaml
+++ b/tekton/ci/templates/all-template.yaml
@@ -53,14 +53,6 @@ spec:
         - name: gitHubCommand
           value: $(tt.params.gitHubCommand)
       resources:
-        - name: source
-          resourceSpec:
-            type: git
-            params:
-            - name: revision
-              value: master
-            - name: url
-              value: $(tt.params.gitRepository)
         - name: pr
           resourceSpec:
             type: pullRequest


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The git pipeline resource is not used by the label check, so
remove it from the task, pipeline and trigger template.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc