### PR TITLE
Add RoleBinding to cleanup pr/tr from bastion-p namespace

### DIFF
--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -147,6 +147,20 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: tektoncd-cleaner-delete-pr-tr-bastion-p
+  namespace: bastion-p
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-pr-tr
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: tektoncd-cleaner-delete-pr-tr-tekton-ci
   namespace: tekton-ci
 subjects:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`cleanup-pr-tr` task is currently failing to remove pr/tr from bastion-p namespace due to missing permissions. The solution for this is similar to one described in #767

/kind bug
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._