### PR TITLE
Add the two new cronjobs to kustomize

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -3,3 +3,5 @@ resources:
 - pipeline-nightly
 - triggers-nightly
 - task-loops-nightly
+- cel-nightly
+- pipelines-in-pipelines-nightly

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 - overlays/pipeline
 - overlays/triggers
 - overlays/task-loops
+- overlays/cel
+- overlays/pipelines-in-pipelines


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the two new cronjobs for nightly builds to kustomize so that they
are deployed and executed. Add the corresponding nightly resources to
the kustomize file.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc