### PR TITLE
Update single arch build template not to use PipelineResources ✨

### DIFF
--- a/tekton/resources/images/single-arch-template.yaml
+++ b/tekton/resources/images/single-arch-template.yaml
@@ -1,3 +1,68 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: "single-arch-build-and-push"
+spec:
+  params:
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitRevision
+      description: The Git revision to be used.
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: imageUrl
+      description: The url to push the built image to
+    - name: contextPath
+      description: Path to the context in the repo to use when building the image
+  workspaces:
+    - name: source
+    - name: secret
+  tasks:
+    - name: git-clone
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: revision
+          value: $(params.gitRevision)
+        - name: depth
+          value: $(params.gitCloneDepth)
+      workspaces:
+        - name: output
+          workspace: source
+    - name: build-and-push
+      runAfter: [git-clone]
+      params:
+        - name: contextPath
+          value: $(params.contextPath)
+        - name: imageUrl
+          value: $(params.imageUrl)
+      workspaces:
+        - name: source
+          workspace: source
+        - name: secret
+          workspace: secret
+      taskSpec:
+        params:
+          - name: contextPath
+          - name: imageUrl
+        workspaces:
+          - name: source
+          - name: secret
+        steps:
+          - name: build-and-push
+            workingdir: $(workspaces.source.path)
+            image: gcr.io/kaniko-project/executor:v0.13.0
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: $(workspaces.secret.path)/release.json
+            command:
+              - /kaniko/executor
+              - --dockerfile=Dockerfile
+              - --context=$(params.contextPath)
+              - --destination=$(params.imageUrl)
+---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
@@ -22,54 +87,35 @@ spec:
     description: The build UUID is used for log collection
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
       generateName: build-and-push-$(tt.params.imageName)-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         plumbing.tekton.dev/image: $(tt.params.imageName)
     spec:
-      taskSpec:
-        resources:
-          inputs:
-            - name: source
-              type: git
-          outputs:
-            - name: image
-              type: image
-        steps:
-        - name: build-and-push
-          workingdir: $(resources.inputs.source.path)
-          image: gcr.io/kaniko-project/executor:v0.13.0
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /secret/release.json
-          command:
-          - /kaniko/executor
-          - --dockerfile=Dockerfile
-          - --context=$(tt.params.contextPath)
-          - --destination=$(resources.outputs.image.url)
-          volumeMounts:
-            - name: gcp-secret
-              mountPath: /secret
-        volumes:
-          - name: gcp-secret
-            secret:
-              secretName: release-secret
-      resources:
-        inputs:
-          - name: source
-            resourceSpec:
-              type: git
-              params:
-              - name: revision
-                value: $(tt.params.gitRevision)
-              - name: url
-                value: https://$(tt.params.gitRepository)
-        outputs:
-          - name: image
-            resourceSpec:
-              type: image
-              params:
-              - name: url
-                value: $(tt.params.registry)/$(tt.params.namespace)/$(tt.params.imageName):$(tt.params.imageTag)
+      pipelineRef:
+        name: single-arch-build-and-push
+      workspaces:
+      - name: source
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+      - name: secret
+        secret:
+          secretName: release-secret
+      params:
+        - name: contextPath
+          value: $(tt.params.contextPath)
+        - name: gitRepository
+          value: "https://$(tt.params.gitRepository)"
+        - name: gitRevision
+          value: $(tt.params.gitRevision)
+        - name: gitCloneDepth
+          value: "2"
+        - name: imageUrl
+          value: "$(tt.params.registry)/$(tt.params.namespace)/$(tt.params.imageName):$(tt.params.imageTag)"


### PR DESCRIPTION
# Changes

As part of TEP-0074 (tektoncd/community#480) I'm trying to update some of
the plumbing use of PipelineResources to not use them anymore - and even
further I want to start dogfooding [the experimental pipeline to taskrun custom task](https://github.com/tektoncd/experimental/tree/main/pipeline-to-taskrun).
So to that end I've found a candiate Task that was using
PipelineResources and I've converted it to use a Pipeline instead. I've
also been able to run this successfully as a single pod on my own
cluster so once I have the pipeline to taskrun controller installed in
dogfooding I can come back and update this to run as a pod as well!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._