### PR TITLE
Add post release file to Tekton install task and script

### DIFF
--- a/robocat/cadmin/200-rbac.yaml
+++ b/robocat/cadmin/200-rbac.yaml
@@ -44,6 +44,9 @@ rules:
     resources: [namespaces]
     verbs: ["patch"]
     resourceNames: ["tekton-pipelines"]
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clusterinterceptors"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -235,7 +235,7 @@ Prerequisites:
 
 Usage:
 
-`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]`
+`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g post-file]`
 
 Where:
 
@@ -248,5 +248,7 @@ Where:
 - `extra-path` is the root path within the bucket where release are stored, empty by default
 
 - `file` is the name of the release file, `release.yaml` by default
+
+- `post-file` is the name of the 2nd release file, none by default, `interceptors.yaml` by default for triggers
 
 To summarize, the deployment job will look for the release file into `<bucket>/<extra-path>/<project>/previous/<version>/<file>`

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE
+declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE POST_RELEASE_FILE
 
 # This script allows to deploy a Tekton release to the dogfooding cluster
 # by creating a job in the robocat cluster. The complete flow is:
@@ -13,7 +13,7 @@ declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELE
 # - cluster gke_tekton-nightly_europe-north1-a_robocat defined in the local kubeconfig
 
 # Read command line options
-while getopts ":p:v:b:e:f:" opt; do
+while getopts ":p:v:b:e:f:g:c:r:" opt; do
   case ${opt} in
     p )
       TEKTON_PROJECT=$OPTARG
@@ -30,10 +30,19 @@ while getopts ":p:v:b:e:f:" opt; do
     f )
       RELEASE_FILE=$OPTARG
       ;;
+    g )
+      POST_RELEASE_FILE=$OPTARG
+      ;;
+    c )
+      CONTEXT=$OPTARG
+      ;;
+    r )
+      CLUSTER_RESOURCE=$OPTARG
+      ;;
     \? )
       echo "Invalid option: $OPTARG" 1>&2
       echo 1>&2
-      echo "Usage:  deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]" 1>&2
+      echo "Usage:  deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g file] [-c context] [-r cluster-resource]" 1>&2
       ;;
     : )
       echo "Invalid option: $OPTARG requires an argument" 1>&2
@@ -59,13 +68,21 @@ if [ -z "$RELEASE_FILE" ]; then
         RELEASE_FILE="release.yaml"
     fi
 fi
+if [ -z "$POST_RELEASE_FILE" ]; then
+    if [ "$TEKTON_PROJECT" == "triggers" ]; then
+        POST_RELEASE_FILE="interceptors.yaml"
+    fi
+fi
+CONTEXT=${CONTEXT:-gke_tekton-nightly_europe-north1-a_robocat}
+CLUSTER_RESOURCE=${CLUSTER_RESOURCE:-dogfooding-tekton-deployer}
 
 # Deploy the release
-cat <<EOF | kubectl create --cluster gke_tekton-nightly_europe-north1-a_robocat -f-
+# cat <<EOF | tee
+cat <<EOF | kubectl create --cluster ${CONTEXT} -f-
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: tekton-deploy-${TEKTON_PROJECT}-${TEKTON_VERSION}-to-dogfooding-
+  generateName: tekton-deploy-${TEKTON_PROJECT}-${TEKTON_VERSION}-${CLUSTER_RESOURCE%%-*}-
   namespace: default
 spec:
   template:
@@ -88,7 +105,7 @@ spec:
             "params": {
               "target": {
                 "namespace": "tekton-pipelines",
-                "cluster-resource": "dogfooding-tekton-deployer"
+                "cluster-resource": "$CLUSTER_RESOURCE"
               },
               "tekton": {
                 "project": "$TEKTON_PROJECT",
@@ -96,6 +113,7 @@ spec:
                 "environment": "dogfooding",
                 "bucket": "$RELEASE_BUCKET",
                 "file": "$RELEASE_FILE",
+                "post-file": "$POST_RELEASE_FILE",
                 "extra-path": "$RELEASE_EXTRA_PATH"
               },
               "plumbing": {

--- a/tekton/cronjobs/bases/tekton-service/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/tekton-service/trigger-resource-cd.yaml
@@ -50,6 +50,7 @@ spec:
                       "environment": "$TEKTON_CLUSTER",
                       "bucket": "$RELEASE_BUCKET",
                       "file": "$RELEASE_FILE",
+                      "post-file": "$POST_RELEASE_FILE",
                       "extra-path": "$RELEASE_EXTRA_PATH"
                     },
                     "plumbing": {
@@ -74,6 +75,8 @@ spec:
                 value: "gs://tekton-releases"
               - name: RELEASE_FILE
                 value: "release.yaml"
+              - name: POST_RELEASE_FILE
+                value: ""
               - name: RELEASE_EXTRA_PATH
                 value: ""
               - name: NAMESPACE

--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -94,6 +94,8 @@ spec:
     value: $(body.params.tekton.bucket)
   - name: releaseFile
     value: $(body.params.tekton.file)
+  - name: postReleaseFile
+    value: $(body.params.tekton.post-file)
   - name: tektonProject
     value: $(body.params.tekton.project)
   - name: tektonVersion

--- a/tekton/resources/cd/tekton-template.yaml
+++ b/tekton/resources/cd/tekton-template.yaml
@@ -27,6 +27,9 @@ spec:
   - name: releaseFile
     description: Name of the release file
     default: release.yaml
+  - name: postReleaseFile
+    description: Name of the extra release file to install once pods and CRDs are ready
+    default: ""
   - name: releaseExtraPath
     description: Any extra path after bucket/project, starting with a "/"
     default: ""
@@ -59,6 +62,8 @@ spec:
         value: $(tt.params.targetCluster)
       - name: release-file
         value: $(tt.params.releaseFile)
+      - name: post-release-file
+        value: $(tt.params.postReleaseFile)
       resources:
         inputs:
           - name: release-bucket

--- a/tekton/resources/release/base/install_tekton_release.yaml
+++ b/tekton/resources/release/base/install_tekton_release.yaml
@@ -32,6 +32,9 @@ spec:
   - name: release-file
     description: Name of the release file
     default: release.yaml
+  - name: post-release-file
+    description: Name of the release file
+    default: ""
   resources:
     inputs:
       - name: release-bucket
@@ -40,6 +43,12 @@ spec:
         type: cluster
       - name: plumbing-library
         type: git
+
+  stepTemplate:
+    env:
+      - name: KUBECONFIG
+        value: /workspace/$(resources.inputs.k8s-cluster.name)/kubeconfig
+
   steps:
 
   - name: deploy-tekton-project
@@ -49,7 +58,7 @@ spec:
       set -exo pipefail
 
       # Export KUBECONFIG so that it's available to pre-scripts too
-      export KUBECONFIG=/workspace/$(resources.inputs.k8s-cluster.name)/kubeconfig
+      export KUBECONFIG
       # Set up RELEASE_ROOT
       if [[ "$(params.version)" == "latest" ]]; then
         RELEASE_ROOT=$(resources.inputs.release-bucket.path)/$(params.version)
@@ -82,16 +91,35 @@ spec:
       fi
       kubectl apply --kubeconfig $KUBECONFIG $APPLY_MODE
 
-  - name: wait-until-pods-running
+  - name: wait-until-pods-and-crds
     image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
     script: |
       #!/usr/bin/env bash
       set -exo pipefail
-      source $(resources.inputs.plumbing-library.path)/scripts/library.sh
-      wait_until_pods_running "$(params.namespace)"
-    env:
-      - name: KUBECONFIG
-        value: /workspace/$(resources.inputs.k8s-cluster.name)/kubeconfig
+      APPLICATION="tekton-$(params.projectName)"
+      if [ "$(params.projectName)" == "pipeline" ]; then
+        APPLICATION="${APPLICATION}s"
+      fi
+      # Wait for pods to be ready and CRDs to be established
+      kubectl wait --for condition=ready --timeout=120s pods -l app.kubernetes.io/part-of=$APPLICATION -n $(params.namespace)
+      kubectl wait --for condition=established --timeout=60s crd -l app.kubernetes.io/part-of=$APPLICATION
+
+
+  - name: deploy-extra-manifest
+    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+    script: |
+      #!/usr/bin/env bash
+      set -exo pipefail
+      if [ "$(params.post-release-file)" != "" ]; then
+          # Set up RELEASE_ROOT
+          if [[ "$(params.version)" == "latest" ]]; then
+            RELEASE_ROOT=$(resources.inputs.release-bucket.path)/$(params.version)
+          else
+            RELEASE_ROOT=$(resources.inputs.release-bucket.path)/previous/$(params.version)
+          fi
+          kubectl apply --kubeconfig $KUBECONFIG -f $RELEASE_ROOT/$(params.post-release-file)
+      fi
+
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tekton triggers installation is now split into two files. The
second one can only be installed once CRDs are established.

To support this, split the tekton install task in three steps:
- install the main release file with overlays, like before
- wait for pods ready and CRD established that match the project
  being installed
- install the post release file, in any

In the script, set the default post file to "interceptors.yaml"
for triggers, to keep the script easy to use.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc