### PR TITLE
Record that Alan Greene has access to our clusters 📝

### DIFF
--- a/bots/buildcaptain/README.md
+++ b/bots/buildcaptain/README.md
@@ -16,9 +16,10 @@ Current build captains are:
 - Vincent Demeester @vdemeester (vdemeest)
 
 Other folks who are not build captains but have build captain access:
-- Piyush Garg @piyush-garg
-- Priti Desai @pritidesai
-- Priya Wadhwa @priyawadhwa
+- Piyush Garg @piyush-garg (for maintaining the Hub in dogfooding)
+- Priti Desai @pritidesai (for Pipelines releases)
+- Priya Wadhwa @priyawadhwa (for Chains releases)
+- Alan Greene @AlanGreene (for Dashboard releases)
 
 Build captain access is given with [adjustpermissions.py](../../adjustpermissions.py).
 


### PR DESCRIPTION
# Changes

I used the adjustpermissions.py script to give @AlanGreene access to our
clusters for creating Dashboards releases.

(When we re-create these projects
(https://github.com/tektoncd/plumbing/issues/865) we might revisit how
we give out these permissions and make it more reliable and less just
based on me running a script XD)

I also added reasons to other non-build-captain folks who have access.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._