### PR TITLE
Shorten cron name so it'll actually apply ✂️

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/kustomization.yaml
@@ -2,4 +2,4 @@ bases:
 - ../../../bases/release
 patchesStrategicMerge:
 - cronjob.yaml
-nameSuffix: "-pipeline-to-taskrun-nightly-release"
+nameSuffix: "-pipeline-to-tr-nightly-release"


### PR DESCRIPTION
# Changes

After merging https://github.com/tektoncd/plumbing/pull/908 I realized I
needed to manually apply the new cronjob. When I manually applied the
cron I got:

```
The CronJob "nightly-cron-trigger-pipeline-to-taskrun-nightly-release" is invalid: metadata.name: Invalid value: "nightly-cron-trigger-pipeline-to-taskrun-nightly-release": must be no more than 52 characters
```

The name was 57 characters XD So I've removed some and applied it

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._