### PR TITLE
Add pipeline to run s390x cli tests

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly cli e2e tests.

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "cli"
+            - name: NAMESPACE
+              value: "bastion-z"
+            - name: REGISTRY
+              value: "sshd.bastion-z.svc.cluster.local:4000"
+            - name: TARGET_ARCH
+              value: "s390x"
+            - name: REMOTE_SECRET_NAME
+              value: "s390x-k8s-ssh"
+            - name: REMOTE_HOST
+              value: "sshd.bastion-z.svc.cluster.local"
+            - name: REMOTE_PORT
+              value: "1122"
+            - name: REMOTE_USER
+              value: "k8smanager"

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-cli-s390x"

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
@@ -2,3 +2,4 @@ namespace: default
 resources:
 - pipeline-nightly-test
 - triggers-nightly-test
+- cli-nightly-test

--- a/tekton/resources/nightly-tests/bastion-z/cleanup_tekton.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/cleanup_tekton.yaml
@@ -8,24 +8,22 @@ spec:
   - name: resources
     description: space separated list of resources to be deleted
     default: "conditions pipelineresources tasks pipelines taskruns pipelineruns"
-  resources:
-    inputs:
-    - name: plumbing-source
-      type: git
-    - name: tekton-project-source
-      type: git
-      targetPath: src/$(params.package)
+  - name: plumbing-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/plumbing
   workspaces:
   - name: k8s-shared
-    description: |
-      k8s config
+    description: workspace for k8s config, configuration file is expected to have `config` name
     mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
   steps:
   - name: cleanup-resources
     image: gcr.io/tekton-releases/dogfooding/kubectl:latest
     env:
     - name: KUBECONFIG
-      value: /root/.kube/config
+      value: $(workspaces.k8s-shared.path)/config
     command:
     - /bin/sh
     args:
@@ -40,12 +38,12 @@ spec:
     workingdir: /workspace/src/$(params.package)
     env:
     - name: KUBECONFIG
-      value: /root/.kube/config
+      value: $(workspaces.k8s-shared.path)/config
     command:
     - /bin/bash
     args:
     - -ce
     - |
-      source $(resources.inputs.plumbing-source.path)/scripts/library.sh
+      source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       ko delete --ignore-not-found=true -f config/
       wait_until_object_does_not_exist namespace tekton-pipelines

--- a/tekton/resources/nightly-tests/bastion-z/deploy_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/deploy_tekton_component.yaml
@@ -10,18 +10,16 @@ spec:
     description: container registry used to publish build images
   - name: target-arch
     description: target architecture for tests (s390x, ppc64le, arm64)
-  resources:
-    inputs:
-    - name: tekton-project-source
-      type: git
-      targetPath: src/$(params.package)
   workspaces:
   - name: k8s-shared
     description: workspace for k8s config, configuration file is expected to have `config` name
     mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
   steps:
   - name: deploy
-    workingdir: /workspace/src/$(params.package)
+    workingdir: $(workspaces.source-code.path)/src/$(params.package)
     image: gcr.io/tekton-releases/dogfooding/test-runner:latest
     env:
     - name: GOPATH

--- a/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - k8s_cluster_setup.yaml
 - test_tekton_component.yaml
 - deploy_tekton_component.yaml
+- test_tekton_cli.yaml

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test-e2e-tekton-cli
+spec:
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: tests-path
+    description: path to the tests within "tests" git resource
+    default: ./test/e2e
+  - name: plumbing-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/plumbing
+  - name: timeout
+    description: timeout for the go test runner
+    default: 20m
+  - name: tags
+    default: e2e
+  workspaces:
+  - name: k8s-shared
+    description: workspace for k8s config, configuration file is expected to have `config` name
+    mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+  steps:
+  - name: run-e2e-tests
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    workingdir: $(workspaces.source-code.path)/src/$(params.package)
+    env:
+    - name: REPO_ROOT_DIR
+      value: $(workspaces.source-code.path)/src/$(params.package)
+    - name: GOPATH
+      value: /workspace
+    - name: KUBECONFIG
+      value: $(workspaces.k8s-shared.path)/config
+    - name: TEST_CLIENT_BINARY
+      value: $(workspaces.source-code.path)/src/$(params.package)/tkn
+    - name: TEST_CLUSTERTASK_LIST_EMPTY
+      value: "yes"
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
+      go build -o tkn $(params.package)/cmd/tkn
+      for testsuite in clustertask eventListener pipeline pipelinerun resource task; do
+        header "Running Go $(params.tags) ${testsuite} tests"
+        report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite} --kubeconfig $(workspaces.k8s-shared.path)/config
+      done

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
@@ -9,6 +9,9 @@ spec:
   - name: tests-path
     description: path to the tests within "tests" git resource
     default: ./test
+  - name: plumbing-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/plumbing
   - name: timeout
     description: timeout for the go test runner
     default: 30m
@@ -18,24 +21,19 @@ spec:
     default: e2e
   - name: target-arch
     description: target architecture for tests (s390x, ppc64le, arm64)
-  resources:
-    inputs:
-    - name: plumbing-source
-      type: git
-    - name: tekton-project-source
-      type: git
-      targetPath: src/$(params.package)
   workspaces:
   - name: k8s-shared
     description: workspace for k8s config, configuration file is expected to have `config` name
     mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
   steps:
   - name: run-e2e-tests
     image: gcr.io/tekton-releases/dogfooding/test-runner:latest
-    workingdir: /workspace/src/$(params.package)
+    workingdir: $(workspaces.source-code.path)/src/$(params.package)
     env:
     - name: REPO_ROOT_DIR
-      value: $(resources.inputs.tekton-project-source.path)
+      value: $(workspaces.source-code.path)/src/$(params.package)
     - name: GOPATH
       value: /workspace
     - name: KO_DOCKER_REPO
@@ -51,7 +49,7 @@ spec:
     args:
     - -ce
     - |
-      source $(resources.inputs.plumbing-source.path)/scripts/library.sh
+      source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       # extend test timeout (from 10 minutes to 20 minutes) to resolve https://github.com/tektoncd/pipeline/issues/3627
       sed -i 's/timeout  = 10/timeout  = 20/g' test/wait.go
       header "Running Go $(params.tags) tests"

--- a/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
@@ -1,0 +1,225 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-cli-nightly-test-s390x
+spec:
+  params:
+  - name: containerRegistry
+  - name: targetArch
+  - name: namespace
+  - name: remoteHost
+  - name: remotePort
+  - name: remoteUser
+  - name: remoteSecret
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-cli-$(tt.params.targetArch)-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      timeout: 2h
+      workspaces:
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+      # this workspace will be used to store ssh key
+      - name: ssh-secret
+        secret:
+          secretName: $(tt.params.remoteSecret)
+          items:
+          - key: privatekey
+            path: id_rsa
+            # yamllint disable rule:octal-values
+            mode: 0600
+            # yamllint enable
+      pipelineSpec:
+        workspaces:
+        - name: shared-workspace
+        - name: ssh-secret
+        params:
+        - name: package
+        - name: container-registry
+        - name: target-arch
+        - name: remote-host
+        - name: remote-port
+        - name: remote-user
+        tasks:
+        - name: git-clone-plumbing
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/plumbing
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-pipeline
+          runAfter: [git-clone-plumbing]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/pipeline
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-triggers
+          runAfter: [git-clone-pipeline]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/triggers
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/triggers
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-cli
+          runAfter: [git-clone-triggers]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/cli
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/cli
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: create-k8s-cluster
+          runAfter: [git-clone-cli]
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+        - name: deploy-pipeline
+          runAfter: [create-k8s-cluster]
+          taskRef:
+            name: deploy-tekton-project-nightly
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          params:
+          - name: package
+            value: github.com/tektoncd/pipeline
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+        - name: deploy-triggers
+          runAfter: [deploy-pipeline]
+          taskRef:
+            name: deploy-tekton-project-nightly
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          params:
+          - name: package
+            value: github.com/tektoncd/triggers
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+        - name: e2e-test-cli
+          runAfter: [deploy-triggers]
+          taskRef:
+            name: test-e2e-tekton-cli
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: $(params.package)
+        finally:
+        - name: delete-k8s-cluster
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+          - name: action
+            value: delete
+      params:
+      - name: package
+        value: github.com/tektoncd/cli
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: target-arch
+        value: $(tt.params.targetArch)
+      - name: remote-host
+        value: $(tt.params.remoteHost)
+      - name: remote-port
+        value: $(tt.params.remotePort)
+      - name: remote-user
+        value: $(tt.params.remoteUser)

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -29,7 +29,18 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-triggers-nightly-test-s390x
-
+  - name: cli-nightly-test-trigger-s390x
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'cli' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 's390x'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-cli-nightly-test-s390x
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - eventlistener.yaml
 - pipeline-deploy-test-s390x-template.yaml
 - triggers-deploy-test-s390x-template.yaml
+- cli-deploy-test-s390x-template.yaml
 - serviceaccount.yaml

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
@@ -33,15 +33,15 @@ spec:
     spec:
       timeout: 2h
       workspaces:
-      # this workspace will be used to store k8s config
-      - name: k8s-shared
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
         volumeClaimTemplate:
           spec:
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 10Mi
+                storage: 1Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:
@@ -54,13 +54,8 @@ spec:
             # yamllint enable
       pipelineSpec:
         workspaces:
-        - name: k8s-shared
+        - name: shared-workspace
         - name: ssh-secret
-        resources:
-        - name: plumbing-source
-          type: git
-        - name: tekton-pipeline-source
-          type: git
         params:
         - name: package
         - name: container-registry
@@ -69,12 +64,43 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
+        - name: git-clone-plumbing
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/plumbing
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-pipeline
+          runAfter: [git-clone-plumbing]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/pipeline
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
         - name: create-k8s-cluster
+          runAfter: [git-clone-pipeline]
           taskRef:
             name: create-delete-k8s-cluster-$(tt.params.targetArch)
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
           - name: ssh-secret
             workspace: ssh-secret
           params:
@@ -90,7 +116,11 @@ spec:
             name: deploy-tekton-project-nightly
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
           params:
           - name: package
             value: $(params.package)
@@ -98,17 +128,17 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-          resources:
-            inputs:
-            - name: tekton-project-source
-              resource: tekton-pipeline-source
         - name: e2e-test-pipeline
           runAfter: [deploy-pipeline]
           taskRef:
             name: test-e2e-tekton-component
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
           retries: 2
           params:
           - name: package
@@ -117,19 +147,17 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-          resources:
-            inputs:
-            - name: plumbing-source
-              resource: plumbing-source
-            - name: tekton-project-source
-              resource: tekton-pipeline-source
         - name: examples-test-pipeline
           runAfter: [e2e-test-pipeline]
           taskRef:
             name: test-e2e-tekton-component
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
           retries: 2
           params:
           - name: package
@@ -140,19 +168,14 @@ spec:
             value: $(params.target-arch)
           - name: tags
             value: "examples"
-          resources:
-            inputs:
-            - name: plumbing-source
-              resource: plumbing-source
-            - name: tekton-project-source
-              resource: tekton-pipeline-source
         finally:
         - name: delete-k8s-cluster
           taskRef:
             name: create-delete-k8s-cluster-$(tt.params.targetArch)
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
           - name: ssh-secret
             workspace: ssh-secret
           params:
@@ -177,20 +200,3 @@ spec:
         value: $(tt.params.remotePort)
       - name: remote-user
         value: $(tt.params.remoteUser)
-      resources:
-      - name: tekton-pipeline-source
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: master
-          - name: url
-            value: https://github.com/tektoncd/pipeline
-      - name: plumbing-source
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: main
-          - name: url
-            value: https://github.com/tektoncd/plumbing

--- a/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
@@ -33,8 +33,8 @@ spec:
     spec:
       timeout: 2h
       workspaces:
-      # this workspace will be used to store k8s config
-      - name: k8s-shared
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
         volumeClaimTemplate:
           spec:
             accessModes:
@@ -54,15 +54,8 @@ spec:
             # yamllint enable
       pipelineSpec:
         workspaces:
-        - name: k8s-shared
+        - name: shared-workspace
         - name: ssh-secret
-        resources:
-        - name: plumbing-source
-          type: git
-        - name: tekton-pipeline-source
-          type: git
-        - name: tekton-triggers-source
-          type: git
         params:
         - name: package
         - name: container-registry
@@ -71,12 +64,58 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
+        - name: git-clone-plumbing
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/plumbing
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-pipeline
+          runAfter: [git-clone-plumbing]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/pipeline
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-triggers
+          runAfter: [git-clone-pipeline]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/triggers
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/triggers
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
         - name: create-k8s-cluster
+          runAfter: [git-clone-triggers]
           taskRef:
             name: create-delete-k8s-cluster-$(tt.params.targetArch)
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
           - name: ssh-secret
             workspace: ssh-secret
           params:
@@ -92,7 +131,11 @@ spec:
             name: deploy-tekton-project-nightly
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
           params:
           - name: package
             value: github.com/tektoncd/pipeline
@@ -100,17 +143,17 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-          resources:
-            inputs:
-            - name: tekton-project-source
-              resource: tekton-pipeline-source
         - name: deploy-triggers
           runAfter: [deploy-pipeline]
           taskRef:
             name: deploy-tekton-project-nightly
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
           params:
           - name: package
             value: $(params.package)
@@ -118,17 +161,17 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-          resources:
-            inputs:
-            - name: tekton-project-source
-              resource: tekton-triggers-source
         - name: e2e-test-triggers
           runAfter: [deploy-triggers]
           taskRef:
             name: test-e2e-tekton-component
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
           retries: 2
           params:
           - name: package
@@ -137,19 +180,14 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-          resources:
-            inputs:
-            - name: plumbing-source
-              resource: plumbing-source
-            - name: tekton-project-source
-              resource: tekton-triggers-source
         finally:
         - name: delete-k8s-cluster
           taskRef:
             name: create-delete-k8s-cluster-$(tt.params.targetArch)
           workspaces:
           - name: k8s-shared
-            workspace: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
           - name: ssh-secret
             workspace: ssh-secret
           params:
@@ -174,28 +212,3 @@ spec:
         value: $(tt.params.remotePort)
       - name: remote-user
         value: $(tt.params.remoteUser)
-      resources:
-      - name: tekton-pipeline-source
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: master
-          - name: url
-            value: https://github.com/tektoncd/pipeline
-      - name: plumbing-source
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: main
-          - name: url
-            value: https://github.com/tektoncd/plumbing
-      - name: tekton-triggers-source
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: master
-          - name: url
-            value: https://github.com/tektoncd/triggers


### PR DESCRIPTION
# Changes

- add corresponding cronjob to trigger s390x tekton cli test
- add separate task for cli tests (default e2e test task cannot be used, because cli e2e test has another setup)
- add template to run s390x cli test pipeline
   - git clone all required tekton repos
   - k8s cluster installation
   - pipeline and triggers deployment
   - e2e cli test
   - k8s cluster removal
   
As discussed at https://github.com/tektoncd/plumbing/pull/732#discussion_r581833660 pipeline resources were removed in favour of [git-clone](https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.2) task. 

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._