### PR TITLE
Fix the check labels job

### DIFF
--- a/tekton/ci/jobs/tasks.yaml
+++ b/tekton/ci/jobs/tasks.yaml
@@ -148,13 +148,6 @@ metadata:
   description: |
     Verifies that a PR has one valid kind label
 spec:
-  resources:
-    inputs:
-      - name: pr
-        type: pullRequest
-    outputs:
-      - name: pr
-        type: pullRequest
   params:
   - name: labels
     description: The labels attached to the Pull Request
@@ -163,12 +156,6 @@ spec:
     configMap:
       name: label-config-v2
   steps:
-  - name: copy-pr-to-output
-    image: busybox
-    script: |
-      #!/bin/sh
-      mkdir -p $(outputs.resources.pr.path)
-      cp -r $(inputs.resources.pr.path)/* $(outputs.resources.pr.path)/
   - name: install-pyyaml
     image: python:3-alpine
     script: |
@@ -187,38 +174,31 @@ spec:
 
       prLabelsText = """$(params.labels)"""
       prLabels = json.loads(prLabelsText)
-      labelNames = list(map(lambda e: e["name"], prLabels))
-      kindLabels = list(filter(lambda e: "kind" in e, labelNames))
 
       availableLabels = None
-      with open("/etc/config/labels.yaml", "r") as stream:
+      with open("labels.yaml", "r") as stream:
         availableLabels = yaml.safe_load(stream)["default"]["labels"]
 
-      availableKindLabels = list(filter(lambda e: "kind/" in e["name"], availableLabels))
-      availableKindNamesAndDescriptions = map(lambda e: "`" +str(e["name"])+ "`" + ":  " + str(e["description"]), availableKindLabels)
+      availableKindLabels = {x.get("name"):x.get("description") for x in availableLabels if x.get("name").startswith("kind/")}
+      foundKindLabels = set([x.get("name") for x in prLabels if x.get("name").startswith("kind/") and x.get("name")])
+      validKindLabels = set([x for x in foundKindLabels if x in availableKindLabels])
 
-      comment_template=""
-      if (len(kindLabels) > 1 or len(kindLabels) == 0):
-        comment_template += """
-      **This PR cannot be merged:** expecting exactly one kind/ label
-
-      <details>
-
-      Available `kind/` labels are:
-
-      """
-
-        for i in availableKindNamesAndDescriptions:
-          comment_template += i + "\n"
-
-        comment_template += """
-
-      </details>
-      """
-        new_comment_path = "$(outputs.resources.pr.path)/comments/new.json"
-        comment_body = dict(body=comment_template)
-        with open(new_comment_path, "w") as comment:
-          json.dump(comment_body, comment)
+      # Check that we have one and only one kind label
+      foundLabels = len(validKindLabels)
+      if (foundLabels > 1 or foundLabels == 0):
+        msg = "Error: {} valid \"kind/*\" labels found".format(foundLabels)
+        if foundLabels > 1:
+            msg += "({})".format(validKindLabels)
+        msg += ", expecting exactly one."
+        invalidKindLabels = foundKindLabels - validKindLabels
+        if len(invalidKindLabels) > 0:
+            msg += " Invalid labels found: {}".format(invalidKindLabels)
+        print(msg)
+        print("\nAvailable \"kind/*\" labels are:")
+        for label, description in availableKindLabels.items():
+          print("\t{}: {}".format(label, description))
 
         # Check failed. Return exit code 1.
         sys.exit(1)
+      else:
+        print("Exactly one \"kind/*\" label found: {}".format(validKindLabels[0]))

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -11,9 +11,6 @@ spec:
       description: The command that was used to trigger testing
     - name: labels
       description: The labels attached to the Pull Request
-  resources:
-    - name: pr
-      type: pullRequest
   tasks:
   - name: check-kind-label
     conditions:
@@ -28,10 +25,3 @@ spec:
     params:
     - name: labels
       value: $(params.labels)
-    resources:
-      inputs:
-      - name: pr
-        resource: pr
-      outputs:
-      - name: pr
-        resource: pr

--- a/tekton/ci/templates/all-template.yaml
+++ b/tekton/ci/templates/all-template.yaml
@@ -52,14 +52,3 @@ spec:
           value: check-pr-has-kind-label
         - name: gitHubCommand
           value: $(tt.params.gitHubCommand)
-      resources:
-        - name: pr
-          resourceSpec:
-            type: pullRequest
-            params:
-            - name: url
-              value: $(tt.params.pullRequestUrl)
-            secrets:
-            - fieldName: authToken
-              secretName: bot-token-github
-              secretKey: bot-token


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The check labels job uses the PR pipeline resource to add a comment
to the PR with instructions for developers in case of failure.
That doesn't work though because in case of failure the sync-up side
of the pipeline resource is not processed, so the commit is not
written.

Fix that by removing the pipeline resource and writing the instructions
to the step log instead. The step log is linked in the github status
details through the tekton dashboard.

In future we might extend the github update service to include
support for comments, but that would require support for results on
failure: https://github.com/tektoncd/pipeline/issues/3749

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc