### PR TITLE
Fix operator nightly tests for s390x and ppc64le

### DIFF
--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -128,7 +128,7 @@ spec:
                 value: linux/$(params.target-arch)
               - name: KO_DOCKER_REPO
                 value: $(params.container-registry)
-              - name: E2E_DEBUG
+              - name: E2E_SKIP_CLUSTER_CREATION
                 value: "true"
               command:
               - /bin/bash

--- a/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
@@ -120,7 +120,7 @@ spec:
                 value: linux/$(params.target-arch)
               - name: KO_DOCKER_REPO
                 value: $(params.container-registry)
-              - name: E2E_DEBUG
+              - name: E2E_SKIP_CLUSTER_CREATION
                 value: "true"
               command:
               - /bin/bash


### PR DESCRIPTION
# Changes

Recently the env variable to skip cluster installation for Tekton Operator e2e tests was changed. Skip is required for Power and Z nightly tests. 
The fix does renaming of the env variable to the current correct one.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._