### PR TITLE
presubmit-tests.sh: Remove quote escaping from already quoted commands.

### DIFF
--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -53,7 +53,7 @@ GOFLAGS=${GOFLAGS:-}
 # Returns true if PR only contains the given file regexes.
 # Parameters: $1 - file regexes, space separated.
 function pr_only_contains() {
-  [[ -z "$(cat \"${CHANGED_FILES}\" | grep -v \"\(${1// /\\|}\)$\")" ]]
+  [[ -z "$(cat ${CHANGED_FILES} | grep -v \"\(${1// /\\|}\)$\")" ]]
 }
 
 # List changed files in the current PR.
@@ -77,8 +77,8 @@ function initialize_environment() {
 
   WORK_DIR=$(mktemp -d)
   CHANGED_FILES="$(list_changed_files)"
-  if [[ -n "$(cat \"${CHANGED_FILES}\")" ]]; then
-    echo -e "Changed files in commit ${PULL_PULL_SHA}:\n$(cat \"${CHANGED_FILES}\")"
+  if [[ -n "$(cat ${CHANGED_FILES})" ]]; then
+    echo -e "Changed files in commit ${PULL_PULL_SHA}:\n$(cat ${CHANGED_FILES})"
     local no_presubmit_files="${NO_PRESUBMIT_FILES[*]}"
     pr_only_contains "${no_presubmit_files}" && IS_PRESUBMIT_EXEMPT_PR=1
     pr_only_contains "\.md ${no_presubmit_files}" && IS_DOCUMENTATION_PR=1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If a command is already quoted, things like `foo="$(cat \"foo.txt\")"` are interpreted as read file `"foo.txt"`, which does not exist and causes failures such as:

```
cat: '"/tmp/tmp.5KnFwQPJrS/changed_files"': No such file or directory
==========================================='========================================
==== NO CHANGED FILES REPORTED, ASSUMING IT'S AN ERROR AND RUNNING TESTS ANYWAY ====
==========================================='========================================
```

See
https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_experimental/731/pull-tekton-experimental-unit-tests/1395436805712515072/
for an example.

This is a partial rollback of https://github.com/tektoncd/plumbing/commit/657b8cc432691ef28c89fbc8532c4a1e7144a3e7

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug
/cc @imjasonh 