### PR TITLE
Add yq to test-runner image

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -187,6 +187,11 @@ RUN gem install mdl -v 0.5.0
 # Extra tools through pip
 RUN python -m pip install yamllint
 
+# Install yq
+ARG YQ_VERSION=4.13.4
+RUN wget https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -O /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq
+
 COPY --from=kubetest /go/bin/kubetest /usr/local/bin
 
 # note the runner is also responsible for making docker in docker function if


### PR DESCRIPTION
# Changes

`yq` is going to be used for catalog tests and it makes sense to have it in test-runner image rather than download for every test run.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._