### PR TITLE
Fix size of workspace volume for s390x triggers pipeline

### DIFF
--- a/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 10Mi
+                storage: 1Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:


### PR DESCRIPTION
The volume size should be large enough to store pipeline, triggers, plumbing source code. So size of workspace volume should be 1Gi.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._