### PR TITLE
Add DNS manager docs and annotations

### DIFF
--- a/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: dashboard.dogfooding.tekton.dev
   name: ing
   namespace: tekton-pipelines
 spec:

--- a/tekton/cd/dashboard/overlays/robocat/ingress.yaml
+++ b/tekton/cd/dashboard/overlays/robocat/ingress.yaml
@@ -4,13 +4,14 @@ metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: dashboard.robocat.tekton.dev
   name: ing
   namespace: tekton-pipelines
 spec:
   tls:
   - secretName: dashboard-robocat-tekton-dev-tls
     hosts:
-    - dashboard.robotcat.tekton.dev
+    - dashboard.robocat.tekton.dev
   rules:
   - http:
       paths:

--- a/tekton/ci/ingress.yaml
+++ b/tekton/ci/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: webhook-draft.ci.dogfooding.tekton.dev
   name: ing
   namespace: tektonci
 spec:

--- a/tekton/mario-bot/ingress.yaml
+++ b/tekton/mario-bot/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: mario.dogfooding.tekton.dev
   name: ing
   namespace: mario
 spec:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Garndener external DNS manager is now installed in the dogfooding
cluster. Add documentation on the installation and configuration process
as well as add annotations to all ingress we use in dogfooding to match
existing DNS record on Netlify side.

For new records, we will not need to provision them manually anymore,
they can be provisioned via annotations on ingresses, services or via
the DNSEntry CRD.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind documentation