### PR TITLE
Fix github CI secret name

### DIFF
--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -14,8 +14,8 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: github-secret
-                secretKey: secretToken
+                secretName: ci-webhook
+                secretKey: secret
             - name: "eventTypes"
               value:
                 - "pull_request"
@@ -46,8 +46,8 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: github-secret
-                secretKey: secretToken
+                secretName: ci-webhook
+                secretKey: secret
             - name: "eventTypes"
               value:
                 - "issue_comment"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When introducing trigger groups, the event listener secret name
for GitHub CI events was inadvertently changed. Restored the
correct one.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc