### PR TITLE
CronJob to enable nightly build for Catlin

### DIFF
--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/README.md
@@ -1,0 +1,1 @@
+Cron Job to build a container image with `catlin` installed. The image is published daily to `gcr.io/tekton-releases/dogfooding/catlin:latest`.

--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-build-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: trigger
+              env:
+                - name: SINK_URL
+                  value: el-image-builder.default.svc.cluster.local:8080
+                - name: GIT_REPOSITORY
+                  value: github.com/tektoncd/plumbing
+                - name: GIT_REVISION
+                  value: main
+                - name: TARGET_IMAGE
+                  value: gcr.io/tekton-releases/dogfooding/catlin:latest
+                - name: CONTEXT_PATH
+                  value: tekton/catlin

--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../../bases/image-build
+patchesStrategicMerge:
+  - cronjob.yaml
+nameSuffix: "-catlin"


### PR DESCRIPTION
# Changes

There is no nightly releases of `catlin` container image as of now.

This PR adds the `CronJob` to enable this.

/cc @afrittoli @vdemeester @savitaashture @piyush-garg 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._