### PR TITLE
Stop using spec.serviceType in event listeners

### DIFF
--- a/tekton/ci/interceptors/github/examples/trigger.yaml
+++ b/tekton/ci/interceptors/github/examples/trigger.yaml
@@ -3,7 +3,9 @@ kind: EventListener
 metadata:
   name: trigger
 spec:
-  serviceType: LoadBalancer
+  resources:
+    kubernetesResource:
+      serviceType: LoadBalancer
   triggers:
     - name: trigger
       interceptors:

--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -45,7 +45,9 @@ metadata:
   name: peribolos-trigger
 spec:
   serviceAccountName: release-right-meow
-  serviceType: LoadBalancer
+  resources:
+    kubernetesResource:
+      serviceType: LoadBalancer
   triggers:
     - name: peribolos-trigger
       bindings:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Since triggers v0.14.x specs.serviceType is not supported anynore.
Use spec.resources.kubernetesResources.serviceType instead.

This fixes CD of resources which is currently blocked because of
the unsupported spec.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc