### PR TITLE
GitHub Simple Interceptor: Standardize naming, fix webhook validation.

### DIFF
--- a/tekton/ci/interceptors/github/README.md
+++ b/tekton/ci/interceptors/github/README.md
@@ -14,6 +14,29 @@ This interceptor expects its configuration in an InterceptorParam named
 `config`. The full config spec (including defaults) can be found at
 `pkg/proto/v1alpha1/config.proto`[./pkg/proto/v1alpha1/config.proto].
 
+## Deployment
+
+1. Generate the secret
+
+   ```bash
+   $ openssl rand -base64 32 > /tmp/webhook.txt
+   ```
+
+2. Create/Update GitHub webhook using secret (see
+   [Securing your webhooks](https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks))
+
+3. Generate Kubernetes Secret
+
+   ```bash
+   $ kubectl create secret generic github-webhook-secret  --from-file=/tmp/webhook.txt
+   ```
+
+4. Deploy interceptor
+
+   ```bash
+   $ ko apply -f config
+   ```
+
 ### Cookbook
 
 #### Allow all pushes, pull requests
@@ -74,8 +97,8 @@ default fields.
 
 ## Extensions
 
-This interceptor will provide the following extension outputs that can be used in
-TriggerTemplates.
+This interceptor will provide the following extension outputs that can be used
+in TriggerTemplates.
 
 These values are intended to be recommended defaults. If you wish to use
 different values, simply specify the desired values in your Trigger binding.

--- a/tekton/ci/interceptors/github/config/service.yaml
+++ b/tekton/ci/interceptors/github/config/service.yaml
@@ -12,30 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-interceptor-github
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tekton-triggers-interceptors-github
-  namespace: tekton-pipelines
+  name: tekton-triggers-interceptor-github
   labels:
     app.kubernetes.io/name: github-simple
-    app.kubernetes.io/component: interceptors
+    app.kubernetes.io/component: tekton-interceptors
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: github-simple
-      app.kubernetes.io/component: interceptors
+      app.kubernetes.io/component: tekton-interceptors
   template:
     metadata:
       labels:
         app.kubernetes.io/name: github-simple
-        app.kubernetes.io/component: interceptors
+        app.kubernetes.io/component: tekton-interceptors
     spec:
-      serviceAccountName: tekton-triggers-core-interceptors
+      serviceAccountName: tekton-triggers-interceptor-github
       containers:
-        - name: tekton-triggers-core-interceptors
+        - name: tekton-triggers-interceptor-github
           image: "ko://github.com/tektoncd/plumbing/tekton/ci/interceptors/github"
+          args:
+            - "--webhook_secret_path=/etc/webhook-secret/webhook.txt"
           securityContext:
             allowPrivilegeEscalation: false
             # User 65532 is the distroless nonroot user ID
@@ -44,15 +50,22 @@ spec:
             capabilities:
               drop:
                 - all
+          volumeMounts:
+          - name: webhook-secret
+            mountPath: "/etc/webhook-secret"
+            readOnly: true
+      volumes:
+      - name: webhook-secret
+        secret:
+          secretName: github-webhook-secret
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: github-simple
-    app.kubernetes.io/component: interceptors
-  name: tekton-triggers-interceptors-github
-  namespace: tekton-pipelines
+    app.kubernetes.io/component: tekton-interceptors
+  name: tekton-triggers-interceptor-github
 spec:
   ports:
     - name: "http"
@@ -60,7 +73,7 @@ spec:
       targetPort: 8080
   selector:
     app.kubernetes.io/name: github-simple
-    app.kubernetes.io/component: interceptors
+    app.kubernetes.io/component: tekton-interceptors
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: ClusterInterceptor
@@ -70,5 +83,5 @@ metadata:
 spec:
   clientConfig:
     service:
-      name: tekton-triggers-interceptors-github
-      namespace: tekton-pipelines
+      name: tekton-triggers-interceptor-github
+      namespace: default

--- a/tekton/ci/interceptors/github/main.go
+++ b/tekton/ci/interceptors/github/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"io/ioutil"
 	"log"
@@ -24,7 +25,7 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-	s := github.New(http.DefaultClient, webhookSecret)
+	s := github.New(http.DefaultClient, bytes.TrimSpace(webhookSecret))
 
 	http.ListenAndServe(":8080", s)
 }

--- a/tekton/ci/interceptors/github/pkg/github/server.go
+++ b/tekton/ci/interceptors/github/pkg/github/server.go
@@ -76,7 +76,7 @@ func (s *Server) handle(r *http.Request) (*v1alpha1.InterceptorResponse, error) 
 	if sig := headers.Get("X-Hub-Signature-256"); sig != "" {
 		fmt.Println(sig)
 		if err := github.ValidateSignature(sig, []byte(in.Body), s.webhookSecret); err != nil {
-			return nil, Error(codes.InvalidArgument, "unknown signature")
+			return nil, Errorf(codes.InvalidArgument, "unknown signature: %v", err)
 		}
 	}
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This makes several small changes to the interceptor:

- Standardizes naming on `tekton-triggers-interceptor-github`, and
component as `tekton-interceptors`
- Adds webhook secret volume in deployment config.
  - Adds documentation for generating the secret.
- Fixes webhook validation due to trailing `\n` in the read secret.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._