### PR TITLE
Switch Event Listener sinks to ClusterIP

### DIFF
--- a/bots/mariobot/README.md
+++ b/bots/mariobot/README.md
@@ -67,7 +67,6 @@ metadata:
   name: mario-image-builder
 spec:
   serviceAccountName: mario-listener
-  serviceType: LoadBalancer
   triggers:
     - name: trigger
       interceptors:

--- a/tekton/ci-workspace/shared/eventlistener.yaml
+++ b/tekton/ci-workspace/shared/eventlistener.yaml
@@ -5,6 +5,5 @@ metadata:
   name: tekton-ci
 spec:
   serviceAccountName: tekton-ci-workspace-listener
-  serviceType: NodePort
   namespaceSelector:
     matchNames: ['tekton-ci']

--- a/tekton/ci/eventlistener.yaml
+++ b/tekton/ci/eventlistener.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: tektonci
 spec:
   serviceAccountName: tekton-ci-listener
-  serviceType: NodePort
   triggers:
     - name: plumbing-pull-request-ci
       interceptors:

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -102,7 +102,6 @@ metadata:
   name: mario-image-builder
 spec:
   serviceAccountName: mario-listener
-  serviceType: NodePort
   triggers:
     - name: trigger
       interceptors:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The legacy (?) load balancing infrastructure in Google cloud required
services to be use NodePort for the healthcheck to be able to work.
With NEGs and cloud-native load balancing cluster IP services are
required instead:
- https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing
- https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#health_checks

Removing the service type from the event listener, so that the default
ClusterIP is used.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc
/cc @dibyom @vdemeester 