### PR TITLE
Add tekton-results-viewer service account.

### DIFF
--- a/tekton/cd/results/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/results/overlays/dogfooding/kustomization.yaml
@@ -6,3 +6,4 @@ patchesStrategicMerge:
 resources:
 - ingress.yaml
 - bec.yaml
+- rbac.yaml

--- a/tekton/cd/results/overlays/dogfooding/rbac.yaml
+++ b/tekton/cd/results/overlays/dogfooding/rbac.yaml
@@ -1,0 +1,22 @@
+# Viewer service account for Results API.
+# While we could grant access to individual human users, we're not 100%
+# confident this is a good idea yet. This is a workaround to let users
+# who have access to the cluster to get the token for this user, which
+# will be scoped to have minimal RO permissions for result resources.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-results-viewer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-results-viewer
+subjects:
+- kind: ServiceAccount
+  name: tekton-results-viewer
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: tekton-results-readonly
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

While we could grant access to individual human users, we're not 100%
confident this is a good idea yet (since we'd need users to pass a valid
GCP credential). This is a workaround to let users
who have access to the cluster to get the token for this user, which
is scoped to have minimal RO permissions for result resources.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._