### PR TITLE
Add SYSTEM_NAMESPACE env variable to fix cli tests for Z and Power

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
@@ -38,6 +38,8 @@ spec:
       value: $(workspaces.source-code.path)/src/$(params.package)/tkn
     - name: TEST_CLUSTERTASK_LIST_EMPTY
       value: "yes"
+    - name: SYSTEM_NAMESPACE
+      value: tekton-pipelines
     command:
     - /bin/bash
     args:

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
@@ -38,6 +38,8 @@ spec:
       value: $(workspaces.source-code.path)/src/$(params.package)/tkn
     - name: TEST_CLUSTERTASK_LIST_EMPTY
       value: "yes"
+    - name: SYSTEM_NAMESPACE
+      value: tekton-pipelines
     command:
     - /bin/bash
     args:


### PR DESCRIPTION
# Changes

With the recent [commit](https://github.com/tektoncd/cli/pull/1419) to cli test code, SYSTEM_NAMESPACE env variable
is expected to be set. The fix is provided for Z and Power setups.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._