### PR TITLE
Fix catlin script lint job

### DIFF
--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -56,13 +56,19 @@ spec:
         catlin validate $(cat $(workspaces.store-changed-files.path)/changed-files.txt) | tee -a $(workspaces.store-changed-files.path)/catlin.txt
         echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
 
-        echo '**Catlin script lint Output**' >> $(workspaces.store-changed-files.path)/catlin.txt
-        echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+        # performing catlin script validattion only on yaml files
+        for file in $(cat $(workspaces.store-changed-files.path)/changed-files.txt);do
+            if [[ ${file} == *.yaml ]];then
+                catlin lint script ${file} | tee -a $(workspaces.store-changed-files.path)/catlin-script.txt
+            fi
+        done
 
-        # performing catlin validate
-        catlin lint script $(cat $(workspaces.store-changed-files.path)/changed-files.txt) | tee -a $(workspaces.store-changed-files.path)/catlin.txt
-        echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
-
+        if [[ -s $(workspaces.store-changed-files.path)/catlin-script.txt ]];then
+          echo '**Catlin script lint Output**' >> $(workspaces.store-changed-files.path)/catlin.txt
+          echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+          cat $(workspaces.store-changed-files.path)/catlin-script.txt >> $(workspaces.store-changed-files.path)/catlin.txt
+          echo '```' >> $(workspaces.store-changed-files.path)/catlin.txt
+        fi
 
         # checking if there are any ERROR or WARN messages produced by catlin
         isWarning=$(cat  $(workspaces.store-changed-files.path)/catlin.txt | grep -c "WARN")


### PR DESCRIPTION
Fix catlin script lint job by only launching on yaml files and only
showing the headers if there is actual errors set

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._