### PR TITLE
Add ingress overlay for results.

### DIFF
--- a/tekton/cd/results/base/kustomization.yaml
+++ b/tekton/cd/results/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/tekton/cd/results/overlays/ingress.yaml
+++ b/tekton/cd/results/overlays/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: 'results.dogfooding.tekton.dev'
+    dns.gardener.cloud/ttl: "3600"
+  name: results
+  namespace: tekton-pipelines
+spec:
+  tls:
+  - secretName: tekton-results-tls
+    hosts:
+    - results.dogfooding.tekton.dev
+  rules:
+  - host: results.dogfooding.tekton.dev
+    http:
+      paths:
+      - backend:
+          serviceName: tekton-results-api-service
+          servicePort: 50051
+        path: /*


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This should allow results to have its own DNS name + TLS for serving
results externally.

Largely based off of https://github.com/tektoncd/plumbing/blob/main/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml

I'm not 100% confident that this is correct, so would definitely appreciate a thorough look at this PR. 🙏 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._