### PR TITLE
Use TriggerGroups for CI Jobs 🥳

### DIFF
--- a/tekton/ci/catalog/template.yaml
+++ b/tekton/ci/catalog/template.yaml
@@ -69,28 +69,6 @@ spec:
             value: $(tt.params.pullRequestBaseRef)
           - name: gitRepository
             value: "$(tt.params.gitRepository)"
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: TriggerTemplate
-metadata:
-  name: tekton-catalog-diff-task-template
-spec:
-  params:
-    - name: buildUUID
-      description: UUID used to track a CI Pipeline Run in logs
-    - name: pullRequestNumber
-      description: The pullRequestNumber
-    - name: pullRequestUrl
-      description: The HTML URL for the pull request
-    - name: pullRequestBaseRef
-      description: |
-        The base git ref for the pull request. This is the branch the
-        pull request would merge onto once approved.
-    - name: gitRepository
-      description: The git repository that hosts context and Dockerfile
-    - name: gitRevision
-      description: The Git revision to be used.
-  resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
@@ -124,4 +102,3 @@ spec:
             value: $(tt.params.pullRequestBaseRef)
           - name: gitRepository
             value: "$(tt.params.gitRepository)"
----

--- a/tekton/ci/catalog/trigger.yaml
+++ b/tekton/ci/catalog/trigger.yaml
@@ -3,21 +3,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: catalog-pull-request
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
-          body.repository.full_name == 'tektoncd/catalog' &&
-          body.action in ['opened','synchronize']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
+          body.repository.full_name == 'tektoncd/catalog'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -30,34 +22,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: catalog-issue-comment
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
     - cel:
         filter: >-
-          body.repository.full_name == 'tektoncd/catalog' &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-        overlays:
-          - key: add_pr_body.pull_request_url
-            expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+          body.repository.full_name == 'tektoncd/catalog'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment
@@ -65,70 +36,3 @@ spec:
     - ref: tekton-ci-webhook-issue-labels
   template:
     ref: tekton-catalog-ci-pipeline
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: Trigger
-metadata:
-  name: catalog-pull-request-diff-task
-spec:
-  interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
-    - cel:
-        filter: >-
-          body.repository.full_name == 'tektoncd/catalog' &&
-          body.action in ['opened','synchronize']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
-  bindings:
-    - ref: tekton-ci-github-base
-    - ref: tekton-ci-webhook-pull-request
-    - ref: tekton-ci-clone-depth
-    - ref: tekton-ci-webhook-pr-labels
-  template:
-    ref: tekton-catalog-diff-task-template
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: Trigger
-metadata:
-  name: catalog-issue-comment-diff-task
-spec:
-  interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
-    - cel:
-        filter: >-
-          body.repository.full_name == 'tektoncd/catalog' &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/diff-task')
-        overlays:
-          - key: add_pr_body.pull_request_url
-            expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
-  bindings:
-    - ref: tekton-ci-github-base
-    - ref: tekton-ci-webhook-comment
-    - ref: tekton-ci-clone-depth
-    - ref: tekton-ci-webhook-issue-labels
-  template:
-    ref: tekton-catalog-diff-task-template

--- a/tekton/ci/community/trigger.yaml
+++ b/tekton/ci/community/trigger.yaml
@@ -3,21 +3,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: community-pull-request
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
-          body.repository.name == 'community' &&
-          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
+          body.repository.name == 'community'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -30,34 +22,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: community-issue-comment
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
     - cel:
         filter: >-
-          body.repository.name == 'community' &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-        overlays:
-        - key: add_pr_body.pull_request_url
-          expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+          body.repository.name == 'community'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/pipeline/trigger.yaml
+++ b/tekton/ci/pipeline/trigger.yaml
@@ -3,21 +3,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: pipeline-pull-request
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
-          body.repository.name == 'pipeline' &&
-          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
+          body.repository.name == 'pipeline'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -30,34 +22,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: pipeline-issue-comment
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
     - cel:
         filter: >-
-          body.repository.name == 'pipeline' &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-        overlays:
-        - key: add_pr_body.pull_request_url
-          expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+          body.repository.name == 'pipeline'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/plumbing/trigger.yaml
+++ b/tekton/ci/plumbing/trigger.yaml
@@ -3,21 +3,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: plumbing-pull-request
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
-          body.repository.name == 'plumbing' &&
-          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
+          body.repository.name == 'plumbing'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -30,34 +22,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: plumbing-issue-comment
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
     - cel:
         filter: >-
-          body.repository.name == 'plumbing' &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-        overlays:
-        - key: add_pr_body.pull_request_url
-          expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+          body.repository.name == 'plumbing'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -5,5 +5,89 @@ metadata:
   name: tekton-ci
 spec:
   serviceAccountName: tekton-ci-workspace-listener
-  namespaceSelector:
-    matchNames: ['tekton-ci']
+  triggerGroups:
+    - name: github-tektoncd-pr-group
+      interceptors:
+        - name: "Validate GitHub payload and filter on eventType"
+          ref:
+            name: "github"
+          params:
+            - name: "secretRef"
+              value:
+                secretName: github-secret
+                secretKey: secretToken
+            - name: "eventTypes"
+              value:
+                - "pull_request"
+        - name: "Filter the GitHub org and actions and add git_clone_depth"
+          ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                body.repository.full_name.startsWith('tektoncd/') &&
+                body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
+            - name: "overlays"
+              value:
+                - key: git_clone_depth
+                  expression: "string(body.pull_request.commits + 1.0)"
+      triggerSelector:
+        namespaceSelector:
+          matchNames:
+            - tekton-ci
+        labelSelector:
+          matchLabels:
+            ci.tekton.dev/trigger-type: github.pull-request
+    - name: github-tektoncd-issue-comment-group
+      interceptors:
+        - name: "Validate GitHub payload and filter on eventType"
+          ref:
+            name: "github"
+          params:
+            - name: "secretRef"
+              value:
+                secretName: github-secret
+                secretKey: secretToken
+            - name: "eventTypes"
+              value:
+                - "issue_comment"
+        - name: "Filter the GitHub org and actions state text"
+          ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                body.repository.full_name.startsWith('tektoncd/') &&
+                body.action == 'created' &&
+                'pull_request' in body.issue &&
+                body.issue.state == 'open' &&
+                body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
+            - name: "overlays"
+              value:
+                - key: add_pr_body.pull_request_url
+                  expression: "body.issue.pull_request.url"
+        - name: "Fetch the PR body"
+          ref:
+            name: "webhook"
+          params:
+            - name: "objectRef"
+              value:
+                kind: Service
+                name: add-pr-body
+                apiVersion: v1
+                namespace: tektonci
+        - name: "Add git_clone_depth"
+          ref:
+            name: "cel"
+          params:
+            - name: "overlays"
+              value:
+                - key: git_clone_depth
+                  expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+      triggerSelector:
+        namespaceSelector:
+          matchNames:
+            - tekton-ci
+        labelSelector:
+          matchLabels:
+            ci.tekton.dev/trigger-type: github.issue-comment

--- a/tekton/ci/shared/trigger.yaml
+++ b/tekton/ci/shared/trigger.yaml
@@ -2,20 +2,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: doc-reviewers
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
           body.action in ['opened', 'synchronize', 'reopened']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -28,19 +21,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: pull-request-label-check
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
-          body.repository.full_name.startsWith('tektoncd/') &&
-          body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub'] &&
-          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled']
+          body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub']
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -52,35 +39,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: comment-label-check
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
     - cel:
         filter: >-
-          body.repository.full_name.startsWith('tektoncd/') &&
-          body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub'] &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-        overlays:
-        - key: add_pr_body.pull_request_url
-          expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-        - key: git_clone_depth
-          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+          body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub']
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/website/trigger.yaml
+++ b/tekton/ci/website/trigger.yaml
@@ -3,21 +3,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: website-pull-request
+  labels:
+    ci.tekton.dev/trigger-type: github.pull-request
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - pull_request
     - cel:
         filter: >-
-          body.repository.name == 'website' &&
-          body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.pull_request.commits + 1.0)"
+          body.repository.name == 'website'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request
@@ -30,34 +22,13 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: Trigger
 metadata:
   name: website-issue-comment
+  labels:
+    ci.tekton.dev/trigger-type: github.issue-comment
 spec:
   interceptors:
-    - github:
-        secretRef:
-          secretName: ci-webhook
-          secretKey: secret
-        eventTypes:
-          - issue_comment
     - cel:
         filter: >-
-          body.repository.name == 'website' &&
-          body.action == 'created' &&
-          'pull_request' in body.issue &&
-          body.issue.state == 'open' &&
-          body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-        overlays:
-        - key: add_pr_body.pull_request_url
-          expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
-    - cel:
-        overlays:
-          - key: git_clone_depth
-            expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+          body.repository.name == 'website'
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

TriggerGroups are a new alpha feature in Triggers that allow define
a set of interceptors that will be processed before Trigger resources
for a filtered group of Triggers.

All triggers in CI jobs deal with GitHub event so they share a large
surface of the interceptors. Using TriggerGroups makes it easier to
maintain the triggers for all projects.

The change is not only cosmetic though: interceptors like github,
cel, add-pr-body will be processed only once. The hash in the GitHub
event is going to be validated once. The PR definition will be pulled
from the GitHub API once (per trigger group) instead of once per
trigger.

This paves the way for further changes:
- add the add-team-member custom interceptor and logic so we only
  run tests for authorised users
- add a trigger group to add comments that enahnce the user experience

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature