### PR TITLE
Use latest prow commenter plugin ✨

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1319,7 +1319,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200727-9592e624ac
+    - image: gcr.io/k8s-prow/commenter:v20211013-66c01a3f21
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -1350,7 +1350,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200727-9592e624ac
+    - image: gcr.io/k8s-prow/commenter:v20211013-66c01a3f21
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -1381,7 +1381,7 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200727-9592e624ac
+    - image: gcr.io/k8s-prow/commenter:v20211013-66c01a3f21
       command:
       - /app/robots/commenter/app.binary
       args:


### PR DESCRIPTION
# Changes

The commenter plugin hasn't been working for a while.
[This fix to the commenter plugin](https://github.com/kubernetes/test-infra/pull/22922)
was in July, which lines up with some of the last instances of this
plugin working being around June (e.g.
https://github.com/tektoncd/plumbing/issues/701#issuecomment-864452674),
and it mentions not being able to handle searches that use `\n` as
separators. Unfortunately it doesn't mention the specific error, but in
the logs for the failed run we can see that our search includes `\n` so
maybe this is the issue we're hitting.

Either way pulling in the latest version of the commenter plugin feels
like it might address this and can't hurt (unless the interface changed
haha...).

Fixes #903

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._