### PR TITLE
Add nightly builds for pipeline-to-taskrun 🌙

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - add-team-members-nightly
 - operator-nightly
 - wait-task-nightly
+- pipeline-to-taskrun-nightly

--- a/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/README.md
@@ -1,0 +1,2 @@
+Cron Job to trigger the [Pipeline to TaskRun](https://github.com/tektoncd/experimental/tree/main/pipeline-to-taskrun) nightly build.
+Results are published to https://storage.cloud.google.com/tekton-releases-nightly/pipeline-to-taskrun/latest/release.yaml

--- a/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-cron-trigger
+spec:
+  schedule: "30 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: PROJECT_NAME
+                value: pipeline-to-taskrun
+          initContainers:
+          - name: git
+            env:
+              - name: GIT_REPO
+                value: github.com/tektoncd/experimental

--- a/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/release
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-pipeline-to-taskrun-nightly-release"

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
 - overlays/add-team-members
 - overlays/operator
 - overlays/wait-task
+- overlays/pipeline-to-taskrun

--- a/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/kustomization.yaml
@@ -1,0 +1,18 @@
+namePrefix: pipeline-to-taskrun-
+bases:
+  - ../../base
+patchesJson6902:
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: TriggerTemplate
+      name: template
+    path: template.yaml
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: Trigger
+      name: nightly
+    path: trigger.yaml
+resources:
+  - github.com/tektoncd/experimental/pipeline-to-taskrun/tekton/?ref=main

--- a/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/template.yaml
@@ -1,0 +1,35 @@
+- op: add
+  path: /spec/resourcetemplates
+  value:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: pipeline-to-taskrun-release-nightly-
+      spec:
+        pipelineRef:
+          name: release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: gitRevision
+          value: $(tt.params.gitrevision)
+        - name: imageRegistry
+          value: $(tt.params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(tt.params.imageRegistryPath)
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        - name: serviceAccountPath
+          value: release.json
+        workspaces:
+          - name: workarea
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: release-secret
+            secret:
+              secretName: release-secret

--- a/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/trigger.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/trigger.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/interceptors
+  value:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+          body.params.release.projectName == 'pipeline-to-taskrun'


### PR DESCRIPTION
# Changes


In order to start dogfooding the pipeline to taskrun (aka pipeline in a
pod light) custom task, I'd like to start making nightly releases of it.

I copied what was setup for task-loops.

This change depends on https://github.com/tektoncd/experimental/pull/803

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._