### PR TITLE
Add 'patch' privillege to tekton-deployer sa

### DIFF
--- a/robocat/cadmin/200-rbac.yaml
+++ b/robocat/cadmin/200-rbac.yaml
@@ -40,6 +40,10 @@ rules:
   - apiGroups: [autoscaling]
     resources: [horizontalpodautoscalers]
     verbs: ["*"]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: ["patch"]
+    resourceNames: ["tekton-pipelines"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adds `patch` privilege to tekton-deployer to patch namespace `tekton-pipelines` on robocat cluster.

Taskruns of Task `install-tekton-release` are failing as `tektin-deployer` serviceaccount
doesn't have the privillege to patch `tekton-pipelines` namespace.

ref: https://dashboard.dogfooding.tekton.dev/#/namespaces/default/taskruns/deploy-pipeline-release-robocat-c5s7m?step=deploy-tekton-project

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._