### PR TITLE
Update cert-manager helm deployment to robocat

### DIFF
--- a/robocat/certificates/clusterissuer.yaml
+++ b/robocat/certificates/clusterissuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/tekton/cronjobs/dogfooding/manifests/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - plumbing-tekton
 - plumbing-tekton-cronjobs
+- plumbing-tekton-cronjobs-robocat

--- a/tekton/cronjobs/robocat/helm/cert-manager-nightly/cronjob.yaml
+++ b/tekton/cronjobs/robocat/helm/cert-manager-nightly/cronjob.yaml
@@ -19,12 +19,10 @@ spec:
               - name: CHART_NAME
                 value: "cert-manager"
               - name: CHART_VERSION
-                value: "v0.14.0"
+                value: "v1.3"
               - name: CHART_PARAMS
-                value: fullnameOverride=cert-manager
+                value: fullnameOverride=cert-manager,installCRDs=true
               - name: CHART_DESCRIPTION
                 value: "cert-manager"
               - name: CHART_REPO
                 value: https://charts.jetstack.io
-              - name: PRE_DEPLOY_RESOURCES
-                value: "https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager.crds.yaml"

--- a/tekton/cronjobs/robocat/helm/cert-manager-nightly/kustomization.yaml
+++ b/tekton/cronjobs/robocat/helm/cert-manager-nightly/kustomization.yaml
@@ -2,4 +2,4 @@ bases:
 - ../../../bases/helm
 patchesStrategicMerge:
 - cronjob.yaml
-nameSuffix: "-cert-manager-helm"
+nameSuffix: "-robocat-cert-manager"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update to the latest version of cert-manager (1.3).
The latest chart supports deploying the CRDs, so enable that
and disable the pre-deploy CRD deployment.

Add the cronjobs that deploys the robocat cronjobs to
kustomize so that the cronjob definition is updated nightly.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc