### PR TITLE
Results API: Add GCP LB specific annotations + resources.

### DIFF
--- a/tekton/cd/results/README.md
+++ b/tekton/cd/results/README.md
@@ -1,0 +1,13 @@
+# Previewing changes
+
+To see the generated config, run:
+
+```sh
+$ kustomize build overlays/dogfooding
+```
+
+To diff the changes against the remote cluster:
+
+```sh
+$ kustomize build overlays/dogfooding | kubectl diff -f -
+```

--- a/tekton/cd/results/base/kustomization.yaml
+++ b/tekton/cd/results/base/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- release.yaml
+  - https://storage.googleapis.com/tekton-releases/results/previous/v0.2.0/release.yaml

--- a/tekton/cd/results/overlays/dogfooding/bec.yaml
+++ b/tekton/cd/results/overlays/dogfooding/bec.yaml
@@ -1,0 +1,12 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: tekton-results-api
+  namespace: tekton-pipelines
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /
+    # This currently points to the prometheus port as a very rough
+    # health check to determine whether the server is alive.
+    port: 8080

--- a/tekton/cd/results/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/results/overlays/dogfooding/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- service.yaml
+resources:
+- ingress.yaml
+- bec.yaml

--- a/tekton/cd/results/overlays/dogfooding/service.yaml
+++ b/tekton/cd/results/overlays/dogfooding/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/backend-config: '{"default": "tekton-results-api"}'
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
+  name: tekton-results-api-service
+  namespace: tekton-pipelines


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds GCP annotions to configure the GCP load balancer for use with gRPC +
a BackendConfig for configuring the load balancer health checks so that
traffic can be successfully routed to the backend.

The BackendConfig uses the prometheus port as a quick and dirty
mechanism to check whether the pod is alive. This can be replaced with a
more comprehensive health check later if needed.

https://medium.com/google-cloud/gke-grpc-ingress-loadbalancing-4b9cdbc09758
was used as a model for many of these configuration settings.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._