### PR TITLE
Bump golangci-lint to v1.42.0.

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -169,7 +169,7 @@ RUN GO111MODULE="off" go get github.com/google/licenseclassifier && \
     GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
-ARG GOLANGCI_VERSION=1.39.0
+ARG GOLANGCI_VERSION=v1.42.0
 RUN curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
 
 # Install Kustomize:


### PR DESCRIPTION
# Changes

This updates the version of golangci-lint installed in our presubmit images.

This accompanies https://github.com/tektoncd/pipeline/pull/4206, which should make
tests pass for tektoncd/pipeline with this update.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._