### PR TITLE
Stop using $(uid) for resource names in templates

### DIFF
--- a/tekton/ci-workspace/community/template.yaml
+++ b/tekton/ci-workspace/community/template.yaml
@@ -34,7 +34,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: pull-community-teps-lint-$(uid)
+      generateName: pull-community-teps-lint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/kind: ci

--- a/tekton/mario-bot/mario-github-comment.yaml
+++ b/tekton/mario-bot/mario-github-comment.yaml
@@ -52,7 +52,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      generateName: mario-comment-github-$(uid)-
+      generateName: mario-comment-github-
     spec:
       serviceAccountName: mario-listener
       taskSpec:

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -155,7 +155,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      generateName: build-and-push-$(uid)-
+      generateName: build-and-push-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         mario.bot/pull-request-id: $(tt.params.pullRequestID)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Triggers v0.12.0 changed the event UID form a short string to
a UUID. Do not use $(uid) anymore in resource names as it creates
invalid names.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc