### PR TITLE
Setup e2e tests on kind

### DIFF
--- a/tekton/ci-workspace/jobs/e2e-kind.yaml
+++ b/tekton/ci-workspace/jobs/e2e-kind.yaml
@@ -1,0 +1,186 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kind-e2e
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Kubernetes
+    tekton.dev/displayName: "kind"
+    tekton.dev/tags: "kind"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    Sets up and executes commands in KinD (Kubernetes in Docker) environment.
+
+    See https://kind.sigs.k8s.io for more details.
+  params:
+    - name: arguments
+      type: array
+      description: args to pass to the kind script
+  workspaces:
+    - name: source
+  steps:
+    - image: gcr.io/tekton-releases/dogfooding/kind-e2e:latest
+      imagePullPolicy: Always
+      workingDir: $(workspaces.source.path)
+      name: kind
+      volumeMounts:
+        - mountPath: /var/run/
+          name: dind-socket
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      args: ["$(params.arguments[*])"]
+  sidecars:
+    - image: docker:20.10.11-dind
+      name: dind-sidecar
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /var/lib/docker
+          name: dind-storage
+        - mountPath: /var/run/
+          name: dind-socket
+      readinessProbe:
+        exec:
+          command:
+          - docker
+          - ps
+        initialDelaySeconds: 5
+        periodSeconds: 5
+  volumes:
+    - name: dind-storage
+      emptyDir: {}
+    - name: dind-socket
+      emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kind-e2e
+  annotations:
+    description: |
+      Run e2e tests on a kind cluster on k8s
+spec:
+  params:
+    - name: pullRequestNumber
+      description: The pullRequestNumber
+    - name: pullRequestBaseRef
+      description: The pull request base branch
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+    - name: gitCloneDepth
+      description: Number of commits in the change + 1
+    - name: fileFilterRegex
+      description: Names regex to be matched in the list of modified files
+    - name: checkName
+      description: The name of the GitHub check that this pipeline is used for
+    - name: gitHubCommand
+      description: The command that was used to trigger testing
+    - name: k8s-version
+      type: string
+      description: The version of k8s (v1.20.x, v1.21.x or v1.22.x)
+    - name: e2e-script
+      type: string
+      description: the path to the e2e script in the sources
+      default: "test/e2e-tests.sh"
+    - name: e2e-env
+      type: string
+      description: |
+        the path to an env file that is loaded before the execution
+        of the e2e-script
+      default: ""
+  workspaces:
+    - name: sources
+      description: Workspace where the git repo is prepared for testing
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-batch-merge
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: mode
+          value: "merge"
+        - name: revision
+          value: $(params.pullRequestBaseRef)
+        - name: refspec
+          value: refs/heads/$(params.pullRequestBaseRef):refs/heads/$(params.pullRequestBaseRef)
+        - name: batchedRefs
+          value: "refs/pull/$(params.pullRequestNumber)/head"
+      workspaces:
+        - name: output
+          workspace: sources
+    - name: check-name-matches
+      taskRef:
+        name: check-name-matches
+      params:
+        - name: gitHubCommand
+          value: $(params.gitHubCommand)
+        - name: checkName
+          value: $(params.checkName)
+    - name: check-git-files-changed
+      runAfter: ['clone-repo']
+      taskRef:
+        name: check-git-files-changed
+      params:
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+        - name: regex
+          value: $(params.fileFilterRegex)
+      workspaces:
+        - name: input
+          workspace: sources
+    - name: e2e-tests
+      when: # implicit dependency on the check tasks
+      - input: $(tasks.check-name-matches.results.check)
+        operator: in
+        values: ["passed"]
+      - input: $(tasks.check-git-files-changed.results.check)
+        operator: in
+        values: ["passed"]
+      taskRef:
+        name: kind-e2e
+      params:
+      - name: arguments
+        value:
+          - --k8s-version
+          - "$(params.k8s-version)"
+          - --cluster-suffix
+          - "$(params.pullRequestNumber)"
+          - --nodes
+          - "3"
+          - --e2e-script
+          - "$(params.e2e-script)"
+          - --e2e-env
+          - "$(params.e2e-env)"
+      workspaces:
+        - name: source
+          workspace: sources

--- a/tekton/ci-workspace/jobs/kustomization.yaml
+++ b/tekton/ci-workspace/jobs/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - tekton-org-validation.yaml
 - tekton-python-unit-tests.yaml
 - tekton-catalog-diff-task.yaml
+- e2e-kind.yaml

--- a/tekton/ci-workspace/kustomization.yaml
+++ b/tekton/ci-workspace/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - plumbing
 - catalog
 - website
+- pipeline

--- a/tekton/ci-workspace/pipeline/kustomization.yaml
+++ b/tekton/ci-workspace/pipeline/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- template.yaml
+- trigger.yaml

--- a/tekton/ci-workspace/pipeline/template.yaml
+++ b/tekton/ci-workspace/pipeline/template.yaml
@@ -1,0 +1,79 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-pipeline-ci-pipeline
+spec:
+  params:
+  - name: buildUUID
+    description: UUID used to track a CI Pipeline Run in logs
+  - name: package
+    description: org/repo
+  - name: pullRequestNumber
+    description: The pullRequestNumber
+  - name: pullRequestUrl
+    description: The HTML URL for the pull request
+  - name: pullRequestBaseRef
+    description: |
+      The base git ref for the pull request. This is the branch the
+      pull request would merge onto once approved.
+  - name: gitRepository
+    description: The git repository that hosts context and Dockerfile
+  - name: gitRevision
+    description: The Git revision to be used.
+  - name: gitCloneDepth
+    description: Number of commits in the change + 1
+  - name: gitHubCommand
+    description: |
+      The GitHub command that was used a trigger. This is only available when
+      this template is triggered by a comment. The default value is for the
+      case of a pull_request event.
+    default: ""
+  - name: labels
+    description: List of labels currently on the Pull Request
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: pull-pipeline-kind-k8s-v1-20-e2e-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/kind: ci
+        tekton.dev/check-name: pull-pipeline-kind-k8s-v1-20-e2e
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+        tekton.dev/gitURL: "$(tt.params.gitRepository)"
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      workspaces:
+        - name: sources
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+      pipelineRef:
+        name: kind-e2e
+      params:
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: pullRequestBaseRef
+          value: $(tt.params.pullRequestBaseRef)
+        - name: gitRepository
+          value: "$(tt.params.gitRepository)"
+        - name: gitCloneDepth
+          value: $(tt.params.gitCloneDepth)
+        - name: fileFilterRegex
+          value: "*"
+        - name: checkName
+          value: pull-pipeline-kind-k8s-v1-20-e2e
+        - name: gitHubCommand
+          value: $(tt.params.gitHubCommand)
+        - name: k8s-version
+          value: v1.20.x
+        - name: e2e-script
+          value: test/e2e-kind.sh
+        - name: e2e-env
+          value: test/e2e-tests-kind.env

--- a/tekton/ci-workspace/pipeline/trigger.yaml
+++ b/tekton/ci-workspace/pipeline/trigger.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: pipeline-pull-request
+spec:
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - pull_request
+    - cel:
+        filter: >-
+          body.repository.name == 'pipeline' &&
+          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
+        overlays:
+          - key: git_clone_depth
+            expression: "string(body.pull_request.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-pull-request
+    - ref: tekton-ci-webhook-pr-labels
+    - ref: tekton-ci-clone-depth
+  template:
+    ref: tekton-pipeline-ci-pipeline
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: pipeline-issue-comment
+spec:
+  interceptors:
+    - github:
+        secretRef:
+          secretName: ci-webhook
+          secretKey: secret
+        eventTypes:
+          - issue_comment
+    - cel:
+        filter: >-
+          body.repository.name == 'pipeline' &&
+          body.action == 'created' &&
+          'pull_request' in body.issue &&
+          body.issue.state == 'open' &&
+          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tektonci
+    - cel:
+        overlays:
+          - key: git_clone_depth
+            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-comment
+    - ref: tekton-ci-clone-depth
+    - ref: tekton-ci-webhook-issue-labels
+  template:
+    ref: tekton-pipeline-ci-pipeline

--- a/tekton/ci/README.md
+++ b/tekton/ci/README.md
@@ -378,3 +378,26 @@ To react to issue comments:
       template:
         ref: tekton-plumbing-ci-pipeline
 ```
+
+### Integration Test Jobs with KinD
+
+Project who want to define an test job running that run on a KinD Kubernetes cluster.
+The [`kind-e2e` pipeline](../ci-workspace/jobs/e2e-task.yaml) defines a pipeline that
+can clones the project repo, sets up Kubernetes in a sidecar using KinD, and runs
+an executable script from the project repo. The behaviour of that script can be
+customized through environment variables stored in an `.env` file in the project repo.
+
+To run the CI job as part of the project CI, a project shall:
+
+- create the test script and `.env` file. In many cases it may be possible to re-use
+  the existing test script that is used in `Prow` based e2e tests jobs
+- add a `PipelineRun` to the project `TriggerTemplate`. The `PipelineRun` runs the
+  `kind-e2e` pipeline and passes to it the name and path of the script and `.env`
+  file (a full example is available in the [pipeline template](../ci-workspace/pipeline/template.yaml)):
+
+```yaml
+        - name: e2e-script
+          value: test/e2e-kind.sh
+        - name: e2e-env
+          value: test/e2e-tests-kind.env
+```

--- a/tekton/cronjobs/dogfooding/images/kind-e2e-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/kind-e2e-nightly/cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-build-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: el-image-builder.default.svc.cluster.local:8080
+            - name: GIT_REPOSITORY
+              value: github.com/tektoncd/plumbing
+            - name: GIT_REVISION
+              value: main
+            - name: TARGET_IMAGE
+              value: gcr.io/tekton-releases/dogfooding/kind-e2e:latest
+            - name: CONTEXT_PATH
+              value: tekton/images/kind-e2e

--- a/tekton/cronjobs/dogfooding/images/kind-e2e-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kind-e2e-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/image-build
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-kind-e2e"

--- a/tekton/cronjobs/dogfooding/images/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - catlin-nightly
 - kind-nightly
 - go-rest-api-test-nightly
+- kind-e2e-nightly

--- a/tekton/images/kind-e2e/Dockerfile
+++ b/tekton/images/kind-e2e/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runtime image for common dependencies when running kind tests.
+
+FROM golang:1.16.10-alpine
+LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
+
+WORKDIR /kind
+
+RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.6.2
+
+# common util tools
+RUN apk add --no-cache \
+  bash curl docker git jq openssl build-base
+
+# Install kubectl and make sure it's available in the PATH.
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /bin
+
+RUN curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.11.1/kind-$(uname)-amd64" && chmod +x ./kind && mv ./kind /bin
+
+COPY setup-kind.sh /usr/local/bin/kind-e2e
+
+ENTRYPOINT ["kind-e2e"]
+CMD []

--- a/tekton/images/kind-e2e/setup-kind.sh
+++ b/tekton/images/kind-e2e/setup-kind.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Attribution:
+# Adapted for Tekton from https://github.com/mattmoor/mink/blob/master/hack/setup-kind.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+# Print error message and exit 1
+# Parameters: $1..$n - error message to be displayed
+function abort() {
+  echo "error: $*"
+  exit 1
+}
+
+# Defaults
+K8S_VERSION="v1.20.x"
+REGISTRY_NAME="registry.local"
+REGISTRY_PORT="5000"
+CLUSTER_SUFFIX="cluster.local"
+NODE_COUNT="1"
+REGISTRY_AUTH="0"
+ESTARGZ_SUPPORT="0"
+E2E_SCRIPT="test/e2e-tests.sh"
+E2E_ENV=""
+
+while [[ $# -ne 0 ]]; do
+  parameter="$1"
+  case "${parameter}" in
+    --k8s-version)
+      shift
+      K8S_VERSION="$1"
+      ;;
+    --registry-url)
+      shift
+      REGISTRY_NAME="$(echo "$1" | cut -d':' -f 1)"
+      REGISTRY_PORT="$(echo "$1" | cut -d':' -f 2)"
+      ;;
+    --cluster-suffix)
+      shift
+      CLUSTER_SUFFIX="$1"
+      ;;
+    --nodes)
+      shift
+      NODE_COUNT="$1"
+      ;;
+    --authenticated-registry)
+      REGISTRY_AUTH="1"
+      ;;
+    --e2e-script)
+      shift
+      E2E_SCRIPT="$1"
+      ;;
+    --e2e-env)
+      shift
+      E2E_ENV="$1"
+      ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+
+# The version map correlated with this version of KinD
+KIND_VERSION="v0.11.1"
+case ${K8S_VERSION} in
+  v1.20.x)
+    K8S_VERSION="1.20.7"
+    KIND_IMAGE_SHA="sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.21.x)
+    K8S_VERSION="1.21.1"
+    KIND_IMAGE_SHA="sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.22.x)
+    K8S_VERSION="1.22.0"
+    KIND_IMAGE_SHA="sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  *) abort "Unsupported version: ${K8S_VERSION}" ;;
+esac
+
+#############################################################
+#
+#    Setup KinD cluster.
+#
+#############################################################
+echo '--- Setup KinD Cluster'
+
+cat > kind.yaml <<EOF
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  image: "${KIND_IMAGE}"
+EOF
+
+for i in $(seq 1 1 "${NODE_COUNT}");
+do
+  cat >> kind.yaml <<EOF
+- role: worker
+  image: "${KIND_IMAGE}"
+EOF
+done
+
+function containerd_config() {
+  # The bulk of this is to enable stargz support:
+  # https://github.com/containerd/stargz-snapshotter/blob/v0.2.0/README.md#quick-start-with-kubernetes
+  if [[ "${ESTARGZ_SUPPORT}" = "1" ]] ; then
+    cat <<EOF
+  # Plug stargz snapshotter into containerd
+  # Containerd recognizes stargz snapshotter through specified socket address.
+  # The specified address below is the default which stargz snapshotter listen to.
+  [proxy_plugins]
+    [proxy_plugins.stargz]
+      type = "snapshot"
+      address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+
+  # Use stargz snapshotter through CRI
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    snapshotter = "stargz"
+    disable_snapshot_annotations = false
+EOF
+  return
+  fi
+
+  # Default configuration
+  cat <<EOF
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    # Support many layered images: https://kubernetes.slack.com/archives/CEKK1KTN2/p1602770111199000
+    disable_snapshot_annotations = true
+EOF
+}
+
+cat >> kind.yaml <<EOF
+kubeadmConfigPatches:
+  # This is needed in order to support projected volumes with service account tokens.
+  # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+    networking:
+      dnsDomain: "${CLUSTER_SUFFIX}"
+
+  # This is needed to avoid filling our disk.
+  # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1603391142276400
+  - |
+    kind: KubeletConfiguration
+    metadata:
+      name: config
+    imageGCHighThresholdPercent: 90
+
+containerdConfigPatches:
+- |-
+$(containerd_config)
+
+  # Support a local registry
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."$REGISTRY_NAME:$REGISTRY_PORT"]
+    endpoint = ["http://$REGISTRY_NAME:$REGISTRY_PORT"]
+EOF
+
+echo '--- kind.yaml'
+cat kind.yaml
+
+# Check the version of kind
+kind --version
+
+# Check we can talk to docker
+docker ps
+
+# Create a cluster!
+kind create cluster --config kind.yaml
+
+#############################################################
+#
+#    Setup metallb
+#
+#############################################################
+echo '--- Setup metallb'
+
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+
+network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - $network.255.1-$network.255.250
+EOF
+
+#############################################################
+#
+#    Setup container registry
+#
+#############################################################
+echo '--- Setup container registry'
+
+EXTRA_ARGS=()
+if [[ "${REGISTRY_AUTH}" == "1" ]]; then
+  # Configure Auth
+  USERNAME="user-${RANDOM}"
+  PASSWORD="pass-${RANDOM}"
+
+  AUTH_DIR=$(mktemp -d)
+
+  # Docker removed htpasswd in a patch release, so pin to 2.7.0 so this works.
+  docker run \
+	 --entrypoint htpasswd \
+	 registry:2.7.0 -Bbn "${USERNAME}" "${PASSWORD}" > "${AUTH_DIR}/htpasswd"
+
+  # Run a registry protected with htpasswd
+  EXTRA_ARGS=(
+    -v "${AUTH_DIR}:/auth"
+    -e "REGISTRY_AUTH=htpasswd"
+    -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm"
+    -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd"
+  )
+
+fi
+
+docker run -d --restart=always \
+       "${EXTRA_ARGS[@]}" \
+       -p "$REGISTRY_PORT:$REGISTRY_PORT" --name "$REGISTRY_NAME" registry:2
+
+# Connect the registry to the KinD network.
+docker network connect "kind" "$REGISTRY_NAME"
+
+# Make the $REGISTRY_NAME -> 127.0.0.1, to tell `ko` to publish to
+# local reigstry, even when pushing $REGISTRY_NAME:$REGISTRY_PORT/some/image
+echo "127.0.0.1 $REGISTRY_NAME" | tee -a /etc/hosts
+
+# Create a registry-credentials secret and attach it to the list of service accounts in the namespace.
+function sa_ips() {
+  local ns="${1}"
+  shift
+
+  # Create a secret resource with the contents of the docker auth configured above.
+  kubectl -n "${ns}" create secret generic registry-credentials \
+	  --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
+	  --type=kubernetes.io/dockerconfigjson
+
+  for sa in "${@}" ; do
+    # Ensure the service account exists.
+    kubectl -n "${ns}" create serviceaccount "${sa}" || true
+
+    # Attach the secret resource to the service account in the namespace.
+    kubectl -n "${ns}" patch serviceaccount "${sa}" -p '{"imagePullSecrets": [{"name": "registry-credentials"}]}'
+  done
+}
+
+if [[ "${REGISTRY_AUTH}" == "1" ]]; then
+
+  # This will create ~/.docker/config.json
+  docker login "http://$REGISTRY_NAME:$REGISTRY_PORT/v2/" -u "${USERNAME}" -p "${PASSWORD}"
+
+  sa_ips "default" "default"
+fi
+
+export KO_DOCKER_REPO=kind.local
+
+if [[ "${E2E_SCRIPT}" == "" ]]; then
+  echo "Nothing else to do"
+  exit 0
+else
+  if [[ "${E2E_ENV}" != "" ]]; then
+    set -o allexport
+    source "${E2E_ENV}"
+    set +o allexport
+  fi
+  "${E2E_SCRIPT}"
+fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a kind-e2e container image with an embedded setup-kind script.
The kind-e2e image includes libraries need to run E2E tests.
Add a cronjob to build the image nightly.

Add a task which runs dind in a sidecar and which triggers
the setup-kind and can run a script on top of the kind cluster.

Setup a generic pipeline which clones a repo and runs the kind
tasks. The repo is used to source the test job.

Add a CI job the pipeline repo that uses the e2e-kind pipeline.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature