### PR TITLE
Fix duplicate DIND env var due to preset 🧙

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1057,9 +1057,6 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
         securityContext:
           privileged: true
   tektoncd/triggers:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

DOCKER_IN_DOCKER_ENABLED is duplicated due to the dind preset applied
to the job. Remove the env variable as it is inherited by the preset,
otherwise it is duplicated and it seems prow fails…

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @wlynch @ImJasonH 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._