### PR TITLE
Ignore warnings when deploying resources

### DIFF
--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -92,7 +92,7 @@ spec:
             if [[ "$(params.deployMethod)" == "replace" ]]; then
               kubectl create $NAMESPACE_PARAM -f $TARGET  2> $CREATE_OUTPUT || true
               # If there was some unexpected message in the error log, fail
-              if grep -v "already exists" $CREATE_OUTPUT; then
+              if egrep -v '(already exists|^Warning)' $CREATE_OUTPUT; then
                   echo "Something went wrong when creating resources"
                   exit 1
               fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The deployment template fails if there is a Warning in the log file.

Fixes: #932

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._