### PR TITLE
Catlin: Report logs back to the PR after execution

### DIFF
--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -40,11 +40,33 @@ spec:
       image: gcr.io/tekton-releases/dogfooding/catlin:latest
       workingDir: $(resources.inputs.source.path)
       script: |
+        set +e
         [[ ! -s $(workspaces.store-changed-files.path)/changed-files.txt ]] && {
           echo "No file change detected in task directory"
+          echo -n "" > $(workspaces.store-changed-files.path)/catlin.txt
           exit 0
         }
-        catlin validate $(cat $(workspaces.store-changed-files.path)/changed-files.txt)
+
+        # creating a file which will contain the final formatted output
+        # which needs to be added as a comment(if any)
+        echo '**Catlin Output**' >> $(workspaces.store-changed-files.path)/catlin.txt
+        echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+
+        # performing catlin validate
+        catlin validate $(cat $(workspaces.store-changed-files.path)/changed-files.txt) | tee -a $(workspaces.store-changed-files.path)/catlin.txt
+        echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+
+        # checking if there are any ERROR or WARN messages produced by catlin
+        isWarning=$(cat  $(workspaces.store-changed-files.path)/catlin.txt | grep -c "WARN")
+        isError=$(cat  $(workspaces.store-changed-files.path)/catlin.txt | grep -c "ERROR")
+
+        # if there are no ERROR or WARN messages then add a empty string which will not
+        # add a comment on the Github PR
+        [[ $isWarning -eq 0 ]] && [[ $isError -eq 0 ]] && \
+        echo -n "" > $(workspaces.store-changed-files.path)/catlin.txt
+
+        # if catlin produced the error then fail the task else success
+        [[ $isError -eq 1 ]] && exit 1 || exit 0
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -65,6 +87,8 @@ spec:
       description: The command that was used to trigger testing
     - name: checkName
       description: The name of the GitHub check that this pipeline is used for
+    - name: pullRequestUrl
+      description: The HTML URL for the pull request
   tasks:
     - name: lint-catalog
       conditions:
@@ -86,3 +110,19 @@ spec:
       params:
         - name: gitCloneDepth
           value: $(params.gitCloneDepth)
+  finally:
+    - name: post-comment
+      taskRef:
+        name: github-add-comment
+      params:
+        - name: COMMENT_OR_FILE
+          value: "catlin.txt"
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token
+        - name: REQUEST_URL
+          value: $(params.pullRequestUrl)
+      workspaces:
+        - name: comment-file
+          workspace: store-changed-files

--- a/tekton/ci/templates/catalog-template.yaml
+++ b/tekton/ci/templates/catalog-template.yaml
@@ -48,7 +48,13 @@ spec:
           name: catlin-linter
         workspaces:
           - name: store-changed-files
-            emptyDir: {}
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 5Mi
         params:
           - name: gitCloneDepth
             value: $(tt.params.gitCloneDepth)
@@ -56,6 +62,8 @@ spec:
             value: $(tt.params.gitHubCommand)
           - name: checkName
             value: pull-catalog-catlin-lint
+          - name: pullRequestUrl
+            value: $(tt.params.pullRequestUrl)
         resources:
           - name: source
             resourceSpec:


### PR DESCRIPTION
# Changes

As of now catlin is running on PRs of catalog and validate them as per
TEP-0003 but there are some warnings which are produced by catlin which
maybe left un-noticed by the PR author as catlin check doesn't fails.

This PR adds a script which will search whether catlin has produced any
warning or error and if found will post the output as comment on the PR.

/kind feature

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._