### PR TITLE
Bump go version to 1.16.3

### DIFF
--- a/catlin/Dockerfile
+++ b/catlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.15-alpine3.12 as build
+FROM docker.io/library/golang:1.16.3-alpine3.12 as build
 
 COPY . /build
 WORKDIR /build

--- a/pipelinerun-logs/Dockerfile
+++ b/pipelinerun-logs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2-alpine3.12
+FROM golang:1.16.3-alpine3.12
 WORKDIR /go/src/pipelinerun-logs
 COPY . .
 RUN go build -o ./pipelinerun-logs ./cmd/http

--- a/tekton/images/coverage/Dockerfile
+++ b/tekton/images/coverage/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15 as buildcoverage
+FROM golang:1.16.3 as buildcoverage
 RUN git clone https://github.com/knative/test-infra /go/src/knative.dev/test-infra
 RUN make -C /go/src/knative.dev/test-infra/tools/coverage
 
-FROM golang:1.15
+FROM golang:1.16.3
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.15-alpine3.12 as build
+ARG GO_VERSION=1.16.3
+FROM golang:${GO_VERSION}-alpine3.12 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates
@@ -29,8 +30,8 @@ FROM google/cloud-sdk:296.0.0-alpine
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 # Install golang
-RUN curl https://dl.google.com/go/go1.15.linux-amd64.tar.gz > go1.15.tar.gz
-RUN tar -C /usr/local -xzf go1.15.tar.gz
+RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz > go${GO_VERSION}.tar.gz
+RUN tar -C /usr/local -xzf go${GO_VERSION}.tar.gz
 ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOROOT /usr/local/go
 

--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.15-alpine3.12
+FROM golang:1.16.3-alpine3.12
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 ENV GOROOT /usr/local/go

--- a/tekton/images/kubectl/Dockerfile
+++ b/tekton/images/kubectl/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.15-alpine3.12 as build
+FROM golang:1.16.3-alpine3.12 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build kubetest independently of the rest
-FROM docker.io/library/golang:1.15 as kubetest
+FROM docker.io/library/golang:1.16.3 as kubetest
 RUN git clone https://github.com/kubernetes/test-infra /go/src/k8s.io/test-infra
 # Using e685556b32c5fb7ab12c3277d41112d47ceac0cd because after that, the URL kubetest
 # uses needs extract credentials.
@@ -144,8 +144,8 @@ RUN ["/bin/chmod", "+x", "/workspace/get-kube.sh"]
 
 # END: test-infra import
 
-# Install Go 1.15.2
-ARG GO_VERSION=1.15.2
+# Install Go 1.16.3
+ARG GO_VERSION=1.16.3
 RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz > go${GO_VERSION}.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.tar.gz && \
     rm go${GO_VERSION}.tar.gz


### PR DESCRIPTION
right now CI is failing on https://github.com/tektoncd/chains/pull/70 because it depends on the `embed` package, which should be fixed with the latest version of golang! 