### PR TITLE
Add pipeline to run s390x operator tests

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - pipeline-nightly-test
 - triggers-nightly-test
 - cli-nightly-test
+- operator-nightly-test

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly operator e2e tests.

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "operator"
+            - name: NAMESPACE
+              value: "bastion-z"
+            - name: REGISTRY
+              value: "sshd.bastion-z.svc.cluster.local:4000"
+            - name: TARGET_ARCH
+              value: "s390x"
+            - name: REMOTE_SECRET_NAME
+              value: "s390x-k8s-ssh"
+            - name: REMOTE_HOST
+              value: "sshd.bastion-z.svc.cluster.local"
+            - name: REMOTE_PORT
+              value: "1122"
+            - name: REMOTE_USER
+              value: "k8smanager"

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-operator-s390x"

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -41,6 +41,18 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-cli-nightly-test-s390x
+  - name: operator-nightly-test-trigger-s390x
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'operator' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 's390x'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-operator-nightly-test-s390x
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 - pipeline-deploy-test-s390x-template.yaml
 - triggers-deploy-test-s390x-template.yaml
 - cli-deploy-test-s390x-template.yaml
+- operator-deploy-test-s390x-template.yaml
 - serviceaccount.yaml

--- a/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
@@ -1,0 +1,172 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-operator-nightly-test-s390x
+spec:
+  params:
+  - name: containerRegistry
+  - name: targetArch
+  - name: namespace
+  - name: remoteHost
+  - name: remotePort
+  - name: remoteUser
+  - name: remoteSecret
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-operator-$(tt.params.targetArch)-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      timeout: 2h
+      workspaces:
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+      # this workspace will be used to store ssh key
+      - name: ssh-secret
+        secret:
+          secretName: $(tt.params.remoteSecret)
+          items:
+          - key: privatekey
+            path: id_rsa
+            # yamllint disable rule:octal-values
+            mode: 0600
+            # yamllint enable
+      pipelineSpec:
+        workspaces:
+        - name: shared-workspace
+        - name: ssh-secret
+        params:
+        - name: container-registry
+        - name: target-arch
+        - name: remote-host
+        - name: remote-port
+        - name: remote-user
+        tasks:
+        - name: git-clone-operator
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/operator
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/operator
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: create-k8s-cluster
+          runAfter: [git-clone-operator]
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+        - name: e2e-test-operator
+          runAfter: [create-k8s-cluster]
+          taskSpec:
+            params:
+            - name: container-registry
+            - name: target-arch
+            workspaces:
+            - name: k8s-shared
+              description: workspace for k8s config, configuration file is expected to have `config` name
+              mountPath: /root/.kube
+            - name: source-code
+              description: workspace with source code for tekton component
+            steps:
+            - name: run-e2e-tests
+              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              workingdir: $(workspaces.source-code.path)/src/github.com/tektoncd/operator
+              env:
+              - name: GOPATH
+                value: /workspace
+              - name: KUBECONFIG
+                value: $(workspaces.k8s-shared.path)/config
+              - name: PLATFORM
+                value: linux/$(params.target-arch)
+              - name: KO_DOCKER_REPO
+                value: $(params.container-registry)
+              - name: E2E_DEBUG
+                value: "true"
+              command:
+              - /bin/bash
+              args:
+              - -ce
+              - |
+                test/e2e-tests.sh
+          params:
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+        finally:
+        - name: delete-k8s-cluster
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+          - name: action
+            value: delete
+      params:
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: target-arch
+        value: $(tt.params.targetArch)
+      - name: remote-host
+        value: $(tt.params.remoteHost)
+      - name: remote-port
+        value: $(tt.params.remotePort)
+      - name: remote-user
+        value: $(tt.params.remoteUser)


### PR DESCRIPTION
# Changes
- add corresponding cronjob to trigger s390x tekton operator test
- add template to run s390x operator test pipeline
   - git clone all required tekton repos
   - k8s cluster installation
   - e2e operator test(with operator image build and installation)
   - k8s cluster removal

/kind misc
/cc @afrittoli @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._