### PR TITLE
Add a pipeline to request doc reviewers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,5 +46,6 @@ The script [adjustpermissions.py](../adjustpermissions.py) gives users access to
 
 ## DNS
 
-DNS Names are managed via [Netlify](https://www.netlify.com/). The setup of DNS
-record, for now, is manual only.
+DNS Names are managed via [Netlify](https://www.netlify.com/).
+Gardener External DNS Manager is deployed on the dogfooding and robocat clusters, and manages names
+via annotations on ingresses and services. Some of the names are defined manually in Netlify.

--- a/tekton/ci-workspace/jobs/kustomization.yaml
+++ b/tekton/ci-workspace/jobs/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - tekton-teps-validation.yaml
 - tekton-golang-tests.yaml
 - tekton-image-build.yaml
+- tekton-docs-reviews.yaml

--- a/tekton/ci-workspace/jobs/tekton-docs-reviews.yaml
+++ b/tekton/ci-workspace/jobs/tekton-docs-reviews.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: request-pr-docs-reviewer
+  annotations:
+    description: |
+      Run unit tests against a list of root folders.
+      Requires the task-loops controller.
+spec:
+  params:
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+    - name: pullRequestBaseRef
+      description: The pull request base branch
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: fileFilterRegex
+      description: Names regex to be matched in the list of modified files
+    - name: package
+      description: package (and its children) under test
+  workspaces:
+    - name: sources
+      description: Workspace where the git repo is prepared for testing
+    - name: github
+      description: A secret with the github token
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-batch-merge # from the catalog
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: mode
+          value: "merge"
+        - name: revision
+          value: $(params.pullRequestBaseRef)
+        - name: refspec
+          value: refs/heads/$(params.pullRequestBaseRef):refs/heads/$(params.pullRequestBaseRef)
+        - name: batchedRefs
+          value: "refs/pull/$(params.pullRequestNumber)/head"
+      workspaces:
+        - name: output
+          workspace: sources
+    - name: check-git-files-changed
+      runAfter: ['clone-repo']
+      taskRef:
+        name: check-git-files-changed
+      params:
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+        - name: regex
+          value: $(params.fileFilterRegex)
+      workspaces:
+        - name: input
+          workspace: sources
+    - name: request-pr-reviewer
+      when: # implicit dependency on the check tasks
+      - input: $(tasks.check-git-files-changed.results.check)
+        operator: in
+        values: ["passed"]
+      taskRef:
+        name: github-request-reviewers
+      params:
+      - name: PACKAGE
+        value: "$(params.package)"
+      - name: PULL_REQUEST_NUMBER
+        value: "$(params.pullRequestNumber)"
+      - name: "GITHUB_TOKEN_FILE"
+        value: bot-token
+      - name: TEAM_REVIEWERS
+        value: "docs.reviewers"
+      workspaces:
+        - name: github
+          workspace: github

--- a/tekton/ci-workspace/shared/template.yaml
+++ b/tekton/ci-workspace/shared/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-all-ci-pipeline
+  name: tekton-doc-reviews
 spec:
   params:
   - name: buildUUID
@@ -32,12 +32,43 @@ spec:
     description: List of labels currently on the Pull Request
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
-      generateName: noop-
+      generateName: request-pr-docs-reviewer-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+        tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
-      steps:
-        - name: nop
-          image: busybox
-          script: |
-            echo "no-op"
+      serviceAccountName: tekton-ci-jobs
+      timeout: 10m
+      workspaces:
+        - name: sources
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+        - name: github
+          secret:
+            secretName: "bot-token-github"
+      pipelineRef:
+        name: request-pr-docs-reviewer
+      params:
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: pullRequestBaseRef
+          value: $(tt.params.pullRequestBaseRef)
+        - name: gitRepository
+          value: "$(tt.params.gitRepository)"
+        - name: gitCloneDepth
+          value: $(tt.params.gitCloneDepth)
+        - name: fileFilterRegex
+          # Start with docs, ends with .md or *.rst, but not in vendor/ or thirdparty/
+          value: "(^docs\\/.*|^(?!vendor\\/)(?!thirdparty\\/).*\\.(md|rst)$)"
+        - name: package
+          value: $(tt.params.package)

--- a/tekton/ci-workspace/shared/trigger.yaml
+++ b/tekton/ci-workspace/shared/trigger.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
-  name: all-repos
+  name: doc-reviewers
 spec:
   interceptors:
     - github:
@@ -13,7 +12,7 @@ spec:
           - pull_request
     - cel:
         filter: >-
-          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
+          body.action in ['opened', 'synchronize', 'reopened']
         overlays:
           - key: git_clone_depth
             expression: "string(body.pull_request.commits + 1.0)"
@@ -23,4 +22,4 @@ spec:
     - ref: tekton-ci-webhook-pr-labels
     - ref: tekton-ci-clone-depth
   template:
-    ref: tekton-all-ci-pipeline
+    ref: tekton-doc-reviews


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a pipeline that runs on all repos with the webhook installed.
This pipeline requests the @tektoncd/docs.reviewers team as reviewer
if files changed in the PR match "(^docs\/.*|^(?!vendor\/)(?!thirdparty\/).*\.(md|rst)$)"

Note that even if the team is only added to the list of reviewers if
it is a collaborator of the repo, a notification email is sent to
the team regardless.

Update the DNS docs in the main README

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature