### PR TITLE
Update ko to v0.9.2

### DIFF
--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOROOT /usr/local/go
 
 # Install ko
-ARG KO_VERSION=0.9.1
+ARG KO_VERSION=0.9.2
 RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 

--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -18,7 +18,7 @@ ENV GOROOT /usr/local/go
 RUN apk add --no-cache curl ca-certificates
 RUN update-ca-certificates
 
-ARG KO_VERSION=0.9.1
+ARG KO_VERSION=0.9.2
 RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -156,7 +156,7 @@ RUN apt update && apt install -y uuid-runtime  # for uuidgen
 RUN apt update && apt install -y rubygems  # for mdl
 
 # Install ko
-ARG KO_VERSION=0.9.1
+ARG KO_VERSION=0.9.2
 RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 


### PR DESCRIPTION
v0.9.2 fixes a regression introduced in v0.9.1 where the built
entrypoint binary would not be correctly added to PATH. Users who
invoked a ko-built container with cmd:my-app would see failures, while
users who invoked with cmd:/ko-app/my-app would not. This is fixed in
v0.9.2.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._