### PR TITLE
Document the eventing setup in dogfooding

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -1,6 +1,6 @@
 # Dogfooding Cluster
 
-The `dogfooding` clusterruns the instance of Tekton that is used for all the CI/CD needs
+The `dogfooding` cluster runs the instance of Tekton that is used for all the CI/CD needs
 of Tekton itself.
 
 - Configuration for the CI is in [tekton](../tekton)

--- a/tekton/cd/pipeline/overlays/dogfooding/config-defaults.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/config-defaults.yaml
@@ -4,4 +4,4 @@ metadata:
   name: config-defaults
   namespace: tekton-pipelines
 data:
-  default-cloud-events-sink: http://el-tekton-events.default:8080
+  default-cloud-events-sink: http://kafka-broker-ingress.knative-eventing.svc.cluster.local/default/default


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Knative eventing + Kafka broken is now available in dogfooding, and it's
used to transport cloudevents generated by Tekton pipelines to
consumers.

Document the installation process, the knative triggers used to get
messages to consumers and alter the tekton pipeline configuration to
send events to the broker.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc