### PR TITLE
Handle mixed main repo names in triggers

### DIFF
--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -34,6 +34,10 @@ spec:
               - |
                 GIT_SHA=$(git ls-remote --heads https://${GIT_REPO} | \
                   awk '/refs\/heads\/master/{ print $1 }')
+                if [ "${GIT_SHA}" == "" ]; then
+                  GIT_SHA=$(git ls-remote --heads https://${GIT_REPO} | \
+                  awk '/refs\/heads\/main/{ print $1 }')
+                fi
                 VERSION_TAG="v$(date +"%Y%m%d")-$(echo $GIT_SHA | cut -c 1-10)"
                 cat <<EOF > /shared/git
                 export GIT_SHA=$GIT_SHA


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The nightly version name is generated from the sha of the last commit.
Depending on the repo that may be on main or master (at least during
the transition), so handle both.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc