### PR TITLE
Add option to build multi-arch images using ko tool

### DIFF
--- a/tekton/resources/images/docker-multi-arch-template.yaml
+++ b/tekton/resources/images/docker-multi-arch-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: build-and-push-image-multi-arch
+  name: docker-build-and-push-image-multi-arch
 spec:
   params:
   - name: gitRepository

--- a/tekton/resources/images/eventlistener.yaml
+++ b/tekton/resources/images/eventlistener.yaml
@@ -15,14 +15,29 @@ spec:
         - ref: trigger-to-build-and-push-image
       template:
         ref: build-and-push-image
-    - name: multi-arch-build-trigger
+    - name: docker-multi-arch-build-trigger
       interceptors:
         - cel:
             filter: >-
               'platforms' in body &&
-              size(body['platforms']) != 0
+              size(body['platforms']) != 0 &&
+              'buildType' in body &&
+              body['buildType'] == 'docker'
       bindings:
         - ref: trigger-to-build-and-push-image
         - ref: trigger-to-build-and-push-image-platform
       template:
-        ref: build-and-push-image-multi-arch
+        ref: docker-build-and-push-image-multi-arch
+    - name: ko-multi-arch-build-trigger
+      interceptors:
+        - cel:
+            filter: >-
+              'platforms' in body &&
+              size(body['platforms']) != 0 &&
+              'buildType' in body &&
+              body['buildType'] == 'ko'
+      bindings:
+        - ref: trigger-to-build-and-push-image
+        - ref: trigger-to-build-and-push-image-platform
+      template:
+        ref: ko-build-and-push-image-multi-arch

--- a/tekton/resources/images/ko-multi-arch-template.yaml
+++ b/tekton/resources/images/ko-multi-arch-template.yaml
@@ -1,0 +1,71 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: ko-build-and-push-image-multi-arch
+spec:
+  params:
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: contextPath
+    description: The path to the context within 'gitRepository'
+  - name: registry
+    description: The container registry *registry*/namespace/name tag
+  - name: namespace
+    description: The namespace (aka user, org, project) registry/*namespace*/name tag
+  - name: imageName
+    description: The image name (aka repository) registry/namespace/*name* tag
+  - name: imageTag
+    description: The image tag registry/namespace/name *tag*
+  - name: buildUUID
+    description: The build UUID is used for log collection
+  - name: platforms
+    description: Platforms for multi-arch build in form of `linux/amd64,linux/s390x`
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      generateName: build-and-push-$(tt.params.imageName)-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        plumbing.tekton.dev/image: $(tt.params.imageName)
+    spec:
+      taskSpec:
+        resources:
+          inputs:
+            - name: source
+              type: git
+        steps:
+        - env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /secret/release.json
+          - name: KO_DOCKER_REPO
+            value: $(tt.params.registry)/$(tt.params.namespace)
+          image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+          name: build-image-multi-arch
+          script: |
+            #!/usr/bin/env sh
+
+            gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+            gcloud auth configure-docker
+
+            cd $(resources.inputs.source.path)
+            ko publish --platform $(tt.params.platforms) --base-import-paths --tags $(tt.params.imageTag) $(tt.params.contextPath)
+          volumeMounts:
+          - mountPath: /secret
+            name: gcp-secret
+        volumes:
+        - name: gcp-secret
+          secret:
+            secretName: release-secret
+      resources:
+        inputs:
+          - name: source
+            resourceSpec:
+              type: git
+              params:
+              - name: revision
+                value: $(tt.params.gitRevision)
+              - name: url
+                value: https://$(tt.params.gitRepository)

--- a/tekton/resources/images/kustomization.yaml
+++ b/tekton/resources/images/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - bindings.yaml
 - single-arch-template.yaml
 - eventlistener.yaml
-- multi-arch-template.yaml
+- docker-multi-arch-template.yaml
+- ko-multi-arch-template.yaml


### PR DESCRIPTION
# Changes

At this moment `docker buildx` is used to build multi-arch images. In some cases `ko` tool can better fit to the multi-arch building process.
Proposed extension adds new template to run multi-arch image build using `ko` tool, when buildType parameter in payload is equal to `ko`. Docker build is done when buildType parameter us equal to `docker`.
If `platform`s parameter is not specified at all, standard single image build for `linux/amd64` is done.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._