### PR TITLE
Add HOME env to create-release-draft step template

### DIFF
--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -38,6 +38,8 @@ spec:
           secretKeyRef:
             name: github-token
             key: GITHUB_TOKEN
+      - name: HOME
+        value: /tekton/home
       - name: VERSION
         value: $(params.release-tag)
       - name: PROJECT


### PR DESCRIPTION
Fix https://github.com/tektoncd/triggers/issues/1145

From release v0.24.x the default changed and now the HOME variable
is not set anymore by Tekton, so fixing the task to work with
the new default.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._