### PR TITLE
Rewrite MarioBot to use Pipelines and Workspaces

### DIFF
--- a/bots/mariobot/README.md
+++ b/bots/mariobot/README.md
@@ -84,6 +84,6 @@ spec:
 
 ## Configuring the GitHub secret
 
-The Mario Bot requires a GitHub Hook Secret in the environment variable `GITHUB_SECRET_TOKEN`.
+The Mario Bot requires a GitHub Hook Secret in the environment variable `token`.
 
 The bot uses [secrets in the dogfooding cluster](../README.md#dogfooding-secrets).

--- a/tekton/mario-bot/mario-github-comment.yaml
+++ b/tekton/mario-bot/mario-github-comment.yaml
@@ -5,17 +5,17 @@ metadata:
 spec:
   params:
   - name: pullRequestID
-    value: $(body.taskRun.metadata.labels.mario\.bot/pull-request-id)
-  - name: buildUUID
-    value: $(body.taskRun.metadata.labels.prow\.k8s\.io/build-id)
+    value: $(body.pull-request-id)
   - name: gitURL
-    value: $(body.taskRun.spec.resources.inputs[?(@.name == 'source')].resourceSpec.params[?(@.name == 'url')].value)
+    value: $(body.git-url)
   - name: gitRevision
-    value: $(body.taskRun.spec.resources.inputs[?(@.name == 'source')].resourceSpec.params[?(@.name == 'revision')].value)
-  - name: targetImageResourceName
-    value: $(body.taskRun.spec.resources.outputs[?(@.name == 'image')].resourceRef.name)
+    value: $(body.git-revision)
+  - name: targetImage
+    value: $(body.target-image)
   - name: passedOrFailed
-    value: $(body.taskRun.status.conditions[?(@.type == 'Succeeded')].status)
+    value: $(body.status)
+  - name: buildPipelineRun
+    value: $(body.build-pipelinerun)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: EventListener
@@ -38,121 +38,160 @@ spec:
   params:
   - name: pullRequestID
     description: The pullRequestID to comment to
-  - name: buildUUID
-    description: The buildUUID for the logs link
   - name: gitURL
     description: The URL of the git repo
-  - name: gitRevision
-    description: The git revision
-  - name: targetImageResourceName
-    description: The name of the target image pipelineresource
+  - name: targetImage
+    description: The fully qualified image target e.g. repo/name:tag
   - name: passedOrFailed
     description: Whether the triggering event was successful or not
+  - name: buildPipelineRun
+    description: The name of the image build PipelineRun for the logs link
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
       generateName: mario-comment-github-
     spec:
       serviceAccountName: mario-listener
-      taskSpec:
-        resources:
-          inputs:
-            - name: source
-              type: git
-            - name: pr
-              type: pullRequest
-          outputs:
-            - name: image
-              type: image
-            - name: pr
-              type: pullRequest
-        steps:
-        - name: copy-pr-to-output
-          image: busybox
-          script: |
-            #!/bin/sh
-            mkdir -p $(resources.outputs.pr.path)
-            cp -r $(resources.inputs.pr.path)/* $(resources.outputs.pr.path)/
-        - name: setup-comment
-          image: python:3-alpine
-          script: |
-            #!/usr/bin/env python
-            import json
-            import random
+      pipelineRef:
+        name: mario-comment-github
+      workspaces:
+      - name: pr
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 10Mi
+      params:
+      - name: pullRequestID
+        value: $(tt.params.pullRequestID)
+      - name: gitURL
+        value: $(tt.params.gitURL)
+      - name: targetImage
+        value: $(tt.params.targetImage)
+      - name: passedOrFailed
+        value: $(tt.params.passedOrFailed)
+      - name: buildPipelineRun
+        value: $(tt.params.buildPipelineRun)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: mario-comment-github
+spec:
+  params:
+  - name: pullRequestID
+  - name: gitURL
+  - name: targetImage
+  - name: passedOrFailed
+  - name: buildPipelineRun
+  workspaces:
+  - name: pr
+  tasks:
+  # TODO: Replace this task with custom interceptor that extends event payload with PR data
+  # example usage: https://github.com/tektoncd/plumbing/blob/def914a109d482355453d7f6dc766e476a371705/tekton/ci-workspace/plumbing/trigger.yaml#L48-L56
+  - name: download-pr-info
+    taskRef:
+      name: pull-request
+      bundle: gcr.io/tekton-releases/catalog/upstream/pull-request:0.1
+    workspaces:
+    - name: pr
+      workspace: pr
+    params:
+    - name: mode
+      value: download
+    - name: url
+      value: $(params.gitURL)/pull/$(params.pullRequestID)
+    - name: provider
+      value: github
+    - name: secret-key-ref
+      value: mario-github-token
+  - name: setup-comment
+    runAfter:
+    - download-pr-info
+    params:
+    - name: passedOrFailed
+      value: $(params.passedOrFailed)
+    - name: targetImage
+      value: $(params.targetImage)
+    - name: buildPipelineRun
+      value: $(params.buildPipelineRun)
+    workspaces:
+    - name: pr
+      workspace: pr
+    taskSpec:
+      params:
+      - name: passedOrFailed
+      - name: targetImage
+      - name: buildPipelineRun
+      workspaces:
+      - name: pr
+      steps:
+      - name: setup-comment
+        image: python:3-alpine
+        script: |
+          #!/usr/bin/env python
+          import json
+          import random
 
-            marios_pics_root = 'https://storage.googleapis.com/mario-bot/pics'
-            ok_pics = ['mario', 'luigi', 'tekton']
-            failed_pics = ['goomba']
-            logs_url = 'http://35.222.249.224/?buildid=%s&namespace=mario'
-            successful = ("$(tt.params.passedOrFailed)" == "True")
-            print("PassedOrFailed: {}".format("$(tt.params.passedOrFailed)"))
+          marios_pics_root = 'https://storage.googleapis.com/mario-bot/pics'
+          ok_pics = ['mario', 'luigi', 'tekton']
+          failed_pics = ['goomba']
+          logs_url = 'http://35.222.249.224/?buildid=%s&namespace=mario'
+          successful = ("$(params.passedOrFailed)" == "Succeeded")
+          print("PassedOrFailed: {}".format("$(params.passedOrFailed)"))
 
-            # Service Image
-            comment_template = (
-              '<img width="200" alt="{pic_alt}" src="{pic_src}">'
-              ' at your service! </p>'
-            )
+          # Service Image
+          comment_template = (
+          '<img width="200" alt="{pic_alt}" src="{pic_src}">'
+          ' at your service! </p>'
+          )
 
-            if successful:
-              chosen_pic = random.choice(ok_pics)
-            else:
-              chosen_pic = random.choice(failed_pics)
-            pic_url = "/".join([marios_pics_root, chosen_pic]) + '.png'
-            comment_params = dict(pic_alt=chosen_pic, pic_src=pic_url)
+          if successful:
+            chosen_pic = random.choice(ok_pics)
+          else:
+            chosen_pic = random.choice(failed_pics)
+          pic_url = "/".join([marios_pics_root, chosen_pic]) + '.png'
+          comment_params = dict(pic_alt=chosen_pic, pic_src=pic_url)
 
-            if successful:
-              comment_template += (
-                'Here is the image you requested: '
-                '<a href="https://{imageurl}">built image</a>|'
-              )
-              comment_params['imageurl'] = '$(resources.outputs.image.url)'
-            else:
-              comment_template += (
-                'Cloud not build the requested image. Please check the '
-              )
-
+          if successful:
             comment_template += (
-              '<a href="http://35.222.249.224/?buildid={buildid}&'
-              'namespace=mario">build logs</a>'
+            'Here is the image you requested: '
+            '<a href="https://{imageurl}">built image</a>|'
             )
-            comment_params['buildid'] = '$(tt.params.buildUUID)'
+            comment_params['imageurl'] = '$(params.targetImage)'
+          else:
+            comment_template += (
+            'Could not build the requested image. Please check the '
+            )
 
-            new_comment_path = "$(resources.outputs.pr.path)/comments/new.json"
-            comment_body = dict(body=comment_template.format(**comment_params))
-            with open(new_comment_path, "w") as comment:
-              json.dump(comment_body, comment)
-      resources:
-        inputs:
-          - name: source
-            resourceSpec:
-              type: git
-              params:
-              - name: revision
-                value: $(tt.params.gitRevision)
-              - name: url
-                value: $(tt.params.gitURL)
-          - name: pr
-            resourceSpec:
-              type: pullRequest
-              params:
-                - name: url
-                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestID)
-              secrets:
-                - fieldName: authToken
-                  secretName: mario-github-token
-                  secretKey: GITHUB_TOKEN
-        outputs:
-          - name: image
-            resourceRef:
-              name: $(tt.params.targetImageResourceName)
-          - name: pr
-            resourceSpec:
-              type: pullRequest
-              params:
-                - name: url
-                  value: $(tt.params.gitURL)/pull/$(tt.params.pullRequestID)
-              secrets:
-                - fieldName: authToken
-                  secretName: mario-github-token
-                  secretKey: GITHUB_TOKEN
+          comment_template += (
+            '<a href="http://dashboard.dogfooding.tekton.dev/#/namespaces/mario/pipelineruns/{buildpipelinerun}?pipelineTask=build&step=build-and-push'
+            'namespace=mario">build logs</a>'
+          )
+          comment_params['buildpipelinerun'] = '$(params.buildPipelineRun)'
+
+          new_comment_path = "$(workspaces.pr.path)/comments/new.json"
+          comment_body = dict(body=comment_template.format(**comment_params))
+          with open(new_comment_path, "w") as comment:
+            json.dump(comment_body, comment)
+  - name: publish-comment
+    runAfter:
+    - setup-comment
+    taskRef:
+      name: pull-request
+      bundle: gcr.io/tekton-releases/catalog/upstream/pull-request:0.1
+    params:
+    - name: mode
+      value: upload
+    - name: url
+      value: $(params.gitURL)/pull/$(params.pullRequestID)
+    - name: provider
+      value: github
+    - name: secret-key-ref
+      value: mario-github-token
+    workspaces:
+    - name: pr
+      workspace: pr

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -83,8 +83,6 @@ metadata:
   name: mario-trigger-to-build-and-push-image
 spec:
   params:
-  - name: buildUUID
-    value: $(body.buildUUID)
   - name: gitRepository
     value: $(body.gitRepository)
   - name: gitRevision
@@ -122,16 +120,6 @@ spec:
       template:
         ref: mario-build-and-push-image
 ---
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: github-feedback-trigger
-spec:
-  type: cloudEvent
-  params:
-  - name: targetURI
-    value: http://el-github-feedback-trigger.mario:8080
----
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
@@ -140,8 +128,6 @@ spec:
   params:
   - name: pullRequestID
     description: The pullRequestID
-  - name: buildUUID
-    description: the buildUUID for logging purposes
   - name: gitRepository
     description: The git repository that hosts context and Dockerfile
   - name: gitRevision
@@ -149,69 +135,121 @@ spec:
   - name: contextPath
     description: The path to the context within 'gitRepository'
   - name: targetImage
-    description: The fully qualifie image target e.g. repo/name:tag.
+    description: The fully qualified image target e.g. repo/name:tag.
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
       generateName: build-and-push-
       labels:
-        prow.k8s.io/build-id: $(tt.params.buildUUID)
         mario.bot/pull-request-id: $(tt.params.pullRequestID)
     spec:
       serviceAccountName: mario-releaser
-      taskSpec:
-        params:
-          - name: contextPath
-            description: The path to the context
-        resources:
-          inputs:
-            - name: source
-              type: git
-          outputs:
-            - name: image
-              type: image
-            - name: endtrigger
-              type: cloudEvent
-        steps:
-        - name: build-and-push
-          workingdir: $(resources.inputs.source.path)
-          image: gcr.io/kaniko-project/executor:v0.13.0
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /secret/release.json
-          command:
-          - /kaniko/executor
-          - --dockerfile=Dockerfile
-          - --context=$(params.contextPath)
-          - --destination=$(tt.params.targetImage)
-          volumeMounts:
-            - name: gcp-secret
-              mountPath: /secret
-        volumes:
-          - name: gcp-secret
-            secret:
-              secretName: release-secret
+      pipelineRef:
+        name: clone-and-build
+      workspaces:
+      - name: source-code
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Mi
+      - name: gcp-secret
+        secret:
+          secretName: release-secret
       params:
       - name: contextPath
         value: $(tt.params.contextPath)
-      resources:
-        inputs:
-          - name: source
-            resourceSpec:
-              type: git
-              params:
-              - name: revision
-                value: $(tt.params.gitRevision)
-              - name: url
-                value: https://$(tt.params.gitRepository)
-        outputs:
-          - name: image
-            resourceSpec:
-              type: image
-              params:
-              - name: url
-                value: $(tt.params.targetImage)
-          - name: endtrigger
-            resourceRef:
-              name: github-feedback-trigger
+      - name: gitRepository
+        value: $(tt.params.gitRepository)
+      - name: gitRevision
+        value: $(tt.params.gitRevision)
+      - name: targetImage
+        value: $(tt.params.targetImage)
+      - name: contextPath
+        value: $(tt.params.contextPath)
+      - name: pullRequestID
+        value: $(tt.params.pullRequestID)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: clone-and-build
+spec:
+  params:
+  - name: gitRepository
+  - name: gitRevision
+  - name: gitCloneDepth
+    default: "10"
+  - name: targetImage
+  - name: contextPath
+  - name: cloudEventSink
+    default: http://el-github-feedback-trigger.mario:8080
+  - name: pullRequestID
+  workspaces:
+  - name: source-code
+  - name: gcp-secret
+  tasks:
+  - name: clone
+    taskRef:
+      name: git-clone
+      bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
+    params:
+    - name: url
+      value: https://$(params.gitRepository)
+    - name: revision
+      value: $(params.gitRevision)
+    - name: depth
+      value: $(params.gitCloneDepth)
+    workspaces:
+    - name: output
+      workspace: source-code
+  - name: build
+    runAfter:
+      - clone
+    params:
+    - name: contextPath
+      value: $(params.contextPath)
+    - name: targetImage
+      value: $(params.targetImage)
+    workspaces:
+    - name: source-code
+      workspace: source-code
+    - name: gcp-secret
+      workspace: gcp-secret
+    taskSpec:
+      params:
+      - name: contextPath
+      - name: targetImage
+      workspaces:
+      - name: source-code
+      - name: gcp-secret
+        mountPath: /secret
+      steps:
+      - name: build-and-push
+        workingdir: $(workspaces.source-code.path)
+        image: gcr.io/kaniko-project/executor:v0.13.0
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secret/release.json
+        command:
+        - /kaniko/executor
+        - --dockerfile=Dockerfile
+        - --context=$(params.contextPath)
+        - --destination=$(params.targetImage)
+  finally:
+  - name: publish-event
+    params:
+    - name: sink
+      value: $(params.cloudEventSink)
+    - name: eventID
+      value: $(context.taskRun.name)
+    - name: eventType
+      value: "dev.tekton.event.task.$(tasks.build.status)"
+    - name: data
+      value: '{"pull-request-id": "$(params.pullRequestID)", "build-pipelinerun": "$(context.pipelineRun.name)", "git-url": "https://$(params.gitRepository)", "git-revision": "$(params.gitRevision)", "target-image": "$(params.targetImage)", "status": "$(tasks.build.status)"}'
+    taskRef:
+      name: cloudevent
+      bundle: gcr.io/tekton-releases/catalog/upstream/cloudevent:0.1


### PR DESCRIPTION
# Changes

PipelineResources are now deprecated, and most of them are replaced with Catalog Tasks.
This commit rewrites the Mario Bot to not use PipelineResources.
The resulting triggers and pipelines have been tested in the dogfooding cluster.
In a subsequent commit, Mario Bot can be used to dogfood the pipeline -> taskrun feature.

Closes #931.

Co-authored-by: Christie Wilson christiewilson@google.com @bobcatfish 
Co-authored-by: Dibyo Mukherjee dibyajyoti@google.com @dibyom 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/kind cleanup