### PR TITLE
Fix: Catlin validate command

### DIFF
--- a/catlin/pkg/validator/task_validator.go
+++ b/catlin/pkg/validator/task_validator.go
@@ -119,7 +119,7 @@ func isValidRegistry(img string) bool {
 // tagWithDigest validates if image has a specific tag along with digest
 func tagWithDigest(img string) bool {
 	withOutDigest := strings.Split(img, "@sha256")[0]
-	if strings.Contains(withOutDigest, ":") && !strings.Contains(withOutDigest, ":latest") {
+	if strings.Contains(withOutDigest, ":") && !strings.HasSuffix(withOutDigest, ":latest") {
 		return true
 	}
 	return false

--- a/catlin/pkg/validator/task_validator_test.go
+++ b/catlin/pkg/validator/task_validator_test.go
@@ -60,6 +60,10 @@ spec:
     image: abc.io/xyz/fedora:v123@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
   - name: s8
     image: 172.16.3.4:3000/foo/bar:baz
+  - name: s9
+    image: abc.io/xyz/fedora:latest-0.2@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
+  - name: s10
+    image: abc.io/xyz/fedora:latest0.2@sha256:deadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33fdeadb33f
 `
 
 const taskWithInvalidImageRef = `


### PR DESCRIPTION
  - This patch fixes validate command which gives warning when tagging
    the image as docker.io/cytopia/black:latest-0.2@sha256:abcdef

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._