### PR TITLE
Add nightly e2e dashboard test for ppc64le

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -29,6 +29,7 @@ Secrets which have been applied to the dogfooding cluster but are not committed 
     - `registry-credentials` used to access registry on remote machine
     - `registry-certificate` self-signed certificate for registry on remote machine
     - `ppc64le-cluster` headless service & endpoint to resolve remote machine address
+    - `ppc64le-k8s-ssh` used to ssh access ppc64le remote machine
 - `GCP` secrets:
   - `nightly-account` is used by nightly releases to push releases
   to the nightly bucket. It's a token for service account

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly dashboard e2e tests on ppc64le hardware.

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "dashboard"
+            - name: NAMESPACE
+              value: "bastion-p"
+            - name: REGISTRY
+              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+            - name: TARGET_ARCH
+              value: "ppc64le"
+            - name: REMOTE_SECRET_NAME
+              value: "ppc64le-k8s-ssh"
+            - name: REMOTE_HOST
+              value: "ppc64le-cluster.bastion-p.svc.cluster.local"
+            - name: REMOTE_PORT
+              value: "22"
+            - name: REMOTE_USER
+              value: "root"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-dashboard-ppc64le"

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - triggers-nightly-test
 - cli-nightly-test
 - operator-nightly-test
+- dashboard-nightly-test

--- a/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-delete-k8s-cluster-ppc64le
+spec:
+  description: Installation of k8s cluster remotely via ssh commands. Get k8s config via scp.
+  workspaces:
+  - name: k8s-shared
+    description: workspace to store k8s config file after cluster setup
+    mountPath: /root/.kube
+  - name: ssh-secret
+    description: workspace to get ssh key
+    mountPath: /root/.ssh
+  params:
+    - name: remote-host
+      type: string
+      description: Remote host to connect
+      default: "ppc64le-cluster.bastion-p.svc.cluster.local"
+    - name: remote-user
+      type: string
+      description: SSH username
+      default: root
+    - name: remote-port
+      type: string
+      description: SSH port
+      default: "22"
+    - name: action
+      type: string
+      description: create and delete actions are supported
+      default: create
+  steps:
+    - name: ssh
+      image: kroniak/ssh-client
+      script: |
+        ssh -p $(params.remote-port) -o StrictHostKeyChecking=no -o LogLevel=ERROR $(params.remote-user)@$(params.remote-host) k8smanager $(params.action)
+        if [ "$(params.action)" == "create" ]; then
+          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P $(params.remote-port) $(params.remote-user)@$(params.remote-host):/root/data/share/config $(workspaces.k8s-shared.path)/config
+        fi

--- a/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - test_tekton_component.yaml
 - cleanup_tekton.yaml
 - test_tekton_cli.yaml
+- k8s_cluster_setup.yaml

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -1,0 +1,201 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-dashboard-nightly-test-ppc64le
+spec:
+  params:
+  - name: containerRegistry
+  - name: targetArch
+  - name: namespace
+  - name: remoteHost
+  - name: remotePort
+  - name: remoteUser
+  - name: remoteSecret
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-dashboard-$(tt.params.targetArch)-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      timeout: 2h
+      workspaces:
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 4Gi
+      # this workspace will be used to store ssh key
+      - name: ssh-secret
+        secret:
+          secretName: $(tt.params.remoteSecret)
+          items:
+          - key: privatekey
+            path: id_rsa
+            # yamllint disable rule:octal-values
+            mode: 0600
+            # yamllint enable
+      # this workspace will be used to store registry credentials
+      - name: registry-credentials
+        secret:
+          secretName: registry-credentials
+      # this workspace will be used to store registry self-signed certificate
+      - name: registry-certificate
+        secret:
+          secretName: registry-certificate
+      pipelineSpec:
+        workspaces:
+        - name: shared-workspace
+        - name: ssh-secret
+        - name: registry-credentials
+        - name: registry-certificate
+        params:
+        - name: container-registry
+        - name: target-arch
+        - name: remote-host
+        - name: remote-port
+        - name: remote-user
+        tasks:
+        - name: git-clone-dashboard
+          taskRef:
+            name: git-clone
+          params:
+          - name: url
+            value: https://github.com/tektoncd/dashboard
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/dashboard
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: create-k8s-cluster
+          runAfter: [git-clone-dashboard]
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+        - name: e2e-test-dashboard
+          runAfter: [create-k8s-cluster]
+          taskSpec:
+            params:
+            - name: container-registry
+            - name: target-arch
+            - name: remote-host
+            workspaces:
+            - name: k8s-shared
+              description: workspace for k8s config, configuration file is expected to have `config` name
+              mountPath: /root/.kube
+            - name: registry-credentials
+              description: workspace to get registry credentials
+              mountPath: /root/.docker
+            - name: registry-certificate
+              description: workspace to get registry self-signed certificate
+              mountPath: /opt/ssl/certs
+            - name: source-code
+              description: workspace with source code for tekton component
+            steps:
+            - name: run-e2e-tests
+              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              workingdir: $(workspaces.source-code.path)/src/github.com/tektoncd/dashboard
+              env:
+              - name: GOPATH
+                value: /workspace
+              - name: KUBECONFIG
+                value: $(workspaces.k8s-shared.path)/config
+              - name: PLATFORM
+                value: linux/$(params.target-arch)
+              - name: KO_DOCKER_REPO
+                value: $(params.container-registry)
+              - name: REPO_ROOT_DIR
+                value: $(workspaces.source-code.path)/src/github.com/tektoncd/dashboard
+              - name: LOCAL_RUN
+                value: "0"
+              - name: SKIP_BUILD_TEST
+                value: "true"
+              - name: SSL_CERT_FILE
+                value: /opt/ssl/certs/registry.crt
+              command:
+              - /bin/bash
+              args:
+              - -ce
+              - |
+                ./test/presubmit-tests.sh --integration-tests
+          params:
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+          - name: remote-host
+            value: $(params.remote-host)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: registry-credentials
+            workspace: registry-credentials
+          - name: registry-certificate
+            workspace: registry-certificate
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+        finally:
+        - name: delete-k8s-cluster
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+          - name: action
+            value: delete
+      params:
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: target-arch
+        value: $(tt.params.targetArch)
+      - name: remote-host
+        value: $(tt.params.remoteHost)
+      - name: remote-port
+        value: $(tt.params.remotePort)
+      - name: remote-user
+        value: $(tt.params.remoteUser)

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -113,6 +113,18 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-operator-nightly-test-ppc64le
+  - name: dashboard-nightly-test-trigger-ppc64le
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'dashboard' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 'ppc64le'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-dashboard-nightly-test-ppc64le
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - triggers-deploy-test-ppc64le-template.yaml
 - cli-deploy-test-ppc64le-template.yaml
 - operator-deploy-test-ppc64le-template.yaml
+- dashboard-deploy-test-ppc64le-template.yaml


### PR DESCRIPTION
- Add ssh secret details to docs.
- Update nightly-test EventListener to include dashboard test for ppc64le architecture.
- Add TriggerTemplate for nightly dashboard test on ppc64le.
- Add cronjob to trigger nightly ppc64le dashboard test.
- Add tasks to create/delete ppc64le k8s cluster on remote hardware.

Signed-off-by: Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._