### PR TITLE
Add diff-task job

### DIFF
--- a/tekton/ci-workspace/catalog/template.yaml
+++ b/tekton/ci-workspace/catalog/template.yaml
@@ -6,8 +6,6 @@ spec:
   params:
     - name: buildUUID
       description: UUID used to track a CI Pipeline Run in logs
-    - name: package
-      description: org/repo
     - name: pullRequestNumber
       description: The pullRequestNumber
     - name: pullRequestUrl
@@ -71,3 +69,59 @@ spec:
             value: $(tt.params.pullRequestBaseRef)
           - name: gitRepository
             value: "$(tt.params.gitRepository)"
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-catalog-diff-task-template
+spec:
+  params:
+    - name: buildUUID
+      description: UUID used to track a CI Pipeline Run in logs
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+    - name: pullRequestUrl
+      description: The HTML URL for the pull request
+    - name: pullRequestBaseRef
+      description: |
+        The base git ref for the pull request. This is the branch the
+        pull request would merge onto once approved.
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitRevision
+      description: The Git revision to be used.
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: pull-catalog-diff-task-run-
+        labels:
+          prow.k8s.io/build-id: $(tt.params.buildUUID)
+          tekton.dev/kind: ci
+          tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+        annotations:
+          tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+          tekton.dev/gitURL: "$(tt.params.gitRepository)"
+      spec:
+        serviceAccountName: tekton-ci-jobs
+        pipelineRef:
+          name: diff-task-job
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+        params:
+          - name: pullRequestUrl
+            value: $(tt.params.pullRequestUrl)
+          - name: pullRequestNumber
+            value: $(tt.params.pullRequestNumber)
+          - name: pullRequestBaseRef
+            value: $(tt.params.pullRequestBaseRef)
+          - name: gitRepository
+            value: "$(tt.params.gitRepository)"
+---

--- a/tekton/ci-workspace/catalog/trigger.yaml
+++ b/tekton/ci-workspace/catalog/trigger.yaml
@@ -65,3 +65,70 @@ spec:
     - ref: tekton-ci-webhook-issue-labels
   template:
     ref: tekton-catalog-ci-pipeline
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: catalog-pull-request-diff-task
+spec:
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - pull_request
+    - cel:
+        filter: >-
+          body.repository.full_name == 'tektoncd/catalog' &&
+          body.action in ['opened','synchronize']
+        overlays:
+          - key: git_clone_depth
+            expression: "string(body.pull_request.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-pull-request
+    - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-pr-labels
+  template:
+    ref: tekton-catalog-diff-task-template
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: catalog-issue-comment-diff-task
+spec:
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - issue_comment
+    - cel:
+        filter: >-
+          body.repository.full_name == 'tektoncd/catalog' &&
+          body.action == 'created' &&
+          'pull_request' in body.issue &&
+          body.issue.state == 'open' &&
+          body.comment.body.matches('^/diff-task')
+        overlays:
+          - key: add_pr_body.pull_request_url
+            expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tektonci
+    - cel:
+        overlays:
+          - key: git_clone_depth
+            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-comment
+    - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-issue-labels
+  template:
+    ref: tekton-catalog-diff-task-template

--- a/tekton/ci-workspace/jobs/tekton-catalog-diff-task.yaml
+++ b/tekton/ci-workspace/jobs/tekton-catalog-diff-task.yaml
@@ -1,0 +1,110 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: diff-task-job
+spec:
+  workspaces:
+    - name: source
+      description: Workspace where the git repo is prepared for linting.
+  params:
+    - name: pullRequestUrl
+      description: The HTML URL for the pull request
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: pullRequestBaseRef
+      description: The pull request base branch
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-clone
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: revision
+          value: $(params.pullRequestBaseRef)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: get-task-diff
+      runAfter:
+        - clone-repo
+      taskRef:
+        name: git-cli
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-cli:0.3
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: GIT_SCRIPT
+          value: |
+            # This needs to be set or the pipeline will fail on the next task.
+            echo -n "" > $(results.commit.path)
+
+            temp_branch="temp-branch-pr-$(params.pullRequestNumber)"
+            git fetch origin pull/$(params.pullRequestNumber)/head:${temp_branch}
+            git checkout ${temp_branch}
+
+            changed_task_version=$(git diff-tree --no-commit-id --name-only -r \
+                          $(git rev-parse --abbrev-ref HEAD)|grep '^task/'| \
+                          sed 's,\([^/]*/[^/]*/[^/]*\).*,\1,'|sort -u)
+
+            if [[ -z ${changed_task_version} ]];then
+                echo "Not a commit with a change in task"
+                exit 0
+            fi
+
+            check_if_task_version_on_main=$(git ls-tree -r origin/$(params.pullRequestBaseRef) --name-only ${changed_task_version} || true)
+            if [[ -n "${check_if_task_version_on_main}" ]];then
+                echo "Not a new version, since '${changed_task_version}' is already in main"
+                exit 0
+            fi
+
+            if [[ $(basename ${changed_task_version}) == 0.1 ]];then
+                echo "New task 0.1, skipping the diff"
+                exit 0
+            fi
+
+            task_name=$(basename $(dirname ${changed_task_version}))
+            task_version=$(basename ${changed_task_version})
+
+            previous_task_version=$(find task/${task_name} -maxdepth 1 -regex '.*/[0-9]\.[0-9]$' \! -name "${task_version}" |sort -run|head -1 | cut -d "/" -f3)
+
+            (
+                echo "<details><summary>Diff between version ${previous_task_version} and ${task_version}</summary>"
+                echo
+                echo "\`\`\`\`diff"
+                git diff --no-index task/${task_name}/${previous_task_version} task/${task_name}/${task_version}
+                echo "\`\`\`\`"
+                echo
+                echo "</details>"
+            ) | tee diff-task-results.txt > /dev/null
+
+    - name: post-comment
+      runAfter:
+        - get-task-diff
+      when:
+        - input: $(tasks.get-task-diff.results.commit)
+          operator: notin
+          values: [""]
+      taskRef:
+        name: github-add-comment
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.3
+      params:
+        - name: COMMENT_OR_FILE
+          value: diff-task-results.txt
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token
+        - name: REQUEST_URL
+          value: $(params.pullRequestUrl)
+      workspaces:
+        - name: comment-file
+          workspace: source


### PR DESCRIPTION
This job will run in the catalog repo and compare the previous version of tasks with the new one and post a
diff to the PR thread.
It incorporates the script of @chmouel https://github.com/tektoncd/catalog/blob/main/hack/diff-task-version for a very large part.
Closes #704 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._