### PR TITLE
Fix Dockrefile for test-runner image

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -169,7 +169,7 @@ RUN GO111MODULE="off" go get github.com/google/licenseclassifier && \
     GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
-ARG GOLANGCI_VERSION=v1.42.0
+ARG GOLANGCI_VERSION=1.42.0
 RUN curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
 
 # Install Kustomize:


### PR DESCRIPTION
# Changes

Currently test-runner image build is failing (see the last [build](https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns/build-and-push-test-runner-wwspm?pipelineTask=build-and-push&step=build-and-push) ) because `GOLANGCI_VERSION` env variable is specified with `v<version>` in Dockerfile. The download URL expects just `<version>` though. As a result the link is not correct and attempt to download golangci archive fails.
The fix just removes `v` from `GOLANGCI_VERSION` env variable.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._