### PR TITLE
cmd/combine: emit built image with digest

### DIFF
--- a/cmd/combine/main.go
+++ b/cmd/combine/main.go
@@ -110,11 +110,18 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(string(b))
+	log.Println("Pushing manifest:", string(b))
 
 	log.Println("pushing...")
 	if err := remote.WriteIndex(dstr, dsti, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
 		log.Fatalf("pushing %q: %v", dst, err)
 	}
 	log.Println("pushed")
+
+	d, err := dsti.Digest()
+	if err != nil {
+		log.Fatalf("digest: %v", err)
+	}
+
+	fmt.Print(dstr.Context().Digest(d.String()))
 }


### PR DESCRIPTION
Having it print the full manifest bytes to stdout makes it harder to
consume in the pipeline release process. Instead, log the manifest bytes
to stderr, and print the pushed index reference@digest to stdout.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/assign @vdemeester 