### PR TITLE
List all members of the org, not just public members

### DIFF
--- a/tekton/ci/interceptors/add-team-members/README.md
+++ b/tekton/ci/interceptors/add-team-members/README.md
@@ -13,14 +13,16 @@ incoming JSON as follows:
 {
   "add_team_members":
   {
-    "org_base_url": "https://api.github.com/repos/tektoncd/",
+    "org_base_url": "https://api.github.com/repos/tektoncd/"
   },
   "other-keys": "other=values"
 }
 ```
 
 It returns the original JSON payload untouched, with the addition of the org
-members:
+members. If the owner of the Github token passed in `GITHUB_TOKEN` is also
+a member of the organization then [both concealed and public members will be
+returned](https://docs.github.com/en/rest/reference/orgs#list-organization-members).
 
 ```json
 {
@@ -28,7 +30,7 @@ members:
   {
     "org_base_url": "https://api.github.com/repos/tektoncd/",
     "team": "plumbing",
-    "public_org_members": ["a", "b", "c"]
+    "org_members": ["a", "b", "c"]
   },
   "other-keys": "other=values"
 }
@@ -58,7 +60,7 @@ org members and the maintainers:
   {
     "org_base_url": "https://api.github.com/repos/tektoncd/",
     "team": "plumbing",
-    "public_org_members": ["a", "b", "c"],
+    "org_members": ["a", "b", "c"],
     "maintainers_team_members": ["a", "b"]
   },
   "other-keys": "other=values"

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main.go
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main.go
@@ -37,9 +37,9 @@ const (
 	prExtensionsKey   = "add_team_members"
 	orgUrlKey         = "org_base_url"
 	teamKey           = "team"
-	orgMembersKey     = "public_org_members"
+	orgMembersKey     = "org_members"
 	teamMembersKey    = "maintainers_team_members"
-	publicMembersPath = "%s/public_members"
+	membersPath       = "%s/members"
 	teamPath          = "%s/teams/%s-maintainers/members"
 )
 
@@ -96,12 +96,13 @@ func makeAddTeamMembersHandler(orgMembersFetcher, teamMembersFetcher urlToList, 
 			return
 		}
 		// Get the list of org members from the URL
-		orgMembers, err := orgMembersFetcher(orgUrl, "")
+		orgMembers, err := orgMembersFetcher(orgUrl, token)
 		if err != nil {
 			log.Printf("failed to get the list of org members: %q", err)
 			marshalError(err, w)
 			return
 		}
+
 		// Add the org members to the original body
 		jsonBody[RootExtensionsKey].(map[string]interface{})[prExtensionsKey].(map[string]interface{})[orgMembersKey] = orgMembers
 
@@ -133,6 +134,7 @@ func makeAddTeamMembersHandler(orgMembersFetcher, teamMembersFetcher urlToList, 
 			marshalError(err, w)
 			return
 		}
+
 		// Set all the original headers
 		for k, values := range r.Header {
 			for _, v := range values {
@@ -213,7 +215,7 @@ func getOrgUrl(body map[string]interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(publicMembersPath, baseUrl), nil
+	return fmt.Sprintf(membersPath, baseUrl), nil
 }
 
 func getTeamUrl(body map[string]interface{}) (string, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We are currently fetching the public members of an organization from the `add-team-members` interceptor. This PR changes `add-team-members` to fetch all members instead.

For that, we change the Github API endpoint from `/public_members` to `/members`. Old behavior can still be achieved if the passed `GITHUB_TOKEN` does not belong to the organization, in which case only public members will be listed. If the user owning the `GITHUB_TOKEN` is in the organization, then [both public and private members will be listed](https://docs.github.com/en/rest/reference/orgs#list-organization-members).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._