### PR TITLE
Move the custom interceptor out of trigger groups

### DIFF
--- a/tekton/ci/community/trigger.yaml
+++ b/tekton/ci/community/trigger.yaml
@@ -29,6 +29,19 @@ spec:
     - cel:
         filter: >-
           body.repository.name == 'community'
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/pipeline/trigger.yaml
+++ b/tekton/ci/pipeline/trigger.yaml
@@ -29,6 +29,19 @@ spec:
     - cel:
         filter: >-
           body.repository.name == 'pipeline'
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/plumbing/trigger.yaml
+++ b/tekton/ci/plumbing/trigger.yaml
@@ -29,6 +29,19 @@ spec:
     - cel:
         filter: >-
           body.repository.name == 'plumbing'
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -62,28 +62,6 @@ spec:
                 'pull_request' in body.issue &&
                 body.issue.state == 'open' &&
                 body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
-            - name: "overlays"
-              value:
-                - key: add_pr_body.pull_request_url
-                  expression: "body.issue.pull_request.url"
-        - name: "Fetch the PR body"
-          ref:
-            name: "webhook"
-          params:
-            - name: "objectRef"
-              value:
-                kind: Service
-                name: add-pr-body
-                apiVersion: v1
-                namespace: tektonci
-        - name: "Add git_clone_depth"
-          ref:
-            name: "cel"
-          params:
-            - name: "overlays"
-              value:
-                - key: git_clone_depth
-                  expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/ci/shared/trigger.yaml
+++ b/tekton/ci/shared/trigger.yaml
@@ -46,6 +46,19 @@ spec:
     - cel:
         filter: >-
           body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub']
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment

--- a/tekton/ci/website/trigger.yaml
+++ b/tekton/ci/website/trigger.yaml
@@ -29,6 +29,19 @@ spec:
     - cel:
         filter: >-
           body.repository.name == 'website'
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Old style interceptors won't work with trigger groups.
Until https://github.com/tektoncd/plumbing/pull/967 is merged,
leave the add-pr-body interceptor out of the trigger group.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc