### PR TITLE
Add script linting to catlin catalog check job

### DIFF
--- a/catlin/Dockerfile
+++ b/catlin/Dockerfile
@@ -7,7 +7,9 @@ RUN GOOS=linux GARCH=amd64 CGO_ENABLED=0 \
 
 FROM docker.io/library/alpine:3.12
 
-RUN apk --no-cache add bash
+RUN apk --no-cache add bash shellcheck py3-pip
+
+RUN pip3 install pylint
 
 WORKDIR /data
 

--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -56,6 +56,14 @@ spec:
         catlin validate $(cat $(workspaces.store-changed-files.path)/changed-files.txt) | tee -a $(workspaces.store-changed-files.path)/catlin.txt
         echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
 
+        echo '**Catlin script lint Output**' >> $(workspaces.store-changed-files.path)/catlin.txt
+        echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+
+        # performing catlin validate
+        catlin lint script $(cat $(workspaces.store-changed-files.path)/changed-files.txt) | tee -a $(workspaces.store-changed-files.path)/catlin.txt
+        echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+
+
         # checking if there are any ERROR or WARN messages produced by catlin
         isWarning=$(cat  $(workspaces.store-changed-files.path)/catlin.txt | grep -c "WARN")
         isError=$(cat  $(workspaces.store-changed-files.path)/catlin.txt | grep -c "ERROR")


### PR DESCRIPTION
# Changes

We are adding the output of the command :

```
catlint lint script
```

to the existing job that would do `catlin validate` on catalog tasks.

We add linters for shells and python.

The output for example when you have your task with a python script
would be something like this :

```
************* Module catlin-script-linter178031378
github-create-deployment-create-deployment:17:0: W0125: Using a conditional statement with a constant value (using-constant-test)
github-create-deployment-create-deployment:36:0: E1111: Assigning result of a function call, where the function has no return (assignment-from-no-return)

-----------------------------------
Your code has been rated at 7.60/10
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._