### PR TITLE
Match iterator TaskLoop variable to match kaniko param

### DIFF
--- a/tekton/ci-workspace/jobs/tekton-image-build.yaml
+++ b/tekton/ci-workspace/jobs/tekton-image-build.yaml
@@ -57,7 +57,7 @@ kind: TaskLoop
 metadata:
   name: image-build
 spec:
-  iterateParam: context
+  iterateParam: CONTEXT
   taskRef:
     name: kaniko4ci
 ---


### PR DESCRIPTION
# Changes

The param that TaskLoop attempts to iterate on when releasing new plumbing
images is named context but the kaniko4ci task exposes a param named CONTEXT.

It looks like this was a source of failure during last nights plumbing-image-build
(PipelineRun [plumbing-image-build-jcqhr](https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-ci/pipelineruns/plumbing-image-build-jcqhr?pipelineTask=clone-repo&step=clone) in dogfooding).

This commit updates the param TaskLoop is looking for from context to CONTEXT.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._