### PR TITLE
Reduce the likelyhood of pending CI jobs

### DIFF
--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -33,12 +33,15 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      generateName: $(tt.params.checkName)-pr-$(tt.params.gitHubCheckStatus)-
+      name: $(tt.params.buildUUID)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+        ci.tekton.dev/repo: $(tt.params.gitHubRepo)
+        ci.tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+        ci.tekton.dev/check-status: $(tt.params.gitHubCheckStatus)
     spec:
       serviceAccountName: tekton-ci-jobs
       podTemplate:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Change the name of the notification taskruns, from a generated
one to a fixed one that includes buildUUID and gitHubCheckStatus
only.

The buildUUID is GitHub event ID, so it will be different between
a PR created, PR sync and comment added events, but it will stay
the same throughout the lifecycle of the PipelineRun triggered by
the event.

The gitHubCheckStatus is set to "pending" by all pipeline run
status except for success and fail. This way, once we run the
<buildUUID>-pending taskrun, it won't be possible to run it again
as the name will already be in the cluster.

On a busy cluster it still may happen that the "pending" taskrun
runs after the "pass/fail" one, but this change reduces the
likelyhood.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc