### PR TITLE
community#418: Add org.yaml peribolos validation 🧙

### DIFF
--- a/tekton/ci-workspace/community/template.yaml
+++ b/tekton/ci-workspace/community/template.yaml
@@ -73,3 +73,43 @@ spec:
           value: $(tt.params.gitHubCommand)
         - name: teps-folder
           value: teps
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: pull-community-org-validation-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/kind: ci
+        tekton.dev/check-name: pull-community-org-validation
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+        tekton.dev/gitURL: "$(tt.params.gitRepository)"
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      workspaces:
+        - name: sources
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+      pipelineRef:
+        name: org-validation
+      params:
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: pullRequestBaseRef
+          value: $(tt.params.pullRequestBaseRef)
+        - name: gitRepository
+          value: "$(tt.params.gitRepository)"
+        - name: gitCloneDepth
+          value: $(tt.params.gitCloneDepth)
+        - name: fileFilterRegex
+          value: "org/**"
+        - name: checkName
+          value: pull-community-org-validation
+        - name: gitHubCommand
+          value: $(tt.params.gitHubCommand)

--- a/tekton/ci-workspace/jobs/kustomization.yaml
+++ b/tekton/ci-workspace/jobs/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - tekton-image-build.yaml
 - tekton-docs-reviews.yaml
 - tekton-catalog-catlin-lint.yaml
+- tekton-org-validation.yaml

--- a/tekton/ci-workspace/jobs/tekton-org-validation.yaml
+++ b/tekton/ci-workspace/jobs/tekton-org-validation.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: peribolos-dry-run
+spec:
+  params:
+  - name: configPath
+    default: org/org.yaml
+  resources:
+    inputs:
+      - name: repo
+        type: git
+  steps:
+  - name: peribolos
+    image: gcr.io/k8s-prow/peribolos:v20201110-efa5cb6a5e
+    command:
+    - /bin/sh
+    args:
+    - -c
+    - |
+      set -ex
+      /peribolos -config-path /workspace/repo/$(params.configPath) -fix-org -fix-org-members -fix-teams -fix-team-repos -fix-team-members -github-token-path /etc/github/bot-token
+    volumeMounts:
+    - name: github-oauth
+      mountPath: /etc/github
+  volumes:
+  - name: github-oauth
+    secret:
+      secretName: bot-token-github
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: org-validation
+  namespace: tektonci
+spec:
+  params:
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+    - name: pullRequestBaseRef
+      description: The pull request base branch
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: fileFilterRegex
+      description: Names regex to be matched in the list of modified files
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+  workspaces:
+    - name: sources
+      description: Workspace where the git repo is prepared for testing
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: mode
+          value: "merge"
+        - name: revision
+          value: $(params.pullRequestBaseRef)
+        - name: refspec
+          value: refs/heads/$(params.pullRequestBaseRef):refs/heads/$(params.pullRequestBaseRef)
+        - name: batchedRefs
+          value: "refs/pull/$(params.pullRequestNumber)/head"
+      workspaces:
+        - name: output
+          workspace: sources
+    - name: check-name-matches
+      taskRef:
+        name: check-name-matches
+      params:
+        - name: gitHubCommand
+          value: $(params.gitHubCommand)
+        - name: checkName
+          value: $(params.checkName)
+    - name: check-git-files-changed
+      runAfter: ['clone-repo']
+      taskRef:
+        name: check-git-files-changed
+      params:
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+        - name: regex
+          value: $(params.fileFilterRegex)
+      workspaces:
+        - name: input
+          workspace: sources
+    - name: org-validation
+      when:  # implicit dependency on the check tasks
+        - input: $(tasks.check-name-matches.results.check)
+          operator: in
+          values: ["passed"]
+        - input: $(tasks.check-git-files-changed.results.check)
+          operator: in
+          values: ["passed"]
+      workspaces:
+        - name: input
+          workspace: sources
+      taskRef:
+        name: peribolos-dry-run


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a pull-community-org-validation job on tektoncd/community
repository that will run peribolos in *dry-run* (not actually updating
the github org) to validate that the file is ok.

Should help keeping the file correct overtime 😛 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @sbwsg @nikhil-thomas 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._