### PR TITLE
Fix CONTEXT_PATH in catlin CronJob

### DIFF
--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
@@ -21,4 +21,4 @@ spec:
                 - name: TARGET_IMAGE
                   value: gcr.io/tekton-releases/dogfooding/catlin:latest
                 - name: CONTEXT_PATH
-                  value: tekton/catlin
+                  value: catlin


### PR DESCRIPTION
# Changes

Changing the CONTEXT_PATH to `catlin` instead of `tekton/catlin`.
Wrongly passed earlier. My bad :(

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._