### PR TITLE
Change mount location for ppc64le nightly tests

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/deploy_tekton_pipeline.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/deploy_tekton_pipeline.yaml
@@ -9,7 +9,7 @@ spec:
     mountPath: /root/.kube
   - name: registry-credentials
     description: workspace to get registry credentials
-    mountPath: /tekton/home/.docker
+    mountPath: /root/.docker
   - name: registry-certificate
     description: workspace to get registry self-signed certificate
     mountPath: /opt/ssl/certs

--- a/tekton/resources/nightly-tests/bastion-p/deploy_tekton_triggers.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/deploy_tekton_triggers.yaml
@@ -9,7 +9,7 @@ spec:
     mountPath: /root/.kube
   - name: registry-credentials
     description: workspace to get registry credentials
-    mountPath: /tekton/home/.docker
+    mountPath: /root/.docker
   - name: registry-certificate
     description: workspace to get registry self-signed certificate
     mountPath: /opt/ssl/certs

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -87,7 +87,7 @@ spec:
               mountPath: /root/.kube
             - name: registry-credentials
               description: workspace to get registry credentials
-              mountPath: /tekton/home/.docker
+              mountPath: /root/.docker
             - name: registry-certificate
               description: workspace to get registry self-signed certificate
               mountPath: /opt/ssl/certs


### PR DESCRIPTION
Signed-off-by: Siddhesh Ghadi <Siddhesh.Ghadi@ibm.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

ppc64le nightly tests mount docker credentials secret to `/tekon/home/.docker`. With latest pipeline version, this fails due to change in default `disable-home-env-overwrite`. Changed mount location to `/root/.docker`.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug
cc: @afrittoli 