### PR TITLE
Upgrade golang to 1.17

### DIFF
--- a/catlin/Dockerfile
+++ b/catlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.16.3-alpine3.12 as build
+FROM docker.io/library/golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e as build
 
 COPY . /build
 WORKDIR /build

--- a/pipelinerun-logs/Dockerfile
+++ b/pipelinerun-logs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.12
+FROM golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e
 WORKDIR /go/src/pipelinerun-logs
 COPY . .
 RUN go build -o ./pipelinerun-logs ./cmd/http

--- a/tekton/images/coverage/Dockerfile
+++ b/tekton/images/coverage/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.3 as buildcoverage
+FROM golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e as buildcoverage
 RUN git clone https://github.com/knative/test-infra /go/src/knative.dev/test-infra
 RUN make -C /go/src/knative.dev/test-infra/tools/coverage
 
-FROM golang:1.16.3
+FROM golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tekton/images/kind/Dockerfile
+++ b/tekton/images/kind/Dockerfile
@@ -14,7 +14,7 @@
 
 # Runtime image for common dependencies when running kind tests.
 
-FROM golang:1.14.2-alpine
+FROM golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e
 
 WORKDIR /kind
 

--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG GO_VERSION=1.16.3
-FROM golang:${GO_VERSION}-alpine3.12 as build
+ARG GO_VERSION=1.17.6
+FROM golang:${GO_VERSION}-alpine3.15 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates

--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.16.3-alpine3.12
+FROM golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 ENV GOROOT /usr/local/go

--- a/tekton/images/kubectl/Dockerfile
+++ b/tekton/images/kubectl/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.16.3-alpine3.12 as build
+FROM golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e-alpine3.15 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build kubetest independently of the rest
-FROM docker.io/library/golang:1.16.3 as kubetest
+FROM docker.io/library/golang:1.17.6@sha256:0fa6504d3f1613f554c42131b8bf2dd1b2346fb69c2fc24a312e7cba6c87a71e as kubetest
 RUN git clone https://github.com/kubernetes/test-infra /go/src/k8s.io/test-infra
 # Using e685556b32c5fb7ab12c3277d41112d47ceac0cd because after that, the URL kubetest
 # uses needs extract credentials.
@@ -144,8 +144,8 @@ RUN ["/bin/chmod", "+x", "/workspace/get-kube.sh"]
 
 # END: test-infra import
 
-# Install Go 1.16.3
-ARG GO_VERSION=1.16.3
+# Install Go 1.17.3
+ARG GO_VERSION=1.17.3
 RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz > go${GO_VERSION}.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.tar.gz && \
     rm go${GO_VERSION}.tar.gz


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

1.17 introduced a few new changes to gofmt (see
https://go.dev/doc/go1.17#gofmt) which is causing issues with
code generation, since 1.17 is including a new style of build tags and
causing diffs (see https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_triggers/1281/pull-tekton-triggers-build-tests/1466107930725060608/ for an example)

This bumps all golang image dependencies to the latest 1.17 release. This uses tag + SHA syntax where it was easy. We should look into pinning other instances in additional PRs.

⚠️ This change will likely cause projects to start failing CI until the next PR bumps the gofmt output to 1.17.
This means we are putting an dependency on developers to start using Go 1.17.
Until then, gofmts < 1.17 will clash with this change since we do exact diff checks in verify-codegen.sh.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._