### PR TITLE
Use larger workspaces for s390x pipelines

### DIFF
--- a/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 1Gi
+                storage: 2Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 1Gi
+                storage: 2Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:

--- a/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 1Gi
+                storage: 2Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:


### PR DESCRIPTION


# Changes

Initial 1Gi size of workspaces was not enough to store source code and do the image builds for s390x testing. Propose is to have 2Gi instead.
Current usage is around 1.2Gi-1.5Gi, but to be on the safe side better to have extra disk space.

/kind bug
/cc @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._