### PR TITLE
Build multi-arch go-rest-api-test image

### DIFF
--- a/tekton/cronjobs/README.md
+++ b/tekton/cronjobs/README.md
@@ -213,11 +213,13 @@ spec:
               value: tekton/images/myimage
 ```
 
-4. Add PLATFORMS to `cronjob.yaml` if you want to build multi-arch image. List target architectures for the image.
+4. Add PLATFORMS and BUILD_TYPE to `cronjob.yaml` if you want to build multi-arch image. List target architectures for the image. For BUILD_TYPE use [docker](../resources/images/docker-multi-arch-template.yaml) or [ko](../resources/images/ko-multi-arch-template.yaml) value to choose the image build tool.
 ```
 ...
             - name: PLATFORMS
               value: "linux/amd64,linux/s390x,linux/ppc64le"
+            - name: BUILD_TYPE
+              value: docker
 ```
 **Note**
 Please, make sure that the image is buildable for listed architectures. For instance, base image in corresponding Dockerfile should support the same(or larger) list of architectures.

--- a/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
+++ b/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
@@ -65,7 +65,8 @@ spec:
                   "namespace": "$NAMESPACE",
                   "imageName": "$IMAGE",
                   "imageTag": "$TAG",
-                  "platforms": "$PLATFORMS"
+                  "platforms": "$PLATFORMS",
+                  "buildType": "$BUILD_TYPE"
                 }
                 EOF
                 curl -d @/workspace/post-body.json $SINK_URL
@@ -82,5 +83,7 @@ spec:
               - name: TARGET_IMAGE
                 value: "gcr.io/tekton-releases/dogfooding/myimage:latest"
               - name: PLATFORMS
+                value: ""
+              - name: BUILD_TYPE
                 value: ""
           restartPolicy: Never

--- a/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/cronjob.yaml
@@ -22,5 +22,7 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
             - name: CONTEXT_PATH
               value: tekton/images/alpine-git-nonroot
+            - name: BUILD_TYPE
+              value: docker
             - name: PLATFORMS
               value: "linux/amd64,linux/s390x,linux/ppc64le"

--- a/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/README.md
@@ -1,0 +1,2 @@
+Cron Job to build a container image with `go-rest-api-test` installed.
+The image is published daily to [gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest](gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest).

--- a/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/cronjob.yaml
@@ -15,14 +15,14 @@ spec:
             - name: SINK_URL
               value: el-image-builder.default.svc.cluster.local:8080
             - name: GIT_REPOSITORY
-              value: github.com/tektoncd/plumbing
+              value: github.com/chmouel/go-rest-api-test
             - name: GIT_REVISION
-              value: main
+              value: master
             - name: TARGET_IMAGE
-              value: gcr.io/tekton-releases/dogfooding/koparse:latest
+              value: gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest
             - name: CONTEXT_PATH
-              value: tekton/images/koparse
+              value: .
             - name: BUILD_TYPE
-              value: docker
+              value: ko
             - name: PLATFORMS
-              value: "linux/amd64,linux/s390x,linux/ppc64le"
+              value: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"

--- a/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/image-build
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-go-rest-api-test"

--- a/tekton/cronjobs/dogfooding/images/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - teps-community-nightly
 - catlin-nightly
 - kind-nightly
+- go-rest-api-test-nightly

--- a/tekton/cronjobs/dogfooding/images/skopeo-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/skopeo-nightly/cronjob.yaml
@@ -22,5 +22,7 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/skopeo:latest
             - name: CONTEXT_PATH
               value: tekton/images/skopeo
+            - name: BUILD_TYPE
+              value: docker
             - name: PLATFORMS
               value: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"

--- a/tekton/cronjobs/dogfooding/images/teps-community-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/teps-community-nightly/cronjob.yaml
@@ -22,5 +22,7 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/teps:latest
             - name: CONTEXT_PATH
               value: teps/tools
+            - name: BUILD_TYPE
+              value: docker
             - name: PLATFORMS
               value: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"

--- a/tekton/cronjobs/dogfooding/images/tkn-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/tkn-nightly/cronjob.yaml
@@ -22,5 +22,7 @@ spec:
               value: gcr.io/tekton-releases/dogfooding/tkn:latest
             - name: CONTEXT_PATH
               value: tekton/images/tkn
+            - name: BUILD_TYPE
+              value: docker
             - name: PLATFORMS
               value: "linux/amd64,linux/s390x,linux/ppc64le"


### PR DESCRIPTION
# Changes

`go-rest-api-test` image is used in many Tekton catalog tests. To be able to run the same tests for different architectures, the image should be multi-arch one.
To build the multi-arch image new nightly cronjob is introduced.

Also 2 values for `build type` parameter of multi-arch image build are introduced - `docker` and `ko` to specify which tool to use for the build. From eventlistener side both types are already supported.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._