### PR TITLE
Catlin: Fix Dockerfile

### DIFF
--- a/catlin/Dockerfile
+++ b/catlin/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.15-alpine3.12 as BUILD
+FROM docker.io/library/golang:1.15-alpine3.12 as build
 
 COPY . /build
 WORKDIR /build
 RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 \
     go build -o catlin ./cmd/catlin
 
-FROM alpine:3.12
+FROM docker.io/library/alpine:3.12
 
 RUN apk --no-cache add bash
 
 WORKDIR /data
 
-COPY --from=BUILD /build/catlin /usr/bin/catlin
+COPY --from=build /build/catlin /usr/bin/catlin
 
 CMD [ "catlin" ]


### PR DESCRIPTION
# Changes

Dockerfile for catlin contains BUILD which is all in UpperCase and kaniko
doesn't supports this so renaming this to `build` all lowercase

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._