### PR TITLE
Add unit tests CI for the plumbing repo

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  enable-custom-tasks: "true"

--- a/tekton/ci/jobs/kustomization.yaml
+++ b/tekton/ci/jobs/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - tekton-python-test.yaml
 - tekton-teps-validation.yaml
 - tekton-catlin-lint.yaml
+- tekton-golang-tests.yaml

--- a/tekton/ci/jobs/tasks.yaml
+++ b/tekton/ci/jobs/tasks.yaml
@@ -202,3 +202,64 @@ spec:
         sys.exit(1)
       else:
         print("Exactly one \"kind/*\" label found: {}".format(validKindLabels))
+---
+apiVersion: custom.tekton.dev/v1alpha1
+kind: TaskLoop
+metadata:
+  name: golang-tests
+spec:
+  iterateParam: context
+  taskSpec:
+    params:
+    - name: package
+      description: package (and its children) under test
+      type: string
+    - name: packages
+      description: 'packages to test (default: ./...)'
+      default: ./...
+      type: string
+    - name: context
+      description: context to test
+      default: ''
+      type: string
+    - name: version
+      description: golang version to use for tests
+      default: latest
+      type: string
+    - name: flags
+      default: -race -cover -v
+      description: flags to use for the test command
+      type: string
+    - name: GOOS
+      default: linux
+      description: running program's operating system target
+      type: string
+    - name: GOARCH
+      default: amd64
+      description: running program's architecture target
+      type: string
+    - name: GO111MODULE
+      default: auto
+      description: value of module support
+      type: string
+    resources:
+      inputs:
+      - name: source
+        targetPath: src/$(inputs.params.package)
+        type: git
+    steps:
+    - name: unit-test
+      image: golang:$(inputs.params.version)
+      env:
+      - name: GOPATH
+        value: /workspace
+      - name: GOOS
+        value: $(inputs.params.GOOS)
+      - name: GOARCH
+        value: $(inputs.params.GOARCH)
+      - name: GO111MODULE
+        value: $(inputs.params.GO111MODULE)
+      resources: {}
+      script: |
+        go test $(inputs.params.flags) $(inputs.params.packages)
+      workingDir: /workspace/src/$(inputs.params.package)/$(params.context)

--- a/tekton/ci/jobs/tekton-golang-tests.yaml
+++ b/tekton/ci/jobs/tekton-golang-tests.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tekton-golang-tests
+  namespace: tektonci
+spec:
+  params:
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: fileFilterRegex
+      description: Names regex to be matched in the list of modified files
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+    - name: package
+      description: package (and its children) under test
+    - name: folders
+      type: array
+      description: The folders to test
+  resources:
+    - name: source
+      type: git
+  tasks:
+  - name: unit-tests
+    conditions:
+    - conditionRef: "check-git-files-changed"
+      params:
+      - name: gitCloneDepth
+        value: $(params.gitCloneDepth)
+      - name: regex
+        value: $(params.fileFilterRegex)
+      resources:
+      - name: source
+        resource: source
+    - conditionRef: "check-name-matches"
+      params:
+      - name: gitHubCommand
+        value: $(params.gitHubCommand)
+      - name: checkName
+        value: $(params.checkName)
+    taskRef:
+      apiVersion: custom.tekton.dev/v1alpha1
+      kind: TaskLoop
+      name: golang-tests
+    params:
+    - name: context
+      value: $(params.folders)
+    - name: version
+      value: "1.15"
+    resources:
+      inputs:
+      - name: source
+        resource: source

--- a/tekton/ci/templates/plumbing-template.yaml
+++ b/tekton/ci/templates/plumbing-template.yaml
@@ -506,3 +506,51 @@ spec:
             value: $(tt.params.gitRepository)
           - name: depth
             value: $(tt.params.gitCloneDepth)
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: plumbing-unit-tests-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/check-name: plumbing-unit-tests
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+        tekton.dev/kind: ci
+      annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+        tekton.dev/gitURL: "$(tt.params.gitRepository)"
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      pipelineRef:
+        name: tekton-golang-tests
+      params:
+        - name: package
+          value: $(tt.params.package)
+        - name: folders
+          value:
+            - bots/buildcaptain
+            - bots/mariobot
+            - catlin
+            - pipelinerun-logs
+            - tekton/ci/interceptors/add-team-members
+            - tekton/ci/interceptors/add-pr-body
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: gitCloneDepth
+          value: $(tt.params.gitCloneDepth)
+        - name: fileFilterRegex
+          value: "tekton/images/alpine-git-nonroot/**"
+        - name: checkName
+          value: plumbing-unit-tests
+        - name: gitHubCommand
+          value: $(tt.params.gitHubCommand)
+      resources:
+      - name: source
+        resourceSpec:
+          type: git
+          params:
+          - name: revision
+            value: $(tt.params.gitRevision)
+          - name: url
+            value: $(tt.params.gitRepository)
+          - name: depth
+            value: $(tt.params.gitCloneDepth)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a unit test CI job for the plumbing repo.
We have several packages that include unit tests. To test all of them
in a single CI job and dedicated tasks, use a task loop.

The taskloop controller has been deployed to dogfooding on nightly
version v20210216. This PR includes a patch to the tekton controller
config to enable support for custom tasks integration in pipeline.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature