### PR TITLE
Add cronjobs to the dashboard

### DIFF
--- a/tekton/cd/dashboard/overlays/dogfooding/extensions.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/extensions.yaml
@@ -1,0 +1,33 @@
+apiVersion: dashboard.tekton.dev/v1alpha1
+kind: Extension
+metadata:
+  name: cronjobs
+  namespace: tekton-pipelines
+spec:
+  apiVersion: batch/v1beta1
+  name: cronjobs
+  displayname: k8s cronjobs
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-cronjobs-extension
+  labels:
+    rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"
+rules:
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-dashboard-cronjobs-extension
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-dashboard-cronjobs-extension
+  apiGroup: rbac.authorization.k8s.io

--- a/tekton/cd/dashboard/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/kustomization.yaml
@@ -4,3 +4,4 @@ patchesStrategicMerge:
 - tekton-dashboard-service.yaml
 resources:
 - ingress.yaml
+- extensions.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Use the dashboard extensions capability to display cronjobs available
in the dogfooding cluster via the dashboard.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc