### PR TITLE
Fix ko-gcloud build

### DIFF
--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -27,6 +27,7 @@ ENV GO111MODULE on
 RUN go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4
 
 FROM google/cloud-sdk:296.0.0-alpine
+ARG GO_VERSION
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 # Install golang


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
An `ARG` declared before a `FROM` is outside of a build stage, so it can’t be
used in any instruction after a `FROM`. To use the default value of an `ARG`
declared before the first `FROM` use an `ARG` instruction without a value
inside of a build stage.

https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

This meant that we were failing to download and extract the go tarball as the GO_VERSION
was unset:
```
INFO[0731] RUN tar -C /usr/local -xzf go${GO_VERSION}.tar.gz 
INFO[0731] cmd: /bin/sh                                 
INFO[0731] args: [-c tar -C /usr/local -xzf go${GO_VERSION}.tar.gz] 
tar: invalid magic
tar: short read
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._