### PR TITLE
Detect git clone tasks in the tekton-events el

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -139,7 +139,7 @@ spec:
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
               (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-clone-repo-') == -1) &&
+              (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
@@ -161,7 +161,7 @@ spec:
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
               (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-clone-repo-') == -1) &&
+              (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
@@ -183,7 +183,7 @@ spec:
               !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
               (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-clone-repo-') == -1) &&
+              (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The tekton-events event listeners filters out git-clone tasks
at the beginning of CI jobs as no notifications should be fired
for those.

The latest tekton release dropped the `-<random>` part suffix from
resource names which causes the CEL filters for git-clone tasks
to break. Remove the trailing "-" should fix the issue.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc