### PR TITLE
Automate Pull Request Checklist - Check Tasks Completed

### DIFF
--- a/tekton/ci/README.md
+++ b/tekton/ci/README.md
@@ -343,6 +343,7 @@ spec:
     - ref: tekton-ci-webhook-pull-request
     - ref: tekton-ci-webhook-pr-labels
     - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-pr-body
   template:
     ref: tekton-plumbing-ci-pipeline
 ```
@@ -366,6 +367,7 @@ spec:
     - ref: tekton-ci-webhook-comment
     - ref: tekton-ci-clone-depth
     - ref: tekton-ci-webhook-issue-labels
+    - ref: tekton-ci-webhook-pr-body
   template:
     ref: tekton-plumbing-ci-pipeline
 ```

--- a/tekton/ci/jobs/kustomization.yaml
+++ b/tekton/ci/jobs/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - tekton-kind-label.yaml
 - tekton-golang-lint.yaml
 - tekton-yamllint.yaml
+- tekton-github-tasks-completed.yaml

--- a/tekton/ci/jobs/tekton-github-tasks-completed.yaml
+++ b/tekton/ci/jobs/tekton-github-tasks-completed.yaml
@@ -1,0 +1,70 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-tasks-completed
+  namespace: tektonci
+  description: |
+    Verifies that a PR has all the tasks completed. A task is considered to be any part of the text that looks like a github markdown checkbox ("- []").
+spec:
+  params:
+    - name: body
+      description: The body of the Pull Request
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
+      - name: PULL_REQUEST_BODY
+        value: $(params.body)
+  steps:
+    - name: install-pyyaml
+      image: python:3-alpine
+      script: |
+        pip install pyyaml --user
+    - name: check-github-tasks-completed
+      image: python:3-alpine
+      script: |
+        #!/usr/bin/env python
+        import sys
+        prBodyText = os.getenv('PULL_REQUEST_BODY')
+        incompleteTasks = prBodyText.count("\n- []")
+        if incompleteTasks > 0:
+          msg = "Error: {} incomplete GitHub Tasks found, expecting no incomplete GitHub Tasks".format(incompleteTasks)
+          print(msg)
+          # TODO (jerop): comment out in a follow up PR
+          # Check failed. Return exit code 1.
+          # sys.exit(1)
+        else:
+          print("Found no incomplete GitHub Tasks)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tekton-github-tasks-completed
+  namespace: tektonci
+spec:
+  params:
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+    - name: body
+      description: The body of the Pull Request
+  tasks:
+    - name: check-name-matches
+      taskRef:
+        name: check-name-matches
+      params:
+        - name: gitHubCommand
+          value: $(params.gitHubCommand)
+        - name: checkName
+          value: $(params.checkName)
+    - name: github-tasks-completed
+      taskRef:
+        name: github-tasks-completed
+      when:
+      - input: $(tasks.check-name-matches.results.check)
+        operator: in
+        values: ["passed"]
+      params:
+        - name: body
+          value: $(params.body)

--- a/tekton/ci/shared/bindings.yaml
+++ b/tekton/ci/shared/bindings.yaml
@@ -85,3 +85,13 @@ spec:
   params:
   - name: labels
     value: $(body.issue.labels)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-webhook-pr-body
+  namespace: tektonci
+spec:
+  params:
+    - name: body
+      value: $(body.pull_request.body)

--- a/tekton/ci/shared/template.yaml
+++ b/tekton/ci/shared/template.yaml
@@ -126,3 +126,57 @@ spec:
           value: check-pr-has-kind-label
         - name: gitHubCommand
           value: $(tt.params.gitHubCommand)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: check-github-tasks-completed
+  annotations:
+    triggers.tekton.dev/old-escape-quotes: "true"
+spec:
+  params:
+  - name: buildUUID
+    description: UUID used to track a CI Pipeline Run in logs
+  - name: package
+    description: org/repo
+  - name: pullRequestNumber
+    description: The pullRequestNumber
+  - name: pullRequestUrl
+    description: The HTML URL for the pull request
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: gitCloneDepth
+    description: Number of commits in the change + 1
+  - name: gitHubCommand
+    description: |
+      The GitHub command that was used a trigger. This is only available when
+      this template is triggered by a comment. The default value is for the
+      case of a pull_request event.
+    default: ""
+  - name: body
+    description: The body of the Pull Request
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: check-github-tasks-completed-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/check-name: check-github-tasks-completed
+        tekton.dev/kind: ci
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+        tekton.dev/gitURL: "$(tt.params.gitRepository)"
+    spec:
+      pipelineRef:
+        name: tekton-github-tasks-completed
+      params:
+        - name: body
+          value: $(tt.params.body)
+        - name: checkName
+          value: check-github-tasks-completed
+        - name: gitHubCommand
+          value: $(tt.params.gitHubCommand)

--- a/tekton/ci/shared/trigger.yaml
+++ b/tekton/ci/shared/trigger.yaml
@@ -66,3 +66,53 @@ spec:
     - ref: tekton-ci-webhook-issue-labels
   template:
     ref: label-check
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: pull-request-check-github-tasks-completed
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub']
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-pull-request
+    - ref: tekton-ci-webhook-pr-body
+  template:
+    ref: check-github-tasks-completed
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: comment-check-github-tasks-completed
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub']
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-comment
+    - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-pr-body
+  template:
+    ref: check-github-tasks-completed


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

As described in https://github.com/tektoncd/plumbing/issues/910, we have a submitter checklists in pull requests that 
enforce with our standards.

Currently, maintainers and reviewers have to manually check that the
submitter checklist has been checked off and verify each item in the
list. If the submitter checklist has not been checked off, they need
to follow up with the user and request them to follow the standards
and check them off.

In this change, we add automation that checks that the checklist has
been checked off. If there's an incomplete item, the check reports that
there are incomplete tasks but does not fail yet. In a future change, we
will make the check fail if the submitter checklist is not checked off.
We hope that enforcing checking off the submitter checklist will encourage
contributors to look into our standards and apply them to their
contributions.

The implementation is modeled after the check-kind-label job.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._