### PR TITLE
Pin GKE cluster version for e2e tests

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -166,7 +166,7 @@ function create_test_cluster() {
 
   # Smallest cluster required to run the end-to-end-tests
   local CLUSTER_CREATION_ARGS=(
-    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate --cluster-version=\"1.18.16-gke.502\" ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
+    --gke-create-command="container clusters create --quiet --enable-autoscaling --min-nodes=${E2E_MIN_CLUSTER_NODES} --max-nodes=${E2E_MAX_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate ${EXTRA_CLUSTER_CREATION_FLAGS[@]}"
     --gke-shape={\"default\":{\"Nodes\":${E2E_MIN_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Default GKE version to be used with Tekton Serving
-readonly SERVING_GKE_VERSION=gke-latest
+readonly SERVING_GKE_VERSION=1.18.16-gke.502
 readonly SERVING_GKE_IMAGE=cos
 
 # Conveniently set GOPATH if unset


### PR DESCRIPTION
# Changes

This change pins the cluster version that will be picked up by kubetest via k8s_extract. Currently, after #818, kubetest will pick up two different --cluster-version flags, and only take the second.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._