### PR TITLE
Add platforms annotation verification to Catlin

### DIFF
--- a/catlin/README.md
+++ b/catlin/README.md
@@ -15,7 +15,7 @@ This command validates
 - If the resource is a valid Tekton Resource
 - If all mandatory fields are added to the resource file
 - If all images used in Task Spec are tagged
-
+- If platforms are specified in correct format
 ```
 catlin validate <path-to-resource-file>
 ```

--- a/catlin/pkg/consts/consts.go
+++ b/catlin/pkg/consts/consts.go
@@ -19,4 +19,5 @@ const (
 	DisplayNameAnnotation        = "tekton.dev/displayName"
 	MinPipelineVersionAnnotation = "tekton.dev/pipelines.minVersion"
 	TagsAnnotation               = "tekton.dev/tags"
+	PlatformsAnnotation          = "tekton.dev/platforms"
 )


### PR DESCRIPTION
# Changes

- Catlin shows recommendation to use platforms annotation
- Catlin checks the format of platforms specification, expecting to get "OS/ARCH" format

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._