### PR TITLE
Add pipeline to run s390x catalog tests

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/README.md
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/README.md
@@ -1,0 +1,1 @@
+Cron Job to run nightly catalog e2e tests on s390x hardware.

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-test-trigger
+spec:
+  schedule: "0 17 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+            - name: SINK_URL
+              value: "http://el-test-nightly.default.svc.cluster.local:8080"
+            - name: TARGET_PROJECT
+              value: "catalog"
+            - name: NAMESPACE
+              value: "bastion-z"
+            - name: REGISTRY
+              value: "sshd.bastion-z.svc.cluster.local:4000"
+            - name: TARGET_ARCH
+              value: "s390x"
+            - name: REMOTE_SECRET_NAME
+              value: "s390x-k8s-ssh"
+            - name: REMOTE_HOST
+              value: "sshd.bastion-z.svc.cluster.local"
+            - name: REMOTE_PORT
+              value: "1122"
+            - name: REMOTE_USER
+              value: "k8smanager"

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../../bases/nightly-tests
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-catalog-s390x"

--- a/tekton/resources/nightly-tests/README.md
+++ b/tekton/resources/nightly-tests/README.md
@@ -61,6 +61,7 @@ The following pipelines are available:
 - cli `e2e` tests
 - operator `e2e` tests
 - dashboard `e2e` tests
+- catalog `e2e` tests
 
 They are running once a day automatically. The results can be seen
 at the [dogfooding dashboard](https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns).

--- a/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
@@ -1,0 +1,186 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-catalog-nightly-test-s390x
+spec:
+  params:
+  - name: containerRegistry
+  - name: targetArch
+  - name: namespace
+  - name: remoteHost
+  - name: remotePort
+  - name: remoteUser
+  - name: remoteSecret
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: tekton-catalog-$(tt.params.targetArch)-nightly-run-
+      namespace: $(tt.params.namespace)
+    spec:
+      timeout: 2h
+      workspaces:
+      # this workspace will be used to share info between tasks
+      - name: shared-workspace
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+      # this workspace will be used to store ssh key
+      - name: ssh-secret
+        secret:
+          secretName: $(tt.params.remoteSecret)
+          items:
+          - key: privatekey
+            path: id_rsa
+            # yamllint disable rule:octal-values
+            mode: 0600
+            # yamllint enable
+      pipelineSpec:
+        workspaces:
+        - name: shared-workspace
+        - name: ssh-secret
+        params:
+        - name: container-registry
+        - name: target-arch
+        - name: remote-host
+        - name: remote-port
+        - name: remote-user
+        tasks:
+        - name: git-clone-catalog
+          taskRef:
+            name: git-clone
+            bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.5
+          params:
+          - name: url
+            value: https://github.com/tektoncd/catalog
+          - name: revision
+            value: main
+          - name: subdirectory
+            value: src/github.com/tektoncd/catalog
+          workspaces:
+          - name: output
+            workspace: shared-workspace
+            subPath: source-code
+        - name: create-k8s-cluster
+          runAfter: [git-clone-catalog]
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+        - name: deploy-pipeline
+          runAfter: [create-k8s-cluster]
+          taskRef:
+            name: deploy-tekton-component-nightly
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          params:
+          - name: package
+            value: pipeline
+        - name: e2e-test-catalog
+          runAfter: [deploy-pipeline]
+          taskSpec:
+            params:
+            - name: container-registry
+            - name: target-arch
+            - name: remote-host
+            workspaces:
+            - name: k8s-shared
+              description: workspace for k8s config, configuration file is expected to have `config` name
+              mountPath: /root/.kube
+            - name: source-code
+              description: workspace with source code for tekton component
+            steps:
+            - name: run-e2e-tests
+              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              workingdir: $(workspaces.source-code.path)/src/github.com/tektoncd/catalog
+              env:
+              - name: KUBECONFIG
+                value: $(workspaces.k8s-shared.path)/config
+              - name: PLATFORM
+                value: linux/$(params.target-arch)
+              - name: KO_DOCKER_REPO
+                value: $(params.container-registry)
+              - name: TEST_RUN_ALL_TESTS
+                value: "true"
+              - name: LOCAL_CI_RUN
+                value: "true"
+              command:
+              - /bin/bash
+              args:
+              - -ce
+              - |
+                test/e2e-tests.sh
+          params:
+          - name: container-registry
+            value: $(params.container-registry)
+          - name: target-arch
+            value: $(params.target-arch)
+          - name: remote-host
+            value: $(params.remote-host)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+        finally:
+        - name: delete-k8s-cluster
+          taskRef:
+            name: create-delete-k8s-cluster-$(tt.params.targetArch)
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: ssh-secret
+            workspace: ssh-secret
+          params:
+          - name: remote-host
+            value: $(params.remote-host)
+          - name: remote-port
+            value: $(params.remote-port)
+          - name: remote-user
+            value: $(params.remote-user)
+          - name: action
+            value: delete
+      params:
+      - name: container-registry
+        value: $(tt.params.containerRegistry)
+      - name: target-arch
+        value: $(tt.params.targetArch)
+      - name: remote-host
+        value: $(tt.params.remoteHost)
+      - name: remote-port
+        value: $(tt.params.remotePort)
+      - name: remote-user
+        value: $(tt.params.remoteUser)

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -65,6 +65,18 @@ spec:
     - ref: trigger-to-deploy-test-tekton-project
     template:
       ref: tekton-dashboard-nightly-test-s390x
+  - name: catalog-nightly-test-trigger-s390x
+    interceptors:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+           body['trigger-template'] == 'catalog' &&
+           'arch' in body.params.target &&
+           body.params.target.arch == 's390x'
+    bindings:
+    - ref: trigger-to-deploy-test-tekton-project
+    template:
+      ref: tekton-catalog-nightly-test-s390x
   - name: pipeline-nightly-test-trigger-ppc64le
     interceptors:
     - cel:

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - cli-deploy-test-s390x-template.yaml
 - operator-deploy-test-s390x-template.yaml
 - dashboard-deploy-test-s390x-template.yaml
+- catalog-deploy-test-s390x-template.yaml
 - pipeline-deploy-test-ppc64le-template.yaml
 - serviceaccount.yaml
 - triggers-deploy-test-ppc64le-template.yaml


### PR DESCRIPTION
# Changes

- add corresponding cronjob to trigger s390x tekton catalog tests
- add template to run s390x catalog test pipeline
  - git clone catalog repo
  - k8s cluster installation
  - e2e tests for tasks marked as runnable for linux/s390x
  - k8s cluster removal

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._