### PR TITLE
Only try to fetch team members if team key is present in body

### DIFF
--- a/tekton/ci/interceptors/add-team-members/README.md
+++ b/tekton/ci/interceptors/add-team-members/README.md
@@ -1,13 +1,42 @@
 # Add Team Members
 
 `add-team-members` is a custom interceptor for Tekton Triggers that enriches the
-payload of an incoming request with the list of public members of the org as well
-as the list of maintainers for the project.
+payload of an incoming request with the list of public members of the org and,
+optionally, the list of maintainers for the project.
 
 ## Interface
 
 `add-team-members` expects the URL to the PR representation to be included in the
 incoming JSON as follows:
+
+```json
+{
+  "add_team_members":
+  {
+    "org_base_url": "https://api.github.com/repos/tektoncd/",
+  },
+  "other-keys": "other=values"
+}
+```
+
+It returns the original JSON payload untouched, with the addition of the org
+members:
+
+```json
+{
+  "add_team_members":
+  {
+    "org_base_url": "https://api.github.com/repos/tektoncd/",
+    "team": "plumbing",
+    "public_org_members": ["a", "b", "c"]
+  },
+  "other-keys": "other=values"
+}
+```
+
+### Adding the maintainers
+When we add the `team` key to the body, the maintainers for that repo will also
+be added:
 
 ```json
 {
@@ -20,7 +49,8 @@ incoming JSON as follows:
 }
 ```
 
-It returns the original JSON payload untouched, with the addition of the PR:
+It returns the original JSON payload untouched, with the addition of both the
+org members and the maintainers:
 
 ```json
 {
@@ -29,7 +59,7 @@ It returns the original JSON payload untouched, with the addition of the PR:
     "org_base_url": "https://api.github.com/repos/tektoncd/",
     "team": "plumbing",
     "public_org_members": ["a", "b", "c"],
-    "maintainers_team_members": ["a", "b"],
+    "maintainers_team_members": ["a", "b"]
   },
   "other-keys": "other=values"
 }

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main_test.go
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main_test.go
@@ -69,7 +69,13 @@ func TestNoTeamUrlFound(t *testing.T) {
 
 	h(w, r)
 
-	assertBadRequestResponse(t, w, "no 'team' found")
+	want := makeTeamBody(true, "foo://some_url", "")
+	wantTeamBody := []interface{}{string("foo"), string("bar")}
+	(*want)[RootExtensionsKey].(map[string]interface{})[prExtensionsKey].(map[string]interface{})[orgMembersKey] = wantTeamBody
+
+	resp := w.Result()
+
+	assertResponsePayload(t, resp, &want)
 }
 
 func TestCannotFetchOrgURL(t *testing.T) {


### PR DESCRIPTION
/kind feature

# Changes

We want to make sure only members from our organization can trigger pipelines. We don't use the same team schema that you folks are using, and changing the code to work with different team terminologies would be too hard I think. That's why I thought about making the team part optional. With these changes, the interceptor will not fail if the `team` key is not in the body payload. If you want to use it, you can still set it, but if you don't, that's fine.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._