### PR TITLE
Increase Dashboard nightly timeout to 1h30m

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -6,6 +6,8 @@
       metadata:
         generateName: dashboard-release-nightly-
       spec:
+        timeouts:
+          pipeline: "1h30m"
         pipelineRef:
           name: dashboard-release
         params:


### PR DESCRIPTION
# Changes

I noticed that the dashboard nightly has timed out at 1h a few times now.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._