### PR TITLE
Use the correct account to deploy labels to tekton-ci

### DIFF
--- a/tekton/cronjobs/dogfooding/configmaps/labels-sync-hourly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/configmaps/labels-sync-hourly/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
               - name: NAMESPACE
                 value: "tekton-ci"
               - name: CLUSTER_RESOURCE
-                value: "dogfooding-tektonci-default"
+                value: "dogfooding-tekton-ci-default"
               - name: CONFIGMAP_NAME
                 value: "label-config-v2"
               - name: CONFIGMAP_KEY


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The cronjob that deploys the labels for CI purposes deployes now
to the tekton-ci namespace, and it should use the default SA in
that namespace instead of that of the tektonci namespace.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc