### PR TITLE
Use alpha features in pipeline and triggers

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
@@ -4,5 +4,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  enable-custom-tasks: "true"
-  enable-tekton-oci-bundles: "true"
+  enable-api-fields: "alpha"

--- a/tekton/cd/triggers/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/triggers/overlays/dogfooding/feature-flags.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags-triggers
+data:
+  enable-api-fields: "alpha"

--- a/tekton/cd/triggers/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/triggers/overlays/dogfooding/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
 - ../../base
-# patchesStrategicMerge:
-# -
+patchesStrategicMerge:
+- feature-flags.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enable alpha features in pipeline and triggers.
OCI bundles and custom tasks are already enabled in pipeline. Replace
the individual settings with the global alpha setting.

For Triggers, alpha is required to dogfood TriggerGroups.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc