### PR TITLE
results dogfooding: Use external DNS hostname in watcher.

### DIFF
--- a/tekton/cd/results/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/results/overlays/dogfooding/kustomization.yaml
@@ -2,6 +2,7 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - service.yaml
+- watcher.yaml
 resources:
 - ingress.yaml
 - bec.yaml

--- a/tekton/cd/results/overlays/dogfooding/watcher.yaml
+++ b/tekton/cd/results/overlays/dogfooding/watcher.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-watcher
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+        - name: tekton-results-watcher
+          args:
+            [
+              "-api_addr",
+              "dns:///results.dogfooding.tekton.dev",
+              "-auth_mode",
+              "token",
+            ]


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


# Changes

Since the API service is configured with the SSL cert for
`results.dogfooding.tekton.dev`, the watcher is unable to connect to the
API via the internal service hostname. This changes the watcher to use
the external hostname so that the SSL cert validation succeeds and we
can successfully connect.

We cannot terminate TLS at the ingress, since gRPC requires encrypted
connections when used with credentials. A potential alternative would be to set
up a different SSL cert for the internal host, but I'm not sure
that gives us significant added benefit over using the external hostname.

Fixes https://github.com/tektoncd/results/issues/131

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._