### PR TITLE
Have separate installation task for triggers for s390x tests

### DIFF
--- a/tekton/resources/nightly-tests/bastion-z/deploy_tekton_pipeline.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/deploy_tekton_pipeline.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-tekton-pipeline-nightly
+spec:
+  params:
+  - name: package
+    description: package to install
+  - name: container-registry
+    description: container registry used to publish build images
+  - name: target-arch
+    description: target architecture for tests (s390x, ppc64le, arm64)
+  workspaces:
+  - name: k8s-shared
+    description: workspace for k8s config, configuration file is expected to have `config` name
+    mountPath: /root/.kube
+  - name: source-code
+    description: workspace with source code for tekton component
+    mountPath: /workspace
+  steps:
+  - name: deploy
+    workingdir: $(workspaces.source-code.path)/src/$(params.package)
+    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: KO_DOCKER_REPO
+      value: $(params.container-registry)
+    - name: KUBECONFIG
+      value: $(workspaces.k8s-shared.path)/config
+    command:
+    - /bin/bash
+    args:
+    - -ce
+    - |
+      ko apply --platform=linux/$(params.target-arch) -f config/
+      kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s

--- a/tekton/resources/nightly-tests/bastion-z/deploy_tekton_triggers.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/deploy_tekton_triggers.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: deploy-tekton-project-nightly
+  name: deploy-tekton-triggers-nightly
 spec:
   params:
   - name: package
@@ -34,4 +34,5 @@ spec:
     - -ce
     - |
       ko apply --platform=linux/$(params.target-arch) -f config/
+      ko apply --platform=linux/$(params.target-arch) -f config/interceptors/
       kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s

--- a/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
@@ -5,5 +5,6 @@ commonAnnotations:
 resources:
 - k8s_cluster_setup.yaml
 - test_tekton_component.yaml
-- deploy_tekton_component.yaml
+- deploy_tekton_pipeline.yaml
+- deploy_tekton_triggers.yaml
 - test_tekton_cli.yaml

--- a/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
@@ -143,7 +143,7 @@ spec:
         - name: deploy-pipeline
           runAfter: [create-k8s-cluster]
           taskRef:
-            name: deploy-tekton-project-nightly
+            name: deploy-tekton-pipeline-nightly
           workspaces:
           - name: k8s-shared
             workspace: shared-workspace
@@ -161,7 +161,7 @@ spec:
         - name: deploy-triggers
           runAfter: [deploy-pipeline]
           taskRef:
-            name: deploy-tekton-project-nightly
+            name: deploy-tekton-triggers-nightly
           workspaces:
           - name: k8s-shared
             workspace: shared-workspace

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
@@ -113,7 +113,7 @@ spec:
         - name: deploy-pipeline
           runAfter: [create-k8s-cluster]
           taskRef:
-            name: deploy-tekton-project-nightly
+            name: deploy-tekton-pipeline-nightly
           workspaces:
           - name: k8s-shared
             workspace: shared-workspace

--- a/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
@@ -128,7 +128,7 @@ spec:
         - name: deploy-pipeline
           runAfter: [create-k8s-cluster]
           taskRef:
-            name: deploy-tekton-project-nightly
+            name: deploy-tekton-pipeline-nightly
           workspaces:
           - name: k8s-shared
             workspace: shared-workspace
@@ -146,7 +146,7 @@ spec:
         - name: deploy-triggers
           runAfter: [deploy-pipeline]
           taskRef:
-            name: deploy-tekton-project-nightly
+            name: deploy-tekton-triggers-nightly
           workspaces:
           - name: k8s-shared
             workspace: shared-workspace


### PR DESCRIPTION
# Changes
Now triggers installation from source code cannot be unified with pipeline installation. 
Instead 2 separate tasks for s390x test pipelines are created.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._