### PR TITLE
Improve the logs of CatlinCI

### DIFF
--- a/tekton/ci-workspace/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci-workspace/jobs/tekton-catalog-catlin-lint.yaml
@@ -46,12 +46,14 @@ spec:
 
         # creating a file which will contain the final formatted output
         # which needs to be added as a comment(if any)
-        echo '**Catlin Output**' >> catlin.txt
+        echo '<details><summary>Catlin Output</summary>' >> catlin.txt
+        echo '' >> catlin.txt
         echo '```' >> catlin.txt
 
         # performing catlin validate
         catlin validate $(cat changed-files.txt) | tee -a catlin.txt
         echo '```' >> catlin.txt
+        echo "</details>" >> catlin.txt
 
         # performing catlin script validattion only on yaml files
         for file in $(cat changed-files.txt);do
@@ -59,7 +61,8 @@ spec:
         done
 
         if [[ -s catlin-script.txt ]];then
-          echo '**Catlin script lint Output**' >> catlin.txt
+          echo '<details><summary>Catlin script lint Output</summary>' >> catlin.txt
+          echo '' >> catlin.txt
           echo '```' >> catlin.txt
           cat catlin-script.txt >> catlin.txt
           echo '```' >> catlin.txt


### PR DESCRIPTION
# Changes

Catlin CI was producing huge logs when there are many linting issues in
a Tekton Task and those logs were taking a lot of space in github which
makes it difficult to scroll.

En-quoting all the logs of catlin under separate heading so that it is
easier to scroll.

/kind misc

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [?] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._