### PR TITLE
Fix the check-pr-kind CI job by restoring HOME

### DIFF
--- a/tekton/ci/jobs/tasks.yaml
+++ b/tekton/ci/jobs/tasks.yaml
@@ -83,6 +83,10 @@ spec:
   - name: label-config-v2
     configMap:
       name: label-config-v2
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
   steps:
   - name: install-pyyaml
     image: python:3-alpine


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `kind-label` task is used in the check pr kind label CI job.
It used to rely on the HOME variable being set by Tekton.
From release v0.24.x the default changed and now the HOME variable
is not set anymore by Tekton, so fixing the task to work with
the new default.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug