### PR TITLE
Fix Catlin to skip deleted tasks

### DIFF
--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -29,7 +29,13 @@ spec:
           git --no-pager diff --name-only HEAD~$(( $(params.gitCloneDepth) - 1 ))|grep 'task/[^\/]*/[^\/]*/*[^/]*.yaml'|xargs -I {} dirname {}
         }
         all_tests=$(detect_new_changed_tasks |sort -u || true)
-        echo -n $all_tests > $(workspaces.store-changed-files.path)/changed-files.txt
+        final_tests=""
+        # check for the tasks which are removed completely and skip them
+        for task in $all_tests; do
+          [[ ! -d $task ]] && continue
+          final_tests="$final_tests $task"
+        done
+        echo -n $final_tests > $(workspaces.store-changed-files.path)/changed-files.txt
     - name: lint-catalog
       image: gcr.io/tekton-releases/dogfooding/catlin:latest
       workingDir: $(resources.inputs.source.path)


### PR DESCRIPTION
# Changes

git diff step in Catlin Task was detecting the changed files which
catlin was unable to find.

modified the script which will check for the deleted tasks and if any is task
being removed from the catalog then it will not be tested by catlin.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._