### PR TITLE
Fix handling of condition tasks in CI

### DIFF
--- a/tekton/ci-workspace/README.md
+++ b/tekton/ci-workspace/README.md
@@ -81,6 +81,10 @@ When a start, failed or succeeded event is received for a CI job, the
 [`github-template.yaml`](../resources/ci/github-template.yaml) is triggered,
 which takes care of updating the check status on GitHub side accordingly.
 
+Conditions must trigger github updates - because of have tasks that implement
+conditions must be named `check-*`, which is used in the trigger CEL filter
+to skip the associated events.
+
 The `github-template` adds labels to the task runs it triggers to make it
 easier to associate them back with the source task run:
 
@@ -245,7 +249,7 @@ spec:
 ```
 
 In case the CI Job is made of multiple tasks, all should run after the task
-that evealuate the conditions are executed.
+that evaluate the conditions are executed.
 
 The `check-name-matches` task is required for the CI job to
 executed on demand via the `/test [regex]` command.

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -120,6 +120,7 @@ spec:
               body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] in ['tekton-ci-webhook', 'tekton-ci'] &&
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
+              !(body.taskRun.metadata.name.indexOf('check-') == 0) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
@@ -140,6 +141,7 @@ spec:
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
+              !(body.taskRun.metadata.name.indexOf('check-') == 0) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
@@ -160,6 +162,7 @@ spec:
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
+              !(body.taskRun.metadata.name.indexOf('check-') == 0) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Condition tasks are used to evaluate whether a CI job should be
executed or not. Cloud events generated before a CI task is
executed should be ignored, which is achieved today by using
a specific annotation on the Task "ci.tekton.dev/condition" and
filtering out matching events in the trigger using a CEL filter.

However, because of https://github.com/tektoncd/pipeline/issues/3864,
the annotations are not immediately available in the TaskRun,
which causes the filtering to fail, CI jobs to be marked as started
in GitHub but never completed if the condition was false and thus
no CI job is executed.

Add an extra check based on the name. If the task name starts with
"check-", the event is ignored and no github update is sent.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug