### PR TITLE
Add pipelines nightly tests for ppc64le architecture

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -24,6 +24,11 @@ Secrets which have been applied to the dogfooding cluster but are not committed 
     - `mario-github-token` used for updating PRs
   - In the bastion-z namespace:
     - `s390x-k8s-ssh` used to ssh access s390x remote machine
+  - In the bastion-p namespace:
+    - `ppc64le-kubeconfig` used to access ppc64le remote k8 cluster
+    - `registry-credentials` used to access registry on remote machine
+    - `registry-certificate` self-signed certificate for registry on remote machine
+    - `ppc64le-cluster` headless service & endpoint to resolve remote machine address
 - `GCP` secrets:
   - `nightly-account` is used by nightly releases to push releases
   to the nightly bucket. It's a token for service account

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/README.md
@@ -1,0 +1,1 @@
+Cron Job to daily cleanup pr/tr from the default namespace in the dogfooding cluster

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+spec:
+  schedule: "0 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: NAMESPACE
+                value: "bastion-p"
+              - name: CLUSTER_RESOURCE
+                value: "dogfooding-tektoncd-cleaner"
+              - name: CLEANUP_KEEP
+                value: "20"

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/cleanup
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dogfooding-bastion-p"

--- a/tekton/cronjobs/dogfooding/cleanup/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - bastion-z-nightly
 - tekton-ci-nightly
 - tekton-nightly-nightly
+- bastion-p-nightly

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
@@ -1,4 +1,3 @@
 namespace: default
 resources:
-- s390x
-- ppc64le
+- pipeline-nightly-test

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly pipeline e2e tests.

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 1 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "pipeline"
+            - name: NAMESPACE
+              value: "bastion-p"
+            - name: REGISTRY
+              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+            - name: TARGET_ARCH
+              value: "ppc64le"
+            - name: REMOTE_SECRET_NAME
+              value: "ppc64le-kubeconfig"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-pipeline-ppc64le"

--- a/tekton/resources/nightly-tests/bastion-p/cleanup_tekton.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/cleanup_tekton.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup-tekton-nightly
+spec:
+  workspaces:
+  - name: k8s-config
+    description: workspace to get k8s config file
+    mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
+  params:
+  - name: package
+  - name: resources
+    description: space separated list of resources to be deleted
+    default: "conditions pipelineresources tasks pipelines taskruns pipelineruns"
+  - name: plumbing-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/plumbing
+  steps:
+  - name: cleanup-resources
+    image: gcr.io/tekton-releases/dogfooding/kubectl:latest
+    env:
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    command:
+    - /bin/sh
+    args:
+    - -ce
+    - |
+      kubectl delete ns -l tekton.dev/test-e2e=true
+      for res in $(params.resources); do
+        kubectl delete --ignore-not-found=true ${res}.tekton.dev --all || return true
+      done
+  - name: uninstall-tekton-project
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    workingdir: /workspace/src/$(params.package)
+    env:
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
+      ko delete --ignore-not-found=true -f config/
+      wait_until_object_does_not_exist namespace tekton-pipelines

--- a/tekton/resources/nightly-tests/bastion-p/deploy_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/deploy_tekton_component.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-tekton-project-nightly
+spec:
+  workspaces:
+  - name: k8s-config
+    description: workspace to get k8s config file
+    mountPath: /root/.kube
+  - name: registry-credentials
+    description: workspace to get registry credentials
+    mountPath: /tekton/home/.docker
+  - name: registry-certificate
+    description: workspace to get registry self-signed certificate
+    mountPath: /opt/ssl/certs
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
+  params:
+  - name: package
+    description: package to install
+  - name: container-registry
+    description: container registry used to publish build images
+  - name: target-arch
+    description: target architecture for tests (s390x, ppc64le, arm64)
+  steps:
+  - name: deploy
+    workingdir: /workspace/src/$(params.package)
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: KO_DOCKER_REPO
+      value: $(params.container-registry)
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    - name: SSL_CERT_FILE
+      value: /opt/ssl/certs/registry.crt
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      # busybox binary in distroless image doesn't work on ppc64le
+      # https://bugs.busybox.net/show_bug.cgi?id=13491
+      sed -i 's/gcr.io\/distroless\/base@sha256:[a-zA-Z0-9]*/registry.access.redhat.com\/ubi8\/ubi-minimal:latest/g' config/controller.yaml
+      ko apply --platform=linux/$(params.target-arch) -f config/
+      kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s

--- a/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: bastion-p
+commonAnnotations:
+  managed-by: Tekton
+
+resources:
+- deploy_tekton_component.yaml
+- test_tekton_component.yaml
+- cleanup_tekton.yaml

--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test-e2e-tekton-component
+spec:
+  workspaces:
+  - name: k8s-config
+    description: workspace to get k8s config file
+    mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: tests-path
+    description: path to the tests within "tests" git resource
+    default: ./test
+  - name: plumbing-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/plumbing
+  - name: timeout
+    description: timeout for the go test runner
+    default: 45m
+  - name: container-registry
+    description: container registry used to push images during tests e.g. gcr.io/tekton-e2e-tests or icr.io/tekton-e2e-tests
+  - name: tags
+    default: e2e
+  - name: target-arch
+    description: target architecture for tests (s390x, ppc64le, arm64)
+  steps:
+  - name: run-e2e-tests
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    workingdir: $(workspaces.source-code.path)/src/$(params.package)
+    env:
+    - name: REPO_ROOT_DIR
+      value: $(workspaces.source-code.path)/src/$(params.package)
+    - name: GOPATH
+      value: /workspace
+    - name: KO_DOCKER_REPO
+      value: $(params.container-registry)
+    - name: TEST_RUNTIME_ARCH
+      value: $(params.target-arch)
+    - name: SYSTEM_NAMESPACE
+      value: tekton-pipelines
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
+      # extend test timeout (from 10 minutes to 20 minutes) to resolve https://github.com/tektoncd/pipeline/issues/3627
+      sed -i 's/timeout  = 10/timeout  = 20/g' test/wait.go
+      header "Running Go $(params.tags) tests"
+      report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path) -kubeconfig /root/.kube/config

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -53,6 +53,18 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-operator-nightly-test-s390x
+  - name: pipeline-nightly-test-trigger-ppc64le
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'pipeline' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 'ppc64le'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      name: tekton-pipeline-nightly-test-ppc64le
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -3,9 +3,11 @@ commonAnnotations:
 
 resources:
 - bastion-z
+- bastion-p
 - eventlistener.yaml
 - pipeline-deploy-test-s390x-template.yaml
 - triggers-deploy-test-s390x-template.yaml
 - cli-deploy-test-s390x-template.yaml
 - operator-deploy-test-s390x-template.yaml
+- pipeline-deploy-test-ppc64le-template.yaml
 - serviceaccount.yaml

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -1,0 +1,154 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-pipeline-nightly-test-ppc64le
+spec:
+  params:
+  - name: containerRegistry
+  - name: targetArch
+  - name: namespace
+  - name: remoteSecret
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      timeout: 2h
+      workspaces:
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+      # this workspace will be used to store k8s config
+      - name: k8s-config
+        secret:
+          secretName: $(tt.params.remoteSecret)
+      # this workspace will be used to store registry credentials
+      - name: registry-credentials
+        secret:
+          secretName: registry-credentials
+      # this workspace will be used to store registry self-signed certificate
+      - name: registry-certificate
+        secret:
+          secretName: registry-certificate
+      pipelineSpec:
+        workspaces:
+        - name: shared-workspace
+        - name: k8s-config
+        - name: registry-credentials
+        - name: registry-certificate
+        params:
+        - name: package
+        - name: container-registry
+        - name: target-arch
+        tasks:
+        - name: git-clone-plumbing
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/plumbing
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-pipeline
+          runAfter: [git-clone-plumbing]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: src/github.com/tektoncd/pipeline
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: deploy-pipeline
+          runAfter: [git-clone-pipeline]
+          taskRef:
+            name: deploy-tekton-project-nightly
+          workspaces:
+          - name: k8s-config
+            workspace: k8s-config
+          - name: registry-credentials
+            workspace: registry-credentials
+          - name: registry-certificate
+            workspace: registry-certificate
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: $(params.package)
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+        - name: e2e-test-pipeline
+          runAfter: [deploy-pipeline]
+          taskRef:
+            name: test-e2e-tekton-component
+          workspaces:
+          - name: k8s-config
+            workspace: k8s-config
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: $(params.package)
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+        finally:
+        - name: cleanup
+          taskRef:
+            name: cleanup-tekton-nightly
+          workspaces:
+          - name: k8s-config
+            workspace: k8s-config
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: $(params.package)
+      params:
+      - name: package
+        value: github.com/tektoncd/pipeline
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: target-arch
+        value: $(tt.params.targetArch)

--- a/tekton/resources/nightly-tests/serviceaccount.yaml
+++ b/tekton/resources/nightly-tests/serviceaccount.yaml
@@ -31,6 +31,20 @@ roleRef:
   kind: ClusterRole
   name: tekton-test-triggers-nightly
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-test-nightly-trigger-bastion-p
+  namespace: bastion-p
+subjects:
+- kind: ServiceAccount
+  name: tekton-test-nightly
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-test-triggers-nightly
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
This PR is similar to #663. It adds `cronjob`, `tasks` & `service account` to run nightly pipeline tests on remote `ppc64le` cluster.

- Add secret & resource details to docs.
- Update nightly test EventListener to include ppc64le architecture.
- Add TriggerTemplate for nightly pipeline tests on ppc64le.
- Add cronjob to trigger nightly ppc64le pipeline tests.
- Add tasks to deploy, test & clean pipeline components on remote ppc64le cluster.
- Add service account for triggering nightly tests.

The job configurations expect following resources to be present on dogfooding 
- `ppc64le-kubeconfig` used to access ppc64le remote k8 cluster
- `registry-credentials` used to access registry on remote machine
- `registry-certificate` self-signed certificate for registry on remote machine
- `ppc64le-cluster` headless service & endpoint to resolve remote machine address

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
/cc @afrittoli