### PR TITLE
Update yamllint to not use resources 🤩

### DIFF
--- a/tekton/ci/jobs/conditions.yaml
+++ b/tekton/ci/jobs/conditions.yaml
@@ -62,3 +62,68 @@ spec:
       REGEX="$(echo $(params.gitHubCommand) | awk '{ print $2}')"
       [[ "$REGEX" == "" ]] && REGEX='.*'
       echo "$(params.checkName)" | grep -E "$REGEX"
+---
+# These tasks replace the above conditions with Tasks that have results which can be used in when expressions
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: check-git-files-changed
+  namespace: tektonci
+  annotations:
+    description: |
+      Returns the number of files (matching the regex) that have changed in the provided git repo
+spec:
+  params:
+    - name: gitCloneDepth
+      description: Number of commits + 1
+    - name: regex
+      description: Regular expression to match files changed
+  workspaces:
+    - name: source
+  results:
+    - name: numFilesChanged
+      description: |
+        Contains the number of files that have changed in the last N commits from
+        the revision of the git repo that is available in the source workspace
+  steps:
+    - name: count-files
+      image: alpine/git
+      script: |
+        set -o pipefail
+
+        BACK="HEAD~$(( $(params.gitCloneDepth) - 1 ))"
+
+        cd $(workspaces.source.path)
+        git diff-tree --no-commit-id --name-only -r HEAD $BACK | \
+            grep -E '$(params.regex)' | \
+            wc -l | \
+            tr -d '\n' | \
+            tee $(results.numFilesChanged.path)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: extract-check-from-command
+  namespace: tektonci
+  annotations:
+    description: |
+      Extracts the name of the CI Job (GitHub Check) from the specified command.
+      If no command is specified, .* is returned to indicate all checks should be run.
+      This is assumed to filtered earlier on such that only commands that start with /test
+      will be processed this way.
+spec:
+  params:
+    - name: gitHubCommand
+      description: The whole comment left on GitHub
+  results:
+    - name: check
+      description: The extracted check or .* for all checks
+  steps:
+    - name: extract-command
+      image: alpine
+      script: |
+        set -o pipefail
+
+        COMMAND="$(echo $(params.gitHubCommand) | awk '{ print $2}')"
+        [[ "$COMMAND" == "" ]] && COMMAND='.*'
+        printf "$COMMAND" > $(results.check.path)

--- a/tekton/ci/jobs/tasks.yaml
+++ b/tekton/ci/jobs/tasks.yaml
@@ -55,14 +55,12 @@ spec:
   params:
   - name: folders
     description: The folders to lint with yamllint
-  resources:
-    inputs:
-      - name: source
-        type: git
+  workspaces:
+    - name: source
   steps:
   - name: lint
     image: gcr.io/tekton-releases/dogfooding/yamllint:latest
-    workingDir: $(resources.inputs.source.path)
+    workingDir: $(workspaces.source.path)
     script: |
       #!/bin/sh
       set -ex

--- a/tekton/ci/jobs/tekton-yamllint.yaml
+++ b/tekton/ci/jobs/tekton-yamllint.yaml
@@ -5,43 +5,70 @@ metadata:
   namespace: tektonci
 spec:
   params:
-    - name: gitCloneDepth
-      description: Number of commits in the change + 1
-    - name: fileFilterRegex
-      description: Names regex to be matched in the list of modified files
-    - name: checkName
-      description: The name of the GitHub check that this pipeline is used for
-    - name: gitHubCommand
-      description: The command that was used to trigger testing
-    - name: folders
-      description: The folders to lint with yamllint
-  resources:
-    - name: source
-      type: git
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: gitCloneDepth
+    description: Number of commits in the change + 1
+  - name: fileFilterRegex
+    description: Names regex to be matched in the list of modified files
+  - name: checkName
+    description: The name of the GitHub check that this pipeline is used for
+  - name: gitHubCommand
+    description: The command that was used to trigger testing
+  - name: folders
+    description: The folders to lint with yamllint
+  workspaces:
+  - name: source
   tasks:
+  - name: extract-check-from-command
+    taskRef:
+      name: extract-check-from-command
+    params:
+    - name: gitHubCommand
+      value: $(params.gitHubCommand)
+  - name: git-clone
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: $(params.gitRepository)
+    - name: revision
+      value: $(params.gitRevision)
+    - name: depth
+      value: $(params.gitCloneDepth)
+    workspaces:
+    - name: output
+      workspace: source
+  - name: check-git-files-changed
+    runAfter: [git-clone] # expects source to be populated by git-clone (TEP-0063)
+    taskRef:
+      name: check-git-files-changed
+    params:
+    - name: gitCloneDepth
+      value: $(params.gitCloneDepth)
+    - name: regex
+      value: $(params.fileFilterRegex)
+    workspaces:
+    - name: source
+      workspace: source
   - name: lint
-    conditions:
-    - conditionRef: "check-git-files-changed"
-      params:
-      - name: gitCloneDepth
-        value: $(params.gitCloneDepth)
-      - name: regex
-        value: $(params.fileFilterRegex)
-      resources:
-      - name: source
-        resource: source
-    - conditionRef: "check-name-matches"
-      params:
-      - name: gitHubCommand
-        value: $(params.gitHubCommand)
-      - name: checkName
-        value: $(params.checkName)
+    when:
+    - input: "$(tasks.check-git-files-changed.results.numFilesChanged)"
+      operator: notin
+      values: ["0"]
+    - input: "$(tasks.extract-check-from-command.results.check)"
+      operator: in
+      values:
+      - "$(params.checkName)" # When it is explicitly run
+      - ".*"                  # When all checks are run
+      - ""                    # In cases triggered not by specific github comments
     taskRef:
       name: yamllint
     params:
     - name: folders
       value: $(params.folders)
-    resources:
-      inputs:
+    workspaces:
       - name: source
-        resource: source
+        workspace: source

--- a/tekton/ci/templates/plumbing-template.yaml
+++ b/tekton/ci/templates/plumbing-template.yaml
@@ -45,6 +45,10 @@ spec:
       pipelineRef:
         name: tekton-yamllint
       params:
+        - name: gitRepository
+          value: $(tt.params.gitRepository)
+        - name: gitRevision
+          value: $(tt.params.gitRevision)
         - name: pullRequestNumber
           value: $(tt.params.pullRequestNumber)
         - name: gitCloneDepth
@@ -57,17 +61,15 @@ spec:
           value: $(tt.params.gitHubCommand)
         - name: folders
           value: bots/buildcaptain/config bots/mariobot/config pipelinerun-logs/config boskos gubernator prow robocat tekton
-      resources:
-      - name: source
-        resourceSpec:
-          type: git
-          params:
-          - name: revision
-            value: $(tt.params.gitRevision)
-          - name: url
-            value: $(tt.params.gitRepository)
-          - name: depth
-            value: $(tt.params.gitCloneDepth)
+      workspaces:
+        - name: source
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:


### PR DESCRIPTION
# Changes

As part of TEP-0074 (https://github.com/tektoncd/community/pull/480) I'm
trying to update some of the plumbing use of PipelineResources to not
use them anymore.

I picked this yamllint pipeline as a simple example; I thought I'd need
the experimental pipeline to taskrun controller, but in this case
conditions are in the mix - when expressions are the way to update those
but they aren't supported in the pipeline to taskrun controller yet.
Also the original version would run 3 separate pods, and each would
separately clone the git resource. So in this updated version, even
though it will run 4 separate pods, it will only clone the git repo once
which seems like an optimization. And once we support when expressions
in the pipeline to taskrun controller (seems like it could be easy
enough? they execute sequentially after all!) this could all happen in
one pod.

Anyway this seems like an okay first step; next I'll tackle something
that can use the experimental pipeline to taskrun controller.

I tested this by setting up my own eventlistener with the same bindings
and trigger template on my own repo and it seems to work - I didn't have
all of the event triggering setup tho so the real test will be live :D

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._