### PR TITLE
Fix namespace specification with kustomize for cleanup RoleBindings

### DIFF
--- a/tekton/resources/cd/kustomization.yaml
+++ b/tekton/resources/cd/kustomization.yaml
@@ -1,6 +1,19 @@
-namespace: default
 commonAnnotations:
   managed-by: Tekton
+
+patches:
+- target:
+    kind: ServiceAccount|Deployment|PipelineResource|EventListener|TriggerBinding|TriggerTemplate
+  patch: |-
+    - op: replace
+      path: /metadata/namespace
+      value: default
+- target:
+    kind: RoleBinding|ClusterRoleBinding
+  patch: |-
+    - op: replace
+      path: /subjects/0/namespace
+      value: default
 
 resources:
 - bindings.yaml


### PR DESCRIPTION
# Changes

Currently the "cleanup old prs/trs" pipeline fails when target namespace is not default one, because there are no permissions to do actions with prs/trs in non-default namespace. The reason is that kustomize applies default namespace value to all resources in the tekton/resources/cd folder and overwrites desired(non-default) namespaces for corresponding RoleBindings which grant the permissions.
Suggested fix is
- set default namespace value to all resources except RoleBindings and ClusterRoleBindings.
- set default namespace only for subject of RoleBindings and ClusterRoleBindings.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._