### PR TITLE
Rename check-kind-label to kind-label

### DIFF
--- a/tekton/ci-workspace/README.md
+++ b/tekton/ci-workspace/README.md
@@ -150,7 +150,7 @@ Example of job names:
 - `pull-triggers-go-coverage`
 - `periodic-dashboard-integration-tests`
 - `post-catalog-publish-tasks`
-- `pull-check-kind-label`
+- `pull-kind-label`
 
 ### Tasks
 

--- a/tekton/ci/README.md
+++ b/tekton/ci/README.md
@@ -146,7 +146,7 @@ Example of job names:
 - `pull-triggers-go-coverage`
 - `periodic-dashboard-integration-tests`
 - `post-catalog-publish-tasks`
-- `pull-check-kind-label`
+- `pull-kind-label`
 
 ### Tasks
 

--- a/tekton/ci/jobs/tasks.yaml
+++ b/tekton/ci/jobs/tasks.yaml
@@ -71,7 +71,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: check-kind-label
+  name: kind-label
   namespace: tektonci
   description: |
     Verifies that a PR has one valid kind label

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -12,7 +12,7 @@ spec:
     - name: labels
       description: The labels attached to the Pull Request
   tasks:
-  - name: check-kind-label
+  - name: kind-label
     conditions:
     - conditionRef: "check-name-matches"
       params:
@@ -21,7 +21,7 @@ spec:
       - name: checkName
         value: $(params.checkName)
     taskRef:
-      name: check-kind-label
+      name: kind-label
     params:
     - name: labels
       value: $(params.labels)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In a previous PR, we added a CEL filter to the tekton-events sink
to exclude events related to taskruns with "-check-" in the name,
to allow filtering out tasks associated to conditions, which should
not trigger github updates.

The new filter however matches the name of the "check-kind-label"
task, which is a CI job and should trigger github updates instead.
Renaming the task to "kind-label" instead, to avoid the conflict
and restore GitHub notifications for the task.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug

/cc @jerop @bobcatfish