### PR TITLE
Add the clusterinterceptors to clusterroles

### DIFF
--- a/tekton/ci-workspace/infra/0001_rbac.yaml
+++ b/tekton/ci-workspace/infra/0001_rbac.yaml
@@ -16,16 +16,6 @@ rules:
   resources: ["serviceaccounts"]
   verbs: ["impersonate"]
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: triggers-minimal-ci
-rules:
-# EventListeners need to be able to fetch any clustertriggerbindings
-- apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings"]
-  verbs: ["get", "list", "watch"]
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -64,18 +54,6 @@ roleRef:
   kind: Role
   name: triggers-minimal
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tekton-ci-workspace-listener-triggers-minimal-ci
-subjects:
-- kind: ServiceAccount
-  name: tekton-ci-workspace-listener
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: triggers-minimal
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -103,7 +81,7 @@ metadata:
   name: tekton-ci-jobs-triggers
 rules:
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings", "clusterinterceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/ci/0001_rbac.yaml
+++ b/tekton/ci/0001_rbac.yaml
@@ -29,7 +29,7 @@ metadata:
 rules:
 # EventListeners need to be able to fetch any clustertriggerbindings
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings"]
+  resources: ["clustertriggerbindings", "clusterinterceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -41,7 +41,7 @@ metadata:
 rules:
 # EventListeners need to be able to fetch any clustertriggerbindings
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings"]
+  resources: ["clustertriggerbindings", "clusterinterceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/resources/nightly-release/serviceaccount.yaml
+++ b/tekton/resources/nightly-release/serviceaccount.yaml
@@ -45,7 +45,7 @@ metadata:
   name: release-cluster-minimal
 rules:
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings", "clusterinterceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/resources/nightly-tests/serviceaccount.yaml
+++ b/tekton/resources/nightly-tests/serviceaccount.yaml
@@ -51,7 +51,7 @@ metadata:
   name: tekton-test-triggers-nightly-clusterrole
 rules:
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings"]
+  resources: ["clustertriggerbindings", "clusterinterceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The tetkoncd service account is used to run the tektoncd and tekton
events event listener, and it requires access to read the
clusterinterceptors to operate.
Same goes for the tekton-ci-listener and tekton-ci-workspace-listener
service accounts, that serve the event listeners for the two
Tekton based CI webhooks.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc