### PR TITLE
Add pipeline to run s390x dashboard tests

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly dashboard e2e tests on s390x hardware.

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "dashboard"
+            - name: NAMESPACE
+              value: "bastion-z"
+            - name: REGISTRY
+              value: "sshd.bastion-z.svc.cluster.local:4000"
+            - name: TARGET_ARCH
+              value: "s390x"
+            - name: REMOTE_SECRET_NAME
+              value: "s390x-k8s-ssh"
+            - name: REMOTE_HOST
+              value: "sshd.bastion-z.svc.cluster.local"
+            - name: REMOTE_PORT
+              value: "1122"
+            - name: REMOTE_USER
+              value: "k8smanager"

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dashboard-s390x"

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - triggers-nightly-test
 - cli-nightly-test
 - operator-nightly-test
+- dashboard-nightly-test

--- a/tekton/resources/nightly-tests/README.md
+++ b/tekton/resources/nightly-tests/README.md
@@ -60,6 +60,7 @@ The following pipelines are available:
 - triggers `e2e` tests
 - cli `e2e` tests
 - operator `e2e` tests
+- dashboard `e2e` tests
 
 They are running once a day automatically. The results can be seen
 at the [dogfooding dashboard](https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns).

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -1,0 +1,179 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-dashboard-nightly-test-s390x
+spec:
+  params:
+  - name: containerRegistry
+  - name: targetArch
+  - name: namespace
+  - name: remoteHost
+  - name: remotePort
+  - name: remoteUser
+  - name: remoteSecret
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-dashboard-$(tt.params.targetArch)-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      timeout: 2h
+      workspaces:
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+      # this workspace will be used to store ssh key
+      - name: ssh-secret
+        secret:
+          secretName: $(tt.params.remoteSecret)
+          items:
+          - key: privatekey
+            path: id_rsa
+            # yamllint disable rule:octal-values
+            mode: 0600
+            # yamllint enable
+      pipelineSpec:
+        workspaces:
+        - name: shared-workspace
+        - name: ssh-secret
+        params:
+        - name: container-registry
+        - name: target-arch
+        - name: remote-host
+        - name: remote-port
+        - name: remote-user
+        tasks:
+        - name: git-clone-dashboard
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/dashboard
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/dashboard
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: create-k8s-cluster
+          runAfter: [git-clone-dashboard]
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+        - name: e2e-test-dashboard
+          runAfter: [create-k8s-cluster]
+          taskSpec:
+            params:
+            - name: container-registry
+            - name: target-arch
+            - name: remote-host
+            workspaces:
+            - name: k8s-shared
+              description: workspace for k8s config, configuration file is expected to have `config` name
+              mountPath: /root/.kube
+            - name: source-code
+              description: workspace with source code for tekton component
+            steps:
+            - name: run-e2e-tests
+              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              workingdir: $(workspaces.source-code.path)/src/github.com/tektoncd/dashboard
+              env:
+              - name: GOPATH
+                value: /workspace
+              - name: KUBECONFIG
+                value: $(workspaces.k8s-shared.path)/config
+              - name: PLATFORM
+                value: linux/$(params.target-arch)
+              - name: KO_DOCKER_REPO
+                value: $(params.container-registry)
+              - name: REPO_ROOT_DIR
+                value: $(workspaces.source-code.path)/src/github.com/tektoncd/dashboard
+              - name: LOCAL_RUN
+                value: "0"
+              - name: SKIP_BUILD_TEST
+                value: "true"
+              command:
+              - /bin/bash
+              args:
+              - -ce
+              - |
+                ./test/presubmit-tests.sh --integration-tests
+          params:
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+          - name: remote-host
+            value: $(params.remote-host)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+        finally:
+        - name: delete-k8s-cluster
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+          - name: action
+            value: delete
+      params:
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: target-arch
+        value: $(tt.params.targetArch)
+      - name: remote-host
+        value: $(tt.params.remoteHost)
+      - name: remote-port
+        value: $(tt.params.remotePort)
+      - name: remote-user
+        value: $(tt.params.remoteUser)

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -53,6 +53,18 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-operator-nightly-test-s390x
+  - name: dashboard-nightly-test-trigger-s390x
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'dashboard' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 's390x'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-dashboard-nightly-test-s390x
   - name: pipeline-nightly-test-trigger-ppc64le
     interceptors:
     - cel:

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
 - triggers-deploy-test-s390x-template.yaml
 - cli-deploy-test-s390x-template.yaml
 - operator-deploy-test-s390x-template.yaml
+- dashboard-deploy-test-s390x-template.yaml
 - pipeline-deploy-test-ppc64le-template.yaml
 - serviceaccount.yaml


### PR DESCRIPTION
# Changes

- add corresponding cronjob to trigger s390x tekton dashboard test
- add template to run s390x operator test pipeline
  - git clone dashbooard repo
  - k8s cluster installation
  - e2e dashboard test(backend and frontend)
  - k8s cluster removal

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._