### PR TITLE
Fix job that is supposed to close rotten issues/prs 🥀

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1364,7 +1364,7 @@ periodics:
       - |-
         --query=org:tektoncd
         -label:lifecycle/frozen
-        label:lifecycle/stale
+        -label:lifecycle/stale
         label:lifecycle/rotten
       - --updated=720h
       - --token=/etc/github-token/oauth


### PR DESCRIPTION
# Changes

I was looking at some PRs and issues today that have been rotten for a
very long time and I was trying to figure out why they weren't getting
automatically closed.

I think that that query was incorrect and was looking for old issues that
were labelled with BOTH stale and rotten, but what we actually want is
issues that are labelled with rotten only, so I think this will do the
trick!

And then I guess we'll see a flurry of automatic closures?? 😅

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._