### PR TITLE
Add feature flags config to pipeline overlay

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
@@ -6,3 +6,4 @@ patchesStrategicMerge:
 - config-observability.yaml
 - webhook.yaml
 - controller.yaml
+- feature-flags.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Feature flags are configured for pipeline in the dogfooding overlay,
but the config map YAML is not included in kustomize.yaml, so the
changes are not applied. Add feature-flags.yaml to kustomize so that
custom tasks are enabled.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc