### PR TITLE
Migrate CI event listener to v1beta1

### DIFF
--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: tekton-ci


### PR DESCRIPTION
# Changes

All trigger resources are still v1alpha1.
Migrating the CI event listener for now since it's required by
for trigger groups: https://github.com/tektoncd/plumbing/pull/956

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._