### PR TITLE
Fix Catlin CI to skip validation if no task change

### DIFF
--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -34,6 +34,10 @@ spec:
       image: gcr.io/tekton-releases/dogfooding/catlin:latest
       workingDir: $(resources.inputs.source.path)
       script: |
+        [[ ! -s $(workspaces.store-changed-files.path)/changed-files.txt ]] && {
+          echo "No file change detected in task directory"
+          exit 0
+        }
         catlin validate $(cat $(workspaces.store-changed-files.path)/changed-files.txt)
 ---
 apiVersion: tekton.dev/v1beta1


### PR DESCRIPTION
# Changes

As of now catlin CI is failing whenever someone raises a PR on catalog
and the file changes are not related to task dir. Checking that and
skipping in that case.

/kind bug
/cc @vdemeester @piyush-garg @afrittoli 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._