### PR TITLE
Stop using depreacted replicas in event listeners

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -83,7 +83,9 @@ metadata:
   name: tekton-events
 spec:
   serviceAccountName: tektoncd
-  replicas: 3
+  resources:
+    kubernetesResource:
+      replicas: 3
   triggers:
     - name: cd-pipeline-failed
       interceptors:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replicas has been deprecated in event listeners starting v0.13.0.
Moving to the new syntax, before support is removed in the next
release.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc