### PR TITLE
Pin ko to 0.8.3

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -156,7 +156,7 @@ RUN apt update && apt install -y uuid-runtime  # for uuidgen
 RUN apt update && apt install -y rubygems  # for mdl
 
 # Install ko
-ARG KO_VERSION=0.9.2
+ARG KO_VERSION=0.8.3
 RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Pipeline's TestYaml integration test uses `ko create` to deploy and run
yamls. There was a small bug in `ko create` that lead to it running `kubectl
apply` instead of `kubectl create` behind the scenes and in turn this
lead to TestYaml failing.

This commit pins `ko` to 0.8.3 in the `test-runner` image to get integration
moving again and we can pin to the new version of `ko` when it's released with
the fix.

Edit:

Here's an example PR with failed integration: https://github.com/tektoncd/pipeline/pull/4345
Here's the fix: https://github.com/google/ko/pull/494

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._