### PR TITLE
Enable OCI bundles

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: tekton-pipelines
 data:
   enable-custom-tasks: "true"
+  enable-tekton-oci-bundles: "true"

--- a/tekton/ci-workspace/jobs/tekton-docs-reviews.yaml
+++ b/tekton/ci-workspace/jobs/tekton-docs-reviews.yaml
@@ -28,7 +28,8 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge # from the catalog
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
       params:
         - name: url
           value: $(params.gitRepository)
@@ -62,6 +63,7 @@ spec:
         values: ["passed"]
       taskRef:
         name: github-request-reviewers
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-request-reviewers:0.1
       params:
       - name: PACKAGE
         value: "$(params.package)"

--- a/tekton/ci-workspace/jobs/tekton-golang-tests.yaml
+++ b/tekton/ci-workspace/jobs/tekton-golang-tests.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   iterateParam: context
   taskRef:
-    name: golang-test  # from the catalog
+    name: golang-test
+    bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -43,7 +44,8 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge # from the catalog
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
       params:
         - name: url
           value: $(params.gitRepository)
@@ -89,7 +91,7 @@ spec:
       taskRef:
         apiVersion: custom.tekton.dev/v1alpha1
         kind: TaskLoop
-        name: golang-tests # from the catalog
+        name: golang-tests
       params:
       - name: package
         value: "$(params.package)"

--- a/tekton/ci-workspace/jobs/tekton-image-build.yaml
+++ b/tekton/ci-workspace/jobs/tekton-image-build.yaml
@@ -95,7 +95,8 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge # from the catalog
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/ci-workspace/jobs/tekton-teps-validation.yaml
+++ b/tekton/ci-workspace/jobs/tekton-teps-validation.yaml
@@ -52,7 +52,8 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge  # from the catalog
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge :0.2
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/ci/interceptors/add-pr-body/tekton/release-pipeline.yaml
+++ b/tekton/ci/interceptors/add-pr-body/tekton/release-pipeline.yaml
@@ -49,6 +49,7 @@ spec:
     - name: git-clone
       taskRef:
         name: git-clone
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
       workspaces:
         - name: output
           workspace: workarea
@@ -62,6 +63,7 @@ spec:
       runAfter: [git-clone]
       taskRef:
         name: golang-test
+        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -73,6 +75,7 @@ spec:
       runAfter: [git-clone]
       taskRef:
         name: golang-build
+        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -114,6 +117,7 @@ spec:
       runAfter: [publish-images]
       taskRef:
         name: gcs-upload
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -135,6 +139,7 @@ spec:
           values: ["true"]
       taskRef:
         name: gcs-upload
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/interceptors/add-team-members/tekton/release-pipeline.yaml
+++ b/tekton/ci/interceptors/add-team-members/tekton/release-pipeline.yaml
@@ -49,6 +49,7 @@ spec:
     - name: git-clone
       taskRef:
         name: git-clone
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
       workspaces:
         - name: output
           workspace: workarea
@@ -62,6 +63,7 @@ spec:
       runAfter: [git-clone]
       taskRef:
         name: golang-test
+        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -73,6 +75,7 @@ spec:
       runAfter: [git-clone]
       taskRef:
         name: golang-build
+        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -114,6 +117,7 @@ spec:
       runAfter: [publish-images]
       taskRef:
         name: gcs-upload
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -135,6 +139,7 @@ spec:
           values: ["true"]
       taskRef:
         name: gcs-upload
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/jobs/tekton-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catlin-lint.yaml
@@ -128,6 +128,7 @@ spec:
     - name: post-comment
       taskRef:
         name: github-add-comment
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.4
       params:
         - name: COMMENT_OR_FILE
           value: "catlin.txt"

--- a/tekton/ci/jobs/tekton-python-test.yaml
+++ b/tekton/ci/jobs/tekton-python-test.yaml
@@ -12,6 +12,7 @@ spec:
     - name: fetch-repository
       taskRef:
         name: git-clone
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
       workspaces:
         - name: output
           workspace: shared-workspace
@@ -27,6 +28,7 @@ spec:
     - name: pytest
       taskRef:
         name: pytest
+        bundle: gcr.io/tekton-releases/catalog/upstream/pytest:0.1
       runAfter:
         - fetch-repository
       workspaces:

--- a/tekton/resources/cd/notification-template.yaml
+++ b/tekton/resources/cd/notification-template.yaml
@@ -35,6 +35,7 @@ spec:
     spec:
       taskRef:
         name: send-to-webhook-slack
+        bundle: gcr.io/tekton-releases/catalog/upstream/send-to-webhook-slack:0.1
       params:
         - name: webhook-secret
           value: robocat-slack-app-webhook

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -47,6 +47,7 @@ spec:
           runAsUser: 1001
       taskRef:
         name: github-set-status
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
       params:
         - name: REPO_FULL_NAME
           value: $(tt.params.gitHubRepo)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enable experimental OCI bundles in tekton pipelines deployment to
dogfooding. This allow us to consume catalog tasks from OCI bundles
directly.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc