### PR TITLE
Remove postsubmit job for the webhooks-extension

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1179,29 +1179,6 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
-  tektoncd/experimental:
-  - name: tekton-dashboard-publish-images
-    labels:
-      preset-postsubmit-sh: "true"
-    always_run: true
-    decorate: true
-    spec:
-      containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
-        imagePullPolicy: Always
-        command:
-        - /usr/local/bin/entrypoint.sh
-        args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
-        - "--service-account=/etc/nightly-account/service-account.json"
-        - "--upload=gs://tekton-prow/logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-        - "./test/publish-images.sh"
   tektoncd/operator:
   - name: post-tekton-operator-go-coverage
     branches:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
https://github.com/tektoncd/experimental/issues/750

webhooks-extension has been deprecated for over 9 months and is now
being deleted. Remove the postsubmit job on the experimental repo
that was used to publish the webhooks-extension image as it's no
longer required.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._