### PR TITLE
Add nightly tests for cli, triggers & operator on ppc64le architecture

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly cli e2e tests on ppc64le hardware.

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "cli"
+            - name: NAMESPACE
+              value: "bastion-p"
+            - name: REGISTRY
+              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+            - name: TARGET_ARCH
+              value: "ppc64le"
+            - name: REMOTE_SECRET_NAME
+              value: "ppc64le-kubeconfig"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-cli-ppc64le"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
@@ -1,3 +1,6 @@
 namespace: default
 resources:
 - pipeline-nightly-test
+- triggers-nightly-test
+- cli-nightly-test
+- operator-nightly-test

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly operator e2e tests on ppc64le hardware.

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "operator"
+            - name: NAMESPACE
+              value: "bastion-p"
+            - name: REGISTRY
+              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+            - name: TARGET_ARCH
+              value: "ppc64le"
+            - name: REMOTE_SECRET_NAME
+              value: "ppc64le-kubeconfig"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-operator-ppc64le"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly triggers e2e tests on ppc64le hardware.

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 21 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "triggers"
+            - name: NAMESPACE
+              value: "bastion-p"
+            - name: REGISTRY
+              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+            - name: TARGET_ARCH
+              value: "ppc64le"
+            - name: REMOTE_SECRET_NAME
+              value: "ppc64le-kubeconfig"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-triggers-ppc64le"

--- a/tekton/resources/nightly-tests/bastion-p/cleanup_tekton.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/cleanup_tekton.yaml
@@ -12,12 +12,18 @@ spec:
     mountPath: /workspace
   params:
   - name: package
+  - name: triggers
+    description: clean triggers component
+    default: "No"
   - name: resources
     description: space separated list of resources to be deleted
     default: "conditions pipelineresources tasks pipelines taskruns pipelineruns"
   - name: plumbing-path
     description: path in the workspace for plumbing source code
     default: src/github.com/tektoncd/plumbing
+  - name: triggers-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/triggers
   steps:
   - name: cleanup-resources
     image: gcr.io/tekton-releases/dogfooding/kubectl:latest
@@ -31,7 +37,7 @@ spec:
     - |
       kubectl delete ns -l tekton.dev/test-e2e=true
       for res in $(params.resources); do
-        kubectl delete --ignore-not-found=true ${res}.tekton.dev --all || return true
+        kubectl delete --ignore-not-found=true ${res}.tekton.dev --all
       done
   - name: uninstall-tekton-project
     image: gcr.io/tekton-releases/dogfooding/test-runner:latest
@@ -45,5 +51,9 @@ spec:
     - -ce
     - |
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
+      if [ "$(params.triggers)" = "Yes" ]; then
+        ko delete --ignore-not-found=true -f $(workspaces.source-code.path)/$(params.triggers-path)/config/interceptors/
+        ko delete --ignore-not-found=true -f $(workspaces.source-code.path)/$(params.triggers-path)/config/
+      fi
       ko delete --ignore-not-found=true -f config/
       wait_until_object_does_not_exist namespace tekton-pipelines

--- a/tekton/resources/nightly-tests/bastion-p/deploy_tekton_pipeline.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/deploy_tekton_pipeline.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: deploy-tekton-project-nightly
+  name: deploy-tekton-pipeline-nightly
 spec:
   workspaces:
   - name: k8s-config

--- a/tekton/resources/nightly-tests/bastion-p/deploy_tekton_triggers.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/deploy_tekton_triggers.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-tekton-triggers-nightly
+spec:
+  workspaces:
+  - name: k8s-config
+    description: workspace to get k8s config file
+    mountPath: /root/.kube
+  - name: registry-credentials
+    description: workspace to get registry credentials
+    mountPath: /tekton/home/.docker
+  - name: registry-certificate
+    description: workspace to get registry self-signed certificate
+    mountPath: /opt/ssl/certs
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
+  params:
+  - name: package
+    description: package to install
+  - name: container-registry
+    description: container registry used to publish build images
+  - name: target-arch
+    description: target architecture for tests (s390x, ppc64le, arm64)
+  steps:
+  - name: deploy
+    workingdir: /workspace/src/$(params.package)
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: KO_DOCKER_REPO
+      value: $(params.container-registry)
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    - name: SSL_CERT_FILE
+      value: /opt/ssl/certs/registry.crt
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      ko apply --platform=linux/$(params.target-arch) -f config/
+      ko apply --platform=linux/$(params.target-arch) -f config/interceptors/
+      kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s

--- a/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
@@ -3,6 +3,8 @@ commonAnnotations:
   managed-by: Tekton
 
 resources:
-- deploy_tekton_component.yaml
+- deploy_tekton_pipeline.yaml
+- deploy_tekton_triggers.yaml
 - test_tekton_component.yaml
 - cleanup_tekton.yaml
+- test_tekton_cli.yaml

--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test-e2e-tekton-cli
+spec:
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: tests-path
+    description: path to the tests within "tests" git resource
+    default: ./test/e2e
+  - name: plumbing-path
+    description: path in the workspace for plumbing source code
+    default: src/github.com/tektoncd/plumbing
+  - name: timeout
+    description: timeout for the go test runner
+    default: 20m
+  - name: tags
+    default: e2e
+  workspaces:
+  - name: k8s-config
+    description: workspace to get k8s config file
+    mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+  steps:
+  - name: run-e2e-tests
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    workingdir: $(workspaces.source-code.path)/src/$(params.package)
+    env:
+    - name: REPO_ROOT_DIR
+      value: $(workspaces.source-code.path)/src/$(params.package)
+    - name: GOPATH
+      value: /workspace
+    - name: KUBECONFIG
+      value: /root/.kube/config
+    - name: TEST_CLIENT_BINARY
+      value: $(workspaces.source-code.path)/src/$(params.package)/tkn
+    - name: TEST_CLUSTERTASK_LIST_EMPTY
+      value: "yes"
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
+      go build -o tkn $(params.package)/cmd/tkn
+      for testsuite in clustertask eventListener pipeline pipelinerun resource task; do
+        header "Running Go $(params.tags) ${testsuite} tests"
+        report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite}
+      done

--- a/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
@@ -14,7 +14,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-pipeline-nightly-test-ppc64le
+  name: tekton-cli-nightly-test-ppc64le
 spec:
   params:
   - name: containerRegistry
@@ -25,7 +25,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
+      generateName: tekton-cli-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
       timeout: 2h
@@ -91,8 +91,38 @@ spec:
           - name: output
             workspace: shared-workspace
             subPath: source-code
-        - name: deploy-pipeline
+        - name: git-clone-triggers
           runAfter: [git-clone-pipeline]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/triggers
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/triggers
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: git-clone-cli
+          runAfter: [git-clone-triggers]
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/cli
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/cli
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: deploy-pipeline
+          runAfter: [git-clone-triggers]
           taskRef:
             name: deploy-tekton-pipeline-nightly
           workspaces:
@@ -108,15 +138,37 @@ spec:
           retries: 2
           params:
           - name: package
-            value: $(params.package)
+            value: github.com/tektoncd/pipeline
           - name: container-registry
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-        - name: e2e-test-pipeline
+        - name: deploy-triggers
           runAfter: [deploy-pipeline]
           taskRef:
-            name: test-e2e-tekton-component
+            name: deploy-tekton-triggers-nightly
+          workspaces:
+          - name: k8s-config
+            workspace: k8s-config
+          - name: registry-credentials
+            workspace: registry-credentials
+          - name: registry-certificate
+            workspace: registry-certificate
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: github.com/tektoncd/triggers
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+        - name: e2e-test-cli
+          runAfter: [deploy-triggers]
+          taskRef:
+            name: test-e2e-tekton-cli
           workspaces:
           - name: k8s-config
             workspace: k8s-config
@@ -127,10 +179,6 @@ spec:
           params:
           - name: package
             value: $(params.package)
-          - name: container-registry
-            value: $(params.container-registry)
-          - name: target-arch
-            value: $(params.target-arch)
         finally:
         - name: cleanup
           taskRef:
@@ -144,10 +192,12 @@ spec:
           retries: 2
           params:
           - name: package
-            value: $(params.package)
+            value: github.com/tektoncd/pipeline
+          - name: triggers
+            value: "Yes"
       params:
       - name: package
-        value: github.com/tektoncd/pipeline
+        value: github.com/tektoncd/cli
       - name: container-registry
         value: $(tt.params.containerRegistry)
       - name: target-arch

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -65,6 +65,42 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-pipeline-nightly-test-ppc64le
+  - name: triggers-nightly-test-trigger-ppc64le
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'triggers' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 'ppc64le'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-triggers-nightly-test-ppc64le
+  - name: cli-nightly-test-trigger-ppc64le
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'cli' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 'ppc64le'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-cli-nightly-test-ppc64le
+  - name: operator-nightly-test-trigger-ppc64le
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'operator' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 'ppc64le'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-operator-nightly-test-ppc64le
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -11,3 +11,6 @@ resources:
 - operator-deploy-test-s390x-template.yaml
 - pipeline-deploy-test-ppc64le-template.yaml
 - serviceaccount.yaml
+- triggers-deploy-test-ppc64le-template.yaml
+- cli-deploy-test-ppc64le-template.yaml
+- operator-deploy-test-ppc64le-template.yaml

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -14,7 +14,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-pipeline-nightly-test-ppc64le
+  name: tekton-operator-nightly-test-ppc64le
 spec:
   params:
   - name: containerRegistry
@@ -25,7 +25,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
+      generateName: tekton-operator-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
       timeout: 2h
@@ -38,7 +38,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 2Gi
+                storage: 1Gi
       # this workspace will be used to store k8s config
       - name: k8s-config
         secret:
@@ -58,43 +58,69 @@ spec:
         - name: registry-credentials
         - name: registry-certificate
         params:
-        - name: package
         - name: container-registry
         - name: target-arch
         tasks:
-        - name: git-clone-plumbing
+        - name: git-clone-operator
           taskRef:
             name: git-clone
           params:
           - name: url
-            value: https://github.com/tektoncd/plumbing
+            value: https://github.com/tektoncd/operator
           - name: revision
             value: main
           - name: subdirectory
-            value: src/github.com/tektoncd/plumbing
+            value: src/github.com/tektoncd/operator
           workspaces:
           - name: output
             workspace: shared-workspace
             subPath: source-code
-        - name: git-clone-pipeline
-          runAfter: [git-clone-plumbing]
-          taskRef:
-            name: git-clone
+        - name: e2e-test-operator
+          runAfter: [git-clone-operator]
+          taskSpec:
+            params:
+            - name: container-registry
+            - name: target-arch
+            workspaces:
+            - name: k8s-config
+              description: workspace to get k8s config file
+              mountPath: /root/.kube
+            - name: registry-credentials
+              description: workspace to get registry credentials
+              mountPath: /tekton/home/.docker
+            - name: registry-certificate
+              description: workspace to get registry self-signed certificate
+              mountPath: /opt/ssl/certs
+            - name: source-code
+              description: workspace with source code for tekton component
+            steps:
+            - name: run-e2e-tests
+              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              workingdir: $(workspaces.source-code.path)/src/github.com/tektoncd/operator
+              env:
+              - name: GOPATH
+                value: /workspace
+              - name: KUBECONFIG
+                value: /root/.kube/config
+              - name: SSL_CERT_FILE
+                value: /opt/ssl/certs/registry.crt
+              - name: PLATFORM
+                value: linux/$(params.target-arch)
+              - name: KO_DOCKER_REPO
+                value: $(params.container-registry)
+              - name: E2E_DEBUG
+                value: "true"
+              command:
+              - /bin/bash
+              args:
+              - -ce
+              - |
+                test/e2e-tests.sh
           params:
-          - name: url
-            value: https://github.com/tektoncd/pipeline
-          - name: revision
-            value: main
-          - name: subdirectory
-            value: src/github.com/tektoncd/pipeline
-          workspaces:
-          - name: output
-            workspace: shared-workspace
-            subPath: source-code
-        - name: deploy-pipeline
-          runAfter: [git-clone-pipeline]
-          taskRef:
-            name: deploy-tekton-pipeline-nightly
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
           workspaces:
           - name: k8s-config
             workspace: k8s-config
@@ -106,35 +132,30 @@ spec:
             workspace: shared-workspace
             subPath: source-code
           retries: 2
-          params:
-          - name: package
-            value: $(params.package)
-          - name: container-registry
-            value: $(params.container-registry)
-          - name: target-arch
-            value: $(params.target-arch)
-        - name: e2e-test-pipeline
-          runAfter: [deploy-pipeline]
-          taskRef:
-            name: test-e2e-tekton-component
-          workspaces:
-          - name: k8s-config
-            workspace: k8s-config
-          - name: source-code
-            workspace: shared-workspace
-            subPath: source-code
-          retries: 2
-          params:
-          - name: package
-            value: $(params.package)
-          - name: container-registry
-            value: $(params.container-registry)
-          - name: target-arch
-            value: $(params.target-arch)
         finally:
         - name: cleanup
-          taskRef:
-            name: cleanup-tekton-nightly
+          taskSpec:
+            workspaces:
+            - name: k8s-config
+              description: workspace to get k8s config file
+              mountPath: /root/.kube
+            - name: source-code
+              description: workspace with source code for tekton component
+            steps:
+            - name: cleanup-operator
+              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              workingdir: $(workspaces.source-code.path)/src/github.com/tektoncd/operator
+              env:
+              - name: GOPATH
+                value: /workspace
+              - name: KUBECONFIG
+                value: /root/.kube/config
+              command:
+              - /bin/bash
+              args:
+              - -ce
+              - |
+                make clean
           workspaces:
           - name: k8s-config
             workspace: k8s-config
@@ -142,12 +163,7 @@ spec:
             workspace: shared-workspace
             subPath: source-code
           retries: 2
-          params:
-          - name: package
-            value: $(params.package)
       params:
-      - name: package
-        value: github.com/tektoncd/pipeline
       - name: container-registry
         value: $(tt.params.containerRegistry)
       - name: target-arch

--- a/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
@@ -14,7 +14,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-pipeline-nightly-test-ppc64le
+  name: tekton-triggers-nightly-test-ppc64le
 spec:
   params:
   - name: containerRegistry
@@ -25,7 +25,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
+      generateName: tekton-triggers-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
       timeout: 2h
@@ -91,10 +91,47 @@ spec:
           - name: output
             workspace: shared-workspace
             subPath: source-code
-        - name: deploy-pipeline
+        - name: git-clone-triggers
           runAfter: [git-clone-pipeline]
           taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/triggers
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/triggers
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: deploy-pipeline
+          runAfter: [git-clone-triggers]
+          taskRef:
             name: deploy-tekton-pipeline-nightly
+          workspaces:
+          - name: k8s-config
+            workspace: k8s-config
+          - name: registry-credentials
+            workspace: registry-credentials
+          - name: registry-certificate
+            workspace: registry-certificate
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: github.com/tektoncd/pipeline
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+        - name: deploy-triggers
+          runAfter: [deploy-pipeline]
+          taskRef:
+            name: deploy-tekton-triggers-nightly
           workspaces:
           - name: k8s-config
             workspace: k8s-config
@@ -113,8 +150,8 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
-        - name: e2e-test-pipeline
-          runAfter: [deploy-pipeline]
+        - name: e2e-test-triggers
+          runAfter: [deploy-triggers]
           taskRef:
             name: test-e2e-tekton-component
           workspaces:
@@ -144,10 +181,12 @@ spec:
           retries: 2
           params:
           - name: package
-            value: $(params.package)
+            value: github.com/tektoncd/pipeline
+          - name: triggers
+            value: "Yes"
       params:
       - name: package
-        value: github.com/tektoncd/pipeline
+        value: github.com/tektoncd/triggers
       - name: container-registry
         value: $(tt.params.containerRegistry)
       - name: target-arch


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds nightly e2e tests on `ppc64le` architecture for `cli`, `triggers` & `operator`. Nightly `pipeline` tests on ppc64le hardware is already enabled via #762.

/kind feature
/cc @afrittoli

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._