### PR TITLE
Add legacy tasks to plumbing releases

### DIFF
--- a/tekton/resources/nightly-release/tasks.yaml
+++ b/tekton/resources/nightly-release/tasks.yaml
@@ -107,3 +107,113 @@ spec:
     script: |
       go test $(inputs.params.flags) $(inputs.params.packages)
     workingDir: /workspace/src/$(inputs.params.package)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-build-legacy
+spec:
+  params:
+  - description: base package to build in
+    name: package
+    type: string
+  - default: ./cmd/...
+    description: 'packages to build (default: ./cmd/...)'
+    name: packages
+    type: string
+  - default: latest
+    description: golang version to use for builds
+    name: version
+    type: string
+  - default: -v
+    description: flags to use for the test command
+    name: flags
+    type: string
+  - default: linux
+    description: running program's operating system target
+    name: GOOS
+    type: string
+  - default: amd64
+    description: running program's architecture target
+    name: GOARCH
+    type: string
+  - default: auto
+    description: value of module support
+    name: GO111MODULE
+    type: string
+  resources:
+    inputs:
+    - name: source
+      targetPath: src/$(inputs.params.package)
+      type: git
+  steps:
+  - env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: $(inputs.params.GOOS)
+    - name: GOARCH
+      value: $(inputs.params.GOARCH)
+    - name: GO111MODULE
+      value: $(inputs.params.GO111MODULE)
+    image: golang:$(inputs.params.version)
+    name: build
+    resources: {}
+    script: |
+      go build $(inputs.params.flags) $(inputs.params.packages)
+    workingDir: /workspace/src/$(inputs.params.package)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-test-legacy
+spec:
+  params:
+  - description: package (and its children) under test
+    name: package
+    type: string
+  - default: ./...
+    description: 'packages to test (default: ./...)'
+    name: packages
+    type: string
+  - default: latest
+    description: golang version to use for tests
+    name: version
+    type: string
+  - default: -race -cover -v
+    description: flags to use for the test command
+    name: flags
+    type: string
+  - default: linux
+    description: running program's operating system target
+    name: GOOS
+    type: string
+  - default: amd64
+    description: running program's architecture target
+    name: GOARCH
+    type: string
+  - default: auto
+    description: value of module support
+    name: GO111MODULE
+    type: string
+  resources:
+    inputs:
+    - name: source
+      targetPath: src/$(inputs.params.package)
+      type: git
+  steps:
+  - env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: $(inputs.params.GOOS)
+    - name: GOARCH
+      value: $(inputs.params.GOARCH)
+    - name: GO111MODULE
+      value: $(inputs.params.GO111MODULE)
+    image: golang:$(inputs.params.version)
+    name: unit-test
+    resources: {}
+    script: |
+      go test $(inputs.params.flags) $(inputs.params.packages)
+    workingDir: /workspace/src/$(inputs.params.package)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add golang-build-legacy and golang-test-legacy.
Theres are identical copies of the existing ones, designed to allow
pipeline, dashboard and triggers to switch to them.

This step uncouples the various projects so that we way then:
- switch pipeline, dashboard and triggers one at the time to a publish
  task and release pipeline that use workspaces, no resources and thus
  the catalog version of golang-build and golang-test
- once the three projects are migrated, the legacy tasks will be
  removed

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc