### PR TITLE
Add catalog s390x nightly test cronjob to kustomization config

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - cli-nightly-test
 - operator-nightly-test
 - dashboard-nightly-test
+- catalog-nightly-test


### PR DESCRIPTION
# Changes

In connection to https://github.com/tektoncd/plumbing/pull/959, the new catalog s390x nightly test should be added to kustomization config to be applied to Tekton dogfooding cluster.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._