### PR TITLE
Fix Dashboard nightly builds

### DIFF
--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -6,8 +6,7 @@
       metadata:
         generateName: dashboard-release-nightly-
       spec:
-        timeouts:
-          pipeline: "1h30m"
+        timeout: "1h30m"
         pipelineRef:
           name: dashboard-release
         params:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Revert to the older PipelineRun `timeout` field for the Dashboard
nightly release until we have the new Dashboard release pipeline or
dogfooding is updated to Pipelines 0.25 or later with support for the
new `timeouts` field.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._