### PR TITLE
Add Catlin to Catalog CI

### DIFF
--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -271,3 +271,60 @@ spec:
         - ref: tekton-ci-webhook-issue-labels
       template:
         ref: tekton-community-ci-pipeline
+    - name: catalog-pull-request-ci
+      interceptors:
+        - github:
+            secretRef:
+              secretName: ci-webhook
+              secretKey: secret
+            eventTypes:
+              - pull_request
+        - cel:
+            filter: >-
+              body.repository.full_name == 'tektoncd/catalog' &&
+              body.action in ['opened','synchronize']
+            overlays:
+              - key: git_clone_depth
+                expression: "string(body.pull_request.commits + 1.0)"
+      bindings:
+        - ref: tekton-ci-github-base
+        - ref: tekton-ci-webhook-pull-request
+        - ref: tekton-ci-clone-depth
+        - ref: tekton-ci-webhook-pr-labels
+      template:
+        ref: tekton-catalog-ci-pipeline
+    - name: catalog-comment-ci
+      interceptors:
+        - github:
+            secretRef:
+              secretName: ci-webhook
+              secretKey: secret
+            eventTypes:
+              - issue_comment
+        - cel:
+            filter: >-
+              body.repository.full_name == 'tektoncd/catalog' &&
+              body.action == 'created' &&
+              'pull_request' in body.issue &&
+              body.issue.state == 'open' &&
+              body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
+            overlays:
+            - key: add_pr_body.pull_request_url
+              expression: "body.issue.pull_request.url"
+        - webhook:
+            objectRef:
+              kind: Service
+              name: add-pr-body
+              apiVersion: v1
+              namespace: tektonci
+        - cel:
+            overlays:
+            - key: git_clone_depth
+              expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+      bindings:
+        - ref: tekton-ci-github-base
+        - ref: tekton-ci-webhook-comment
+        - ref: tekton-ci-clone-depth
+        - ref: tekton-ci-webhook-issue-labels
+      template:
+        ref: tekton-catalog-ci-pipeline

--- a/tekton/ci/jobs/kustomization.yaml
+++ b/tekton/ci/jobs/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - tekton-yamllint.yaml
 - tekton-python-test.yaml
 - tekton-teps-validation.yaml
+- tekton-catlin-lint.yaml

--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: catlin-lint
+  namespace: tektonci
+spec:
+  description: >-
+    This task detects changes in the pull request using git diff
+    and stores the changed tasks names in a workspace and passes
+    that to the catlin so that catlin can validate only changed
+    files.
+  workspaces:
+    - name: store-changed-files
+      description: Stores list of changed tasks
+  params:
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+  resources:
+    inputs:
+      - name: source
+        type: git
+  steps:
+    - name: find-changed-tasks
+      image: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
+      workingDir: $(resources.inputs.source.path)
+      script: |
+        function detect_new_changed_tasks() {
+          # detect for changes in the task manifest
+          git --no-pager diff --name-only HEAD~$(( $(params.gitCloneDepth) - 1 ))|grep 'task/[^\/]*/[^\/]*/*[^/]*.yaml'|xargs -I {} dirname {}
+        }
+        all_tests=$(detect_new_changed_tasks |sort -u || true)
+        echo -n $all_tests > $(workspaces.store-changed-files.path)/changed-files.txt
+    - name: lint-catalog
+      image: gcr.io/tekton-releases/dogfooding/catlin:latest
+      workingDir: $(resources.inputs.source.path)
+      script: |
+        catlin validate $(cat $(workspaces.store-changed-files.path)/changed-files.txt)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: catlin-linter
+  namespace: tektonci
+spec:
+  workspaces:
+    - name: store-changed-files
+      description: Stores list of changed tasks
+  resources:
+    - name: source
+      type: git
+  params:
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+  tasks:
+    - name: lint-catalog
+      conditions:
+        - conditionRef: "check-name-matches"
+          params:
+            - name: gitHubCommand
+              value: $(params.gitHubCommand)
+            - name: checkName
+              value: $(params.checkName)
+      taskRef:
+        name: catlin-lint
+      workspaces:
+        - name: store-changed-files
+          workspace: store-changed-files
+      resources:
+        inputs:
+          - name: source
+            resource: source
+      params:
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)

--- a/tekton/ci/templates/catalog-template.yaml
+++ b/tekton/ci/templates/catalog-template.yaml
@@ -1,0 +1,69 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-catalog-ci-pipeline
+  namespace: tektonci
+  annotations:
+    triggers.tekton.dev/old-escape-quotes: "true"
+spec:
+  params:
+    - name: buildUUID
+      description: UUID used to track a CI Pipeline Run in logs
+    - name: package
+      description: org/repo
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+    - name: pullRequestUrl
+      description: The HTML URL for the pull request
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitRevision
+      description: The Git revision to be used.
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: gitHubCommand
+      description: |
+        The GitHub command that was used a trigger. This is only available when
+        this template is triggered by a comment. The default value is for the
+        case of a pull_request event.
+      default: ""
+    - name: labels
+      description: List of labels currently on the Pull Request
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: catalog-catlin-run-
+        labels:
+          prow.k8s.io/build-id: $(tt.params.buildUUID)
+          tekton.dev/check-name: pull-catalog-catlin-lint
+          tekton.dev/kind: ci
+          tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+        annotations:
+          tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+          tekton.dev/gitURL: "$(tt.params.gitRepository)"
+      spec:
+        serviceAccountName: tekton-ci-jobs
+        pipelineRef:
+          name: catlin-linter
+        workspaces:
+          - name: store-changed-files
+            emptyDir: {}
+        params:
+          - name: gitCloneDepth
+            value: $(tt.params.gitCloneDepth)
+          - name: gitHubCommand
+            value: $(tt.params.gitHubCommand)
+          - name: checkName
+            value: pull-catalog-catlin-lint
+        resources:
+          - name: source
+            resourceSpec:
+              type: git
+              params:
+                - name: revision
+                  value: $(tt.params.gitRevision)
+                - name: url
+                  value: $(tt.params.gitRepository)
+                - name: depth
+                  value: $(tt.params.gitCloneDepth)

--- a/tekton/ci/templates/kustomization.yaml
+++ b/tekton/ci/templates/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - bindings.yaml
 - website-template.yaml
 - community-template.yaml
+- catalog-template.yaml


### PR DESCRIPTION
# Changes

- Adds a Tekton Task and Pipeline which will run catlin on catalog
  tasks.
- Add corresponding TriggerTemplate.
- Modify EventListener to add catlin jobs.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._