### PR TITLE
Remove --enable-basic-auth from e2e test clusters.

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -166,7 +166,7 @@ function create_test_cluster() {
 
   # Smallest cluster required to run the end-to-end-tests
   local CLUSTER_CREATION_ARGS=(
-    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
+    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --no-issue-client-certificate ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
     --gke-shape={\"default\":{\"Nodes\":${E2E_MIN_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke
@@ -282,11 +282,8 @@ function setup_test_cluster() {
   local k8s_user=$(gcloud config get-value core/account)
   local k8s_cluster=$(kubectl config current-context)
 
-  # If cluster admin role isn't set, this is a brand new cluster
-  # Setup the admin role and also KO_DOCKER_REPO
-  if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
-    acquire_cluster_admin_role ${k8s_user} ${E2E_CLUSTER_NAME} ${E2E_CLUSTER_REGION} ${E2E_CLUSTER_ZONE}
-    kubectl config set-context ${k8s_cluster} --namespace=default
+  # If KO_DOCKER_REPO isn't set, use default.
+  if [[ -z "${KO_DOCKER_REPO}" ]]; then
     export KO_DOCKER_REPO=gcr.io/${E2E_PROJECT_ID}/${E2E_BASE_NAME}-e2e-img
   fi
 

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -240,44 +240,6 @@ function dump_app_logs() {
   done
 }
 
-# Sets the given user as cluster admin.
-# Parameters: $1 - user
-#             $2 - cluster name
-#             $3 - cluster region
-#             $4 - cluster zone, optional
-function acquire_cluster_admin_role() {
-  echo "Acquiring cluster-admin role for user '$1'"
-  local geoflag="--region=$3"
-  [[ -n $4 ]] && geoflag="--zone=$3-$4"
-  # Get the password of the admin and use it, as the service account (or the user)
-  # might not have the necessary permission.
-  local password=$(gcloud --format="value(masterAuth.password)" \
-      container clusters describe $2 ${geoflag})
-  if [[ -n "${password}" ]]; then
-    # Cluster created with basic authentication
-    kubectl config set-credentials cluster-admin \
-        --username=admin --password=${password}
-  else
-    local cert=$(mktemp)
-    local key=$(mktemp)
-    echo "Certificate in ${cert}, key in ${key}"
-    gcloud --format="value(masterAuth.clientCertificate)" \
-      container clusters describe $2 ${geoflag} | base64 -d > ${cert}
-    gcloud --format="value(masterAuth.clientKey)" \
-      container clusters describe $2 ${geoflag} | base64 -d > ${key}
-    kubectl config set-credentials cluster-admin \
-      --client-certificate=${cert} --client-key=${key}
-  fi
-  kubectl config set-context $(kubectl config current-context) \
-      --user=cluster-admin
-  kubectl create clusterrolebinding cluster-admin-binding \
-      --clusterrole=cluster-admin \
-      --user=$1
-  # Reset back to the default account
-  gcloud container clusters get-credentials \
-      $2 ${geoflag} --project $(gcloud config get-value project)
-}
-
 # Runs a go test and generate a junit summary.
 # Parameters: $1... - parameters to go test
 function report_go_test() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

See
https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#legacy-auth
for more details for what this flag does.

This flag, and the related code to uses it, shouldn't be needed - the Prow SA
should have sufficient permissions via IAM
(https://cloud.google.com/kubernetes-engine/docs/how-to/iam#predefined)
to interact with the created cluster.

Additionally, this feature is going away in GKE 1.19, so we're better
off disabling it ASAP in preparation.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._