### PR TITLE
Remove check-kind-label check from catalog

### DIFF
--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -76,7 +76,7 @@ spec:
         - cel:
             filter: >-
               body.repository.full_name.startsWith('tektoncd/') &&
-              body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'catalog', 'hub'] &&
+              body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub'] &&
               body.action == 'created' &&
               'pull_request' in body.issue &&
               body.issue.state == 'open' &&
@@ -112,7 +112,7 @@ spec:
         - cel:
             filter: >-
               body.repository.full_name.startsWith('tektoncd/') &&
-              body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'catalog', 'hub'] &&
+              body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub'] &&
               (body.action == 'opened' ||
                body.action == 'synchronize' ||
                body.action == 'labeled' ||


### PR DESCRIPTION
# Changes

Catalog repository doesn't require the check-pr-kind-label as of now so
removing it from the `EventListener` filter.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._