### PR TITLE
Dogfood Pipeline to TaskRun with Mario bot

### DIFF
--- a/tekton/mario-bot/mario-github-comment.yaml
+++ b/tekton/mario-bot/mario-github-comment.yaml
@@ -47,14 +47,16 @@ spec:
   - name: buildPipelineRun
     description: The name of the image build PipelineRun for the logs link
   resourcetemplates:
-  - apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Run
     metadata:
       generateName: mario-comment-github-
     spec:
-      serviceAccountName: mario-listener
-      pipelineRef:
+      ref:
+        apiVersion: tekton.dev/v1alpha1
+        kind: PipelineToTaskRun
         name: mario-comment-github
+      serviceAccountName: mario-listener
       workspaces:
       - name: pr
         volumeClaimTemplate:
@@ -95,7 +97,6 @@ spec:
   - name: download-pr-info
     taskRef:
       name: pull-request
-      bundle: gcr.io/tekton-releases/catalog/upstream/pull-request:0.1
     workspaces:
     - name: pr
       workspace: pr
@@ -168,7 +169,7 @@ spec:
             )
 
           comment_template += (
-            '<a href="http://dashboard.dogfooding.tekton.dev/#/namespaces/mario/pipelineruns/{buildpipelinerun}?pipelineTask=build&step=build-and-push'
+            '<a href="http://dashboard.dogfooding.tekton.dev/#/namespaces/mario/pipelineruns/{buildpipelinerun}?pipelineTask=build&step=build-and-push&'
             'namespace=mario">build logs</a>'
           )
           comment_params['buildpipelinerun'] = '$(params.buildPipelineRun)'
@@ -182,7 +183,6 @@ spec:
     - setup-comment
     taskRef:
       name: pull-request
-      bundle: gcr.io/tekton-releases/catalog/upstream/pull-request:0.1
     params:
     - name: mode
       value: upload

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -145,8 +145,66 @@ spec:
         mario.bot/pull-request-id: $(tt.params.pullRequestID)
     spec:
       serviceAccountName: mario-releaser
-      pipelineRef:
-        name: clone-and-build
+      pipelineSpec:
+        workspaces:
+        - name: source-code
+        - name: gcp-secret
+        params:
+        - name: contextPath
+        - name: gitRepository
+        - name: gitRevision
+        - name: targetImage
+        - name: contextPath
+        - name: pullRequestID
+        - name: cloudEventSink
+          default: http://el-github-feedback-trigger.mario:8080
+        tasks:
+        - name: clone-and-build
+          taskRef:
+            apiVersion: tekton.dev/v1alpha1
+            kind: PipelineToTaskRun
+            name: clone-and-build
+          params:
+          - name: gitRepository
+            value: $(params.gitRepository)
+          - name: gitRevision
+            value: $(params.gitRevision)
+          - name: targetImage
+            value: $(params.targetImage)
+          - name: contextPath
+            value: $(params.contextPath)
+          - name: pullRequestID
+            value: $(params.pullRequestID)
+          workspaces:
+          - name: source-code
+            workspace: source-code
+          - name: gcp-secret
+            workspace: gcp-secret
+        finally:
+        - name: publish-event
+          params:
+          - name: sink
+            value: $(params.cloudEventSink)
+          - name: eventID
+            value: $(context.taskRun.name)
+          - name: eventType
+            value: "dev.tekton.event.task.$(tasks.clone-and-build.status)"
+          - name: data
+            value: '{"pull-request-id": "$(params.pullRequestID)", "build-pipelinerun": "$(context.pipelineRun.name)", "git-url": "https://$(params.gitRepository)", "git-revision": "$(params.gitRevision)", "target-image": "$(params.targetImage)", "status": "$(tasks.clone-and-build.status)"}'
+          taskRef:
+            name: cloudevent
+            bundle: gcr.io/tekton-releases/catalog/upstream/cloudevent:0.1
+      params:
+      - name: pullRequestID
+        value: $(tt.params.pullRequestID)
+      - name: gitRepository
+        value: $(tt.params.gitRepository)
+      - name: gitRevision
+        value: $(tt.params.gitRevision)
+      - name: contextPath
+        value: $(tt.params.contextPath)
+      - name: targetImage
+        value: $(tt.params.targetImage)
       workspaces:
       - name: source-code
         volumeClaimTemplate:
@@ -159,19 +217,6 @@ spec:
       - name: gcp-secret
         secret:
           secretName: release-secret
-      params:
-      - name: contextPath
-        value: $(tt.params.contextPath)
-      - name: gitRepository
-        value: $(tt.params.gitRepository)
-      - name: gitRevision
-        value: $(tt.params.gitRevision)
-      - name: targetImage
-        value: $(tt.params.targetImage)
-      - name: contextPath
-        value: $(tt.params.contextPath)
-      - name: pullRequestID
-        value: $(tt.params.pullRequestID)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
@@ -185,8 +230,6 @@ spec:
     default: "10"
   - name: targetImage
   - name: contextPath
-  - name: cloudEventSink
-    default: http://el-github-feedback-trigger.mario:8080
   - name: pullRequestID
   workspaces:
   - name: source-code
@@ -195,7 +238,6 @@ spec:
   - name: clone
     taskRef:
       name: git-clone
-      bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
     params:
     - name: url
       value: https://$(params.gitRepository)
@@ -226,30 +268,15 @@ spec:
       workspaces:
       - name: source-code
       - name: gcp-secret
-        mountPath: /secret
       steps:
       - name: build-and-push
         workingdir: $(workspaces.source-code.path)
         image: gcr.io/kaniko-project/executor:v0.13.0
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /secret/release.json
+          value: $(workspaces.gcp-secret.path)/release.json
         command:
         - /kaniko/executor
         - --dockerfile=Dockerfile
         - --context=$(params.contextPath)
         - --destination=$(params.targetImage)
-  finally:
-  - name: publish-event
-    params:
-    - name: sink
-      value: $(params.cloudEventSink)
-    - name: eventID
-      value: $(context.taskRun.name)
-    - name: eventType
-      value: "dev.tekton.event.task.$(tasks.build.status)"
-    - name: data
-      value: '{"pull-request-id": "$(params.pullRequestID)", "build-pipelinerun": "$(context.pipelineRun.name)", "git-url": "https://$(params.gitRepository)", "git-revision": "$(params.gitRevision)", "target-image": "$(params.targetImage)", "status": "$(tasks.build.status)"}'
-    taskRef:
-      name: cloudevent
-      bundle: gcr.io/tekton-releases/catalog/upstream/cloudevent:0.1


### PR DESCRIPTION
# Changes

Dogfooding Pipeline to Taskrun is part of our strategy for creating a
successor to PipelineResources. This commit rewrites the mario
image builder trigger template to use a PipelineRun containing a
PipelineToTaskRun, plus a finally Task, and rewrites the mario
github trigger template to use a Run of kind PipelineToTaskRun.

PipelineToTaskRun does not support workspace mountPaths or finally Tasks,
so this commit rewrites existing pipelines to avoid using those features
in a PipelineToTaskRun. In addition, PipelineToTaskRun does not support
OCI bundles, so the pull-request and git-clone tasks were installed
in the mario namespace of the dogfooding cluster.

This commit requires updating Triggers in the dogfooding cluster
to pull in [PR: support Runs in TriggerTemplates](https://github.com/tektoncd/triggers/pull/1283).

Closes #921.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/kind misc