### PR TITLE
Run catlin when task dir path is passed as argument

### DIFF
--- a/catlin/Dockerfile
+++ b/catlin/Dockerfile
@@ -1,13 +1,16 @@
-FROM golang:1.15 as BUILD
+FROM golang:1.15-alpine3.12 as BUILD
 
 COPY . /build
 WORKDIR /build
 RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 \
     go build -o catlin ./cmd/catlin
 
-FROM scratch
+FROM alpine:3.12
 
-WORKDIR /app
-COPY --from=BUILD /build/catlin /app/catlin
+RUN apk --no-cache add bash
 
-ENTRYPOINT ["/app/catlin"]
+WORKDIR /data
+
+COPY --from=BUILD /build/catlin /usr/bin/catlin
+
+CMD [ "catlin" ]

--- a/catlin/pkg/cmd/validate/testdata/task/maven/0.1/maven.yaml
+++ b/catlin/pkg/cmd/validate/testdata/task/maven/0.1/maven.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: maven
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: build-automation
+    tekton.dev/displayName: "maven"
+spec:
+  description: >-
+    This Task can be used to run a Maven build.
+  params:
+    - name: GOALS
+      type: array
+  steps:
+    - name: execute-goals
+      image: gcr.io/cloud-builders/mvn:3.6.8@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641
+      command:
+        - mvn
+      args:
+        - $(params.GOALS)

--- a/catlin/pkg/cmd/validate/testdata/task/npm/0.1/npm.yaml
+++ b/catlin/pkg/cmd/validate/testdata/task/npm/0.1/npm.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: npm
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: build-automation
+    tekton.dev/displayName: "npm"
+spec:
+  description: >-
+    This task can be used to run npm goals on a project.
+
+    This task can be used to run npm goals on a project
+    where package.json is present and has some pre-defined
+    npm scripts.
+  params:
+    - name: GOALS
+      type: array
+  steps:
+    - name: execute-goals
+      image: docker.io/library/node:12-alpine@sha256:12048cdfd75d944df35f3144132d9bdeee78015fbd6df765edad1be46599b110
+      command:
+        - npm
+      args:
+        - $(params.GOALS)

--- a/catlin/pkg/cmd/validate/validate.go
+++ b/catlin/pkg/cmd/validate/validate.go
@@ -17,6 +17,7 @@ package validate
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -26,12 +27,40 @@ import (
 	"github.com/tektoncd/plumbing/catlin/pkg/validator"
 )
 
+func getFilesInDir(path string) ([]os.FileInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	files, err := f.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return false
 	}
-	return !info.IsDir()
+
+	if info.IsDir() {
+
+		files, err := getFilesInDir(path)
+		if err != nil {
+			return false
+		}
+
+		for _, file := range files {
+			if filepath.Ext(file.Name()) == ".yaml" {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
 }
 
 func validResourcePath() cobra.PositionalArgs {
@@ -40,9 +69,12 @@ func validResourcePath() cobra.PositionalArgs {
 			return fmt.Errorf("requires at least 1 path to tekton resource yaml but received none")
 		}
 
-		if !fileExists(args[0]) {
-			return fmt.Errorf("no such file - %s", args[0])
+		for _, filePath := range args {
+			if !fileExists(filePath) {
+				return fmt.Errorf("valid Tekton resource not found in the path - %s", filePath)
+			}
 		}
+
 		return nil
 	}
 }
@@ -53,9 +85,47 @@ func Command(cli app.CLI) *cobra.Command {
 		Aliases: []string{"verify"},
 		Args:    validResourcePath(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return validate(cli, args[0])
+			return validateResources(cli, args)
 		},
 	}
+}
+
+func validateResources(cli app.CLI, args []string) error {
+
+	out := cli.Stream().Out
+	for _, filePath := range args {
+		info, _ := os.Stat(filePath)
+		if info.IsDir() {
+
+			files, err := getFilesInDir(filePath)
+			if err != nil {
+				return fmt.Errorf(err.Error())
+			}
+
+			for _, file := range files {
+				if filepath.Ext(file.Name()) == ".yaml" {
+					fileWithPath := filePath
+					if strings.HasSuffix(fileWithPath, "/") {
+						fileWithPath = fileWithPath + file.Name()
+					} else {
+						fileWithPath = fileWithPath + "/" + file.Name()
+					}
+					fmt.Fprintf(out, "FILE: %s\n", fileWithPath)
+					err = validate(cli, fileWithPath)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		} else if filepath.Ext(filePath) == ".yaml" {
+			fmt.Fprintf(out, "FILE: %s\n", filePath)
+			err := validate(cli, filePath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func validate(cli app.CLI, path string) error {

--- a/catlin/pkg/cmd/validate/validate_test.go
+++ b/catlin/pkg/cmd/validate/validate_test.go
@@ -1,0 +1,59 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package validate
+
+import (
+	"testing"
+
+	"github.com/tektoncd/plumbing/catlin/pkg/app"
+	"github.com/tektoncd/plumbing/catlin/pkg/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestValidate(t *testing.T) {
+
+	testParams := []struct {
+		name      string
+		args      []string
+		wantError bool
+		want      string
+	}{
+		{
+			name:      "single filepath",
+			args:      []string{"./testdata/task/maven/0.1"},
+			wantError: false,
+			want:      "",
+		},
+		{
+			name:      "multiple filepath",
+			args:      []string{"./testdata/task/maven/0.1", "./testdata/task/npm/0.1"},
+			wantError: false,
+			want:      "",
+		},
+	}
+
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			cli := app.New()
+			validate := Command(cli)
+			got, err := test.ExecuteCommand(validate, tp.args...)
+			if !tp.wantError {
+				if err != nil {
+					t.Errorf("Unexpected error")
+				}
+				assert.Equal(t, tp.want, got)
+			}
+		})
+	}
+}

--- a/catlin/pkg/test/cobra.go
+++ b/catlin/pkg/test/cobra.go
@@ -1,0 +1,41 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+)
+
+// ExecuteCommand executes the root command passing the args and returns
+// the output as a string and error
+func ExecuteCommand(root *cobra.Command, args ...string) (string, error) {
+	_, output, err := ExecuteCommandC(root, args...)
+	return output, err
+}
+
+// ExecuteCommandC executes the root command passing the args and returns
+// the root command, output as a string and error if any
+func ExecuteCommandC(c *cobra.Command, args ...string) (*cobra.Command, string, error) {
+	buf := new(bytes.Buffer)
+	c.SetOutput(buf)
+	c.SetArgs(args)
+	c.SilenceUsage = true
+
+	root, err := c.ExecuteC()
+
+	return root, buf.String(), err
+}


### PR DESCRIPTION
# Changes

With the patch now you can run catlin on directories and also you can
now run catlin on multiple inputs.

Sample execution command would be

```sh
$ catlin validate task/black/0.1 task/maven/0.2
```
- Also added tests for the above command.
- Modified Dockerfile to include bash so that user can use catlin as per their script


Closes #715 
Closes #716 

/cc @SM43 @piyush-garg @vdemeester 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._