### PR TITLE
Catlin: Generate warning when using secretKeyRef in env

### DIFF
--- a/catlin/pkg/validator/task_validator.go
+++ b/catlin/pkg/validator/task_validator.go
@@ -97,6 +97,21 @@ func (t *taskValidator) validateStep(s v1beta1.Step) Result {
 		result.Error("Step %q uses image %q which must be tagged with a specific version", step, img)
 	}
 
+	// According to [CIS benchmarks](https://cloud.google.com/kubernetes-engine/docs/concepts/cis-benchmarks).
+	// > 5.4.1 Prefer using secrets as files over secrets as environment variables
+	for _, env := range s.Env {
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			continue
+		}
+		result.Warn("Step %q uses secret to populate env %q. Prefer using secrets as files over secrets as environment variables", step, env.Name)
+	}
+	for _, envFrom := range s.EnvFrom {
+		if envFrom.SecretRef == nil {
+			continue
+		}
+		result.Warn("Step %q uses secret as environment variables. Prefer using secrets as files over secrets as environment variables", step)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
According to [CIS Benchmarks][1]:

> 5.4.1 Prefer using secrets as files over secrets as environment
> variables

We should discourage the usage of secretKeyRef in step env and thus this
proposal to report warning.

See [tektoncd/catalog#717][2] as well.

[1]: https://cloud.google.com/kubernetes-engine/docs/concepts/cis-benchmarks
[2]: https://github.com/tektoncd/catalog/issues/717

# Changes

Catlin: Generate warning when using secretKeyRef in env

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)