### PR TITLE
Rework the prerelease-check task to use workspaces

### DIFF
--- a/tekton/resources/release/prerelease_checks.yaml
+++ b/tekton/resources/release/prerelease_checks.yaml
@@ -22,20 +22,16 @@ spec:
     default: github.com/tektoncd/pipeline
   - name: versionTag
     description: The X.Y.Z version that the artifacts would be tagged with
-  resources:
-    inputs:
-      - name: source-to-release
-        type: git
-      - name: release-bucket
-        type: storage
+  - name: releaseBucket
+    description: >-
+      The bucket where to look for the release, in the format gs://<bucket-name>/<project-name>
+  workspaces:
+    - name: source-to-release
+      description: The workspace where the repo has been cloned
   steps:
     - name: check-git-tag
       image: alpine/git
-      command:
-      - /bin/sh
-      args:
-      - -ce
-      - |
+      script: |
         echo "Checking git tag"
         # Look for the tag in the list of tags
         git ls-remote --tags https://$(params.package) | \
@@ -44,26 +40,19 @@ spec:
         echo "Version $(params.versionTag) already tagged for $(params.package)"
         exit 1
     - name: check-release-file
-      image: alpine
-      command:
-      - /bin/sh
-      args:
-      - -ce
-      - |
+      image: gcr.io/google.com/cloudsdktool/cloud-sdk:310.0.0@sha256:cb03669fcdb9191d55a6200f2911fff3baec0b8c39b156d95b68aabe975ac506
+      script: |
         echo "Checking release file"
         # Check if the release file already exists
-        if [ -f $(resources.inputs.release-bucket.path)/previous/$(params.versionTag)/release.yaml ]; then
+        # gsutil retuns 1 if the object was not found
+        if gsutil stat $(params.releaseBucket)/previous/$(params.versionTag)/release.yaml; then
           echo "Release file already exists for $(params.versionTag) in the release bucket,"
           echo "but no git tag was found. To continue remove the release file first."
           exit 1
         fi
     - name: check-github-release
       image: python:3.6-alpine3.9
-      command:
-      - /bin/sh
-      args:
-      - -ce
-      - |
+      script: |
         echo "Checking GitHub release"
         PACKAGE=$(echo $(params.package) | cut -d/ -f2,3)
         # Check if the release exists on GitHub
@@ -75,10 +64,6 @@ spec:
         exit 1
     - name: success-confirmation
       image: alpine
-      command:
-      - /bin/sh
-      args:
-      - -ce
-      - |
-        echo "All prelease checks for $(params.package) @ $(params.versionTag) where successful"
+      script: |
+        echo "All pre-release checks for $(params.package) @ $(params.versionTag) where successful"
         echo "Happy releasing 😺"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Stop using pipeline resources, use workspaces instead.
For the gcs object, use gsutils directly to stat the object,
which saves us downloading the whole bucket to check a single file.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc