### PR TITLE
prow: Add dind and kind presets.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -124,6 +124,49 @@ presets:
   - name: github-token
     secret:
       secretName: oauth-token
+# docker-in-docker (with images/bootstrap) preset
+# NOTE: using this also requires using that image,
+# ensuring you run your test under either the ENTRYPOINT or:
+# /usr/local/bin/runner.sh my-test-command --foo --bar
+# AND setting the following on your PodSpec:
+# securityContext:
+#   privileged: true
+# These settings were taken from kubernetes/test-infra: https://github.com/kubernetes/test-infra/blob/aaf616ee940bcc64f775a77797fc80048df634b4/config/prow/config.yaml#L751
+- labels:
+    preset-dind-enabled: "true"
+  env:
+  - name: DOCKER_IN_DOCKER_ENABLED
+    value: "true"
+  volumes:
+  # kubekins-e2e legacy path
+  - name: docker-graph
+    emptyDir: {}
+  # krte (normal) path
+  - name: docker-root
+    emptyDir: {}
+  volumeMounts:
+  - name: docker-graph
+    mountPath: /docker-graph
+  - name: docker-root
+    mountPath: /var/lib/docker
+# volume mounts for kind
+- labels:
+    preset-kind-volume-mounts: "true"
+  volumeMounts:
+    - mountPath: /lib/modules
+      name: modules
+      readOnly: true
+    - mountPath: /sys/fs/cgroup
+      name: cgroup
+  volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
 
 presubmits:
   tektoncd/plumbing:
@@ -989,6 +1032,7 @@ presubmits:
   - name: pull-tekton-results-integration-tests
     labels:
       preset-presubmit-sh: "true"
+      preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     agent: kubernetes
     always_run: true


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This is a continuation of https://github.com/tektoncd/plumbing/pull/703.
Previously we added the label, but there wasn't any matching definition for\
this label so it didn't actually do anything.

This adds the label definition, as well as the definition for dind for
completeness to match the kubernetes/test-infra environment (https://github.com/kubernetes/test-infra/blob/1d4b6a6db932c31c3996387420401316c9180fc9/config/jobs/kubernetes-sigs/kind/kind.yaml)

Part of tektoncd/results#15

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._