### PR TITLE
Fix TEPs table lint

### DIFF
--- a/tekton/ci/jobs/tekton-teps-validation.yaml
+++ b/tekton/ci/jobs/tekton-teps-validation.yaml
@@ -25,7 +25,7 @@ spec:
   - name: teps-table
     image: alpine/git:latest
     workingDir: $(resources.inputs.source.path)
-    args: ['diff', '--exit-code']
+    args: ['diff', '--exit-code', '$(params.teps-folder)/README.md']
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline


### PR DESCRIPTION
Add `teps/README.md` as arugment to `git diff --exit-code` command.
So that the only diff in table (README.md) can fail table lint.

needed for PRs like https://github.com/tektoncd/community/pull/315

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._