### PR TITLE
Fix the branch selection in cronjobs

### DIFF
--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -33,10 +33,10 @@ spec:
               - -ce
               - |
                 GIT_SHA=$(git ls-remote --heads https://${GIT_REPO} | \
-                  awk '/refs\/heads\/master/{ print $1 }')
+                  awk '/refs\/heads\/main$/{ print $1 }')
                 if [ "${GIT_SHA}" == "" ]; then
                   GIT_SHA=$(git ls-remote --heads https://${GIT_REPO} | \
-                  awk '/refs\/heads\/main/{ print $1 }')
+                  awk '/refs\/heads\/master$/{ print $1 }')
                 fi
                 VERSION_TAG="v$(date +"%Y%m%d")-$(echo $GIT_SHA | cut -c 1-10)"
                 cat <<EOF > /shared/git


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix the branch selection in cronjobs by:
- checking for main before master
- make the regex more robust by adding a $ to avoid partial matches

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc