### PR TITLE
Fix check-name-matches Task and add Catlin to `ci-workspace` directory

### DIFF
--- a/tekton/ci-workspace/catalog/kustomization.yaml
+++ b/tekton/ci-workspace/catalog/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - template.yaml
+  - trigger.yaml

--- a/tekton/ci-workspace/catalog/template.yaml
+++ b/tekton/ci-workspace/catalog/template.yaml
@@ -1,0 +1,73 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-catalog-ci-pipeline
+spec:
+  params:
+    - name: buildUUID
+      description: UUID used to track a CI Pipeline Run in logs
+    - name: package
+      description: org/repo
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+    - name: pullRequestUrl
+      description: The HTML URL for the pull request
+    - name: pullRequestBaseRef
+      description: |
+        The base git ref for the pull request. This is the branch the
+        pull request would merge onto once approved.
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitRevision
+      description: The Git revision to be used.
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: gitHubCommand
+      description: |
+        The GitHub command that was used a trigger. This is only available when
+        this template is triggered by a comment. The default value is for the
+        case of a pull_request event.
+      default: ""
+    - name: labels
+      description: List of labels currently on the Pull Request
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: pull-catalog-catlin-run-
+        labels:
+          prow.k8s.io/build-id: $(tt.params.buildUUID)
+          tekton.dev/kind: ci
+          tekton.dev/check-name: pull-catalog-catlin-lint
+          tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+        annotations:
+          tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+          tekton.dev/gitURL: "$(tt.params.gitRepository)"
+      spec:
+        serviceAccountName: tekton-ci-jobs
+        pipelineRef:
+          name: catlin-linter
+        workspaces:
+          - name: store-changed-files
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+        params:
+          - name: gitCloneDepth
+            value: $(tt.params.gitCloneDepth)
+          - name: gitHubCommand
+            value: $(tt.params.gitHubCommand)
+          - name: checkName
+            value: pull-catalog-catlin-lint
+          - name: pullRequestUrl
+            value: $(tt.params.pullRequestUrl)
+          - name: pullRequestNumber
+            value: $(tt.params.pullRequestNumber)
+          - name: pullRequestBaseRef
+            value: $(tt.params.pullRequestBaseRef)
+          - name: gitRepository
+            value: "$(tt.params.gitRepository)"

--- a/tekton/ci-workspace/catalog/trigger.yaml
+++ b/tekton/ci-workspace/catalog/trigger.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: catalog-pull-request
+spec:
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - pull_request
+    - cel:
+        filter: >-
+          body.repository.full_name == 'tektoncd/catalog' &&
+          body.action in ['opened','synchronize']
+        overlays:
+          - key: git_clone_depth
+            expression: "string(body.pull_request.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-pull-request
+    - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-pr-labels
+  template:
+    ref: tekton-catalog-ci-pipeline
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: catalog-issue-comment
+spec:
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - issue_comment
+    - cel:
+        filter: >-
+          body.repository.full_name == 'tektoncd/catalog' &&
+          body.action == 'created' &&
+          'pull_request' in body.issue &&
+          body.issue.state == 'open' &&
+          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
+        overlays:
+          - key: add_pr_body.pull_request_url
+            expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tektonci
+    - cel:
+        overlays:
+          - key: git_clone_depth
+            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-comment
+    - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-issue-labels
+  template:
+    ref: tekton-catalog-ci-pipeline

--- a/tekton/ci-workspace/jobs/kustomization.yaml
+++ b/tekton/ci-workspace/jobs/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - tekton-golang-tests.yaml
 - tekton-image-build.yaml
 - tekton-docs-reviews.yaml
+- tekton-catalog-catlin-lint.yaml

--- a/tekton/ci-workspace/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci-workspace/jobs/tekton-catalog-catlin-lint.yaml
@@ -1,0 +1,165 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: catlin-lint
+spec:
+  description: >-
+    This task detects changes in the pull request using git diff
+    and stores the changed tasks names in a workspace and passes
+    that to the catlin so that catlin can validate only changed
+    files.
+  workspaces:
+    - name: source
+      description: >
+        Workspace where the git repo is prepared for linting and catlin
+        output is stored.
+  params:
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+  steps:
+    - name: find-changed-tasks
+      image: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
+      workingDir: $(workspaces.source.path)
+      script: |
+        function detect_new_changed_tasks() {
+          # detect for changes in the task manifest
+          git --no-pager diff --name-only HEAD~$(( $(params.gitCloneDepth) - 1 ))|grep 'task/[^\/]*/[^\/]*/*[^/]*.yaml'|xargs -I {} dirname {}
+        }
+        all_tests=$(detect_new_changed_tasks |sort -u || true)
+        final_tests=""
+        # check for the tasks which are removed completely and skip them
+        for task in $all_tests; do
+          [[ ! -d $task ]] && continue
+          final_tests="$final_tests $task"
+        done
+        echo -n $final_tests > changed-files.txt
+    - name: lint-catalog
+      image: gcr.io/tekton-releases/dogfooding/catlin:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        set +e
+        [[ ! -s changed-files.txt ]] && {
+          echo "No file change detected in task directory"
+          echo -n "" > catlin.txt
+          exit 0
+        }
+
+        # creating a file which will contain the final formatted output
+        # which needs to be added as a comment(if any)
+        echo '**Catlin Output**' >> catlin.txt
+        echo '```' >> catlin.txt
+
+        # performing catlin validate
+        catlin validate changed-files.txt | tee -a catlin.txt
+        echo '```' >> catlin.txt
+
+        # performing catlin script validattion only on yaml files
+        for file in $(cat changed-files.txt);do
+          catlin lint script ${file}/*.yaml | tee -a catlin-script.txt
+        done
+
+        if [[ -s catlin-script.txt ]];then
+          echo '**Catlin script lint Output**' >> catlin.txt
+          echo '```' >> catlin.txt
+          cat catlin-script.txt >> catlin.txt
+          echo '```' >> catlin.txt
+        fi
+
+        # checking if there are any ERROR or WARN messages produced by catlin
+        isWarning=$(cat catlin.txt | grep -c "WARN")
+        isError=$(cat catlin.txt | grep -c "ERROR")
+
+        # if there are no ERROR or WARN messages then add a empty string which will not
+        # add a comment on the Github PR
+        [[ $isWarning -eq 0 ]] && [[ $isError -eq 0 ]] && \
+        echo -n "" > catlin.txt
+
+        # if catlin produced the error then fail the task else success
+        [[ $isError -eq 1 ]] && exit 1 || exit 0
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: catlin-linter
+spec:
+  workspaces:
+    - name: source
+      description: Workspace where the git repo is prepared for linting.
+  params:
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+    - name: pullRequestUrl
+      description: The HTML URL for the pull request
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: pullRequestBaseRef
+      description: The pull request base branch
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+  tasks:
+    - name: check-name-match
+      taskRef:
+        name: check-name-matches
+      params:
+        - name: gitHubCommand
+          value: $(params.gitHubCommand)
+        - name: checkName
+          value: $(params.checkName)
+    - name: clone-repo
+      when:
+        - input: $(tasks.check-name-match.results.check)
+          operator: in
+          values: ["passed"]
+      taskRef:
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: mode
+          value: "merge"
+        - name: revision
+          value: $(params.pullRequestBaseRef)
+        - name: refspec
+          value: refs/heads/$(params.pullRequestBaseRef):refs/heads/$(params.pullRequestBaseRef)
+        - name: batchedRefs
+          value: "refs/pull/$(params.pullRequestNumber)/head"
+    - name: lint-catalog
+      runAfter:
+        - "clone-repo"
+      taskRef:
+        name: catlin-lint
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+  finally:
+    - name: post-comment
+      when:
+        - input: $(tasks.check-name-match.results.check)
+          operator: in
+          values: ["passed"]
+      taskRef:
+        name: github-add-comment
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.3
+      params:
+        - name: COMMENT_OR_FILE
+          value: "catlin.txt"
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token
+        - name: REQUEST_URL
+          value: $(params.pullRequestUrl)
+      workspaces:
+        - name: comment-file
+          workspace: source

--- a/tekton/ci-workspace/kustomization.yaml
+++ b/tekton/ci-workspace/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - jobs
 - community
 - plumbing
+- catalog

--- a/tekton/ci-workspace/shared/common-tasks.yaml
+++ b/tekton/ci-workspace/shared/common-tasks.yaml
@@ -82,6 +82,6 @@ spec:
         # If a command was specified, the regex should match the checkName
         REGEX="$(echo $(params.gitHubCommand) | awk '{ print $2}')"
         [[ "$REGEX" == "" ]] && REGEX='.*'
-        echo "$(params.checkName)" | grep -E "$REGEX" \
-            || printf "failed" > $(results.check.path) \
-            && printf "passed" > $(results.check.path)
+        (echo "$(params.checkName)" | grep -E "$REGEX") \
+            && printf "passed" > $(results.check.path) \
+            || printf "failed" > $(results.check.path)


### PR DESCRIPTION
# Changes

- Catlin Task was not able to perform lint check on the script present
  inside the Task. This commit removes extra if condition and directly
  performs the `catlin lint script` command.
    
- Catlin Pipeline was running the finally task ie github-add-comment
  when it was not required so adding a Task check-name-matches and
  replacing it with condition and guarding other tasks in the pipeline
  using when conditions.

- The task `check-name-matches` in `ci-workspace` used to produce the result `passed` even if the name doesn't
  matches so re-arranged the condition so that proper result can be
  produced.
    
Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._