### PR TITLE
Update the hacktoberfest label to 2021

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -162,7 +162,7 @@ default:
       addedBy: anyone
     - color: 8F0891
       name: hacktoberfest-accepted
-      description: Categorizes issue or PR as one for Hacktoberfest 2020
+      description: Categorizes issue or PR as one for Hacktoberfest 2021
       target: both
       prowPlugin: label
       addedBy: humans


### PR DESCRIPTION
Set the description for the label to 2021 instead of 2020.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc