### PR TITLE
Add corresponding RoleBindings for cleanup pipelineruns

### DIFF
--- a/tekton/cronjobs/README.md
+++ b/tekton/cronjobs/README.md
@@ -138,6 +138,26 @@ To reapply all cronjobs on dogfooding:
 kubectl replace -k tekton/cronjobs/dogfooding
 ```
 
+Make sure that RBAC is confifured properly to execute pipelinerun/taskrun
+triggered by cronjob. For cleanup, new RoleBinding should be added to
+[serviceaccount.yaml](../resources/cd/serviceaccount.yaml).
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-default
+  namespace: mynamespace
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr
+```
+
 ## Adding a daily build for a new image
 
 To build daily a container image, follow these steps:

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -130,6 +130,48 @@ roleRef:
   kind: ClusterRole
   name: delete-pr-tr
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-bastion-z
+  namespace: bastion-z
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-tekton-ci
+  namespace: tekton-ci
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-tekton-nightly
+  namespace: tekton-nightly
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
# Changes

Several cleanup pipelineruns fail to execute, because there are no permissions to access resources in corresponding namespaces. Addition of the RoleBindngs to allow access to the pipelineruns and taskruns in the `bastion-z`, `tekton-ci` and `tekton-nightly` namespaces will fix this problem.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._