### PR TITLE
Update peribolos-dry-run task to use workspaces

### DIFF
--- a/tekton/ci-workspace/jobs/tekton-org-validation.yaml
+++ b/tekton/ci-workspace/jobs/tekton-org-validation.yaml
@@ -7,10 +7,8 @@ spec:
   params:
   - name: configPath
     default: org/org.yaml
-  resources:
-    inputs:
-      - name: repo
-        type: git
+  workspaces:
+    - name: input
   steps:
   - name: peribolos
     image: gcr.io/k8s-prow/peribolos:v20201110-efa5cb6a5e
@@ -20,7 +18,7 @@ spec:
     - -c
     - |
       set -ex
-      /peribolos -config-path /workspace/repo/$(params.configPath) -fix-org -fix-org-members -fix-teams -fix-team-repos -fix-team-members -github-token-path /etc/github/bot-token
+      /peribolos -config-path /workspace/input/$(params.configPath) -fix-org -fix-org-members -fix-teams -fix-team-repos -fix-team-members -github-token-path /etc/github/bot-token
     volumeMounts:
     - name: github-oauth
       mountPath: /etc/github


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Issue
CI job failing  with below error 
```
invalid input resources for task peribolos-dry-run: Task's declared required resources are missing from the TaskRun: [repo]
```
# Changes

Updated `peribolos-dry-run` task to use workspaces instead of input resources.

Verified by updating `peribolos-dry-run` task on dogfooding cluster 
https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-ci/pipelineruns/pull-community-org-validation-9jxvj?pipelineTask=clone-repo&step=clone

/cc @vdemeester

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._