### PR TITLE
Allow to update resources from tekton/resources in different namespaces

### DIFF
--- a/tekton/cronjobs/robocat/manifests/plumbing-tekton-resources-nightly/cronjob.yaml
+++ b/tekton/cronjobs/robocat/manifests/plumbing-tekton-resources-nightly/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
               - name: GIT_REVISION
                 value: "main"
               - name: NAMESPACE
-                value: "default"
+                value: ""
               - name: CLUSTER_RESOURCE
                 value: "robocat-cadmin"
               - name: FOLDER_PATH


### PR DESCRIPTION
# Changes
At this moment only installed resources in `default` namespace are taken into account in diff procedure to identify whether updates from `tekton/resources` directory should be applied to CI cluster.
However there are already resources in `bastion-z` namespace, specified in the directory.
To fix the problem namespace parameter in apply cronjob just should be empty, then corresponding diff/apply task will work for all namespaces.

/kind misc
/cc @afrittoli

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._