### PR TITLE
Use bundle for git-clone to fix yamllint pipeline 🙃

### DIFF
--- a/tekton/ci/jobs/tekton-yamllint.yaml
+++ b/tekton/ci/jobs/tekton-yamllint.yaml
@@ -31,6 +31,7 @@ spec:
   - name: git-clone
     taskRef:
       name: git-clone
+      bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
     params:
     - name: url
       value: $(params.gitRepository)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This was overlooked during yaml migration PR and this is blocking PRs
in plumbing. This should get fixed.

Note: this works because oci bundle are enabled in our dogfooding cluster(s).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._