### PR TITLE
Use GitHub Token Preset for Lifecycle Automation

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1313,6 +1313,8 @@ periodics:
       - name: TEST_RUN_ALL_TESTS
         value: "true"
 - name: periodic-tekton-stale
+  labels:
+    preset-github-token: "true"
   interval: 1h
   decorate: true
   spec:
@@ -1341,14 +1343,9 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
-      volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
-    volumes:
-      - name: github-token
-        secret:
-          secretName: oauth-token
 - name: periodic-tekton-rotten
+  labels:
+    preset-github-token: "true"
   interval: 1h
   decorate: true
   spec:
@@ -1377,14 +1374,9 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
-      volumeMounts:
-        - name: github-token
-          mountPath: /etc/github-token
-    volumes:
-      - name: github-token
-        secret:
-          secretName: oauth-token
 - name: periodic-tekton-close
+  labels:
+    preset-github-token: "true"
   interval: 1h
   decorate: true
   spec:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

We introduced presets in https://github.com/tektoncd/plumbing/pull/454 to remove duplication in jobs - including one for jobs that need the github token

However, we haven't updated the issues and pull requests lifecycle automation jobs to use that preset

In this change, we reuse the github token preset

Moreover, we're seeing the lifecycle automation jobs failing due to permissions issues so eliminating this as a possible cause

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._