### PR TITLE
Remove the extra labels from the github-set-status

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -135,15 +135,17 @@ spec:
             filter: >-
               header.match('ce-type', 'dev.tekton.event.taskrun.started.v1') &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] in ['tekton-ci-webhook', 'tekton-ci'] &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
               (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
               (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
+              (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
                 expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
+              - key: shortBuildUUID
+                expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
         - ref: tekton-ci-check-pending
@@ -156,16 +158,18 @@ spec:
         - cel:
             filter: >-
               header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] in ['tekton-ci-webhook', 'tekton-ci'] &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
               (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
               (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
+              (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
                 expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
+              - key: shortBuildUUID
+                expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
         - ref: tekton-ci-check-success
@@ -178,16 +182,18 @@ spec:
         - cel:
             filter: >-
               header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] in ['tekton-ci-webhook', 'tekton-ci'] &&
+              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
               body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('tekton.dev/conditionName' in body.taskRun.metadata.labels) &&
               !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
               (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
               (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
+              (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
               'ownerReferences' in body.taskRun.metadata
             overlays:
               - key: repo
                 expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
+              - key: shortBuildUUID
+                expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
       bindings:
         - ref: tekton-ci-taskrun-cloudevent
         - ref: tekton-ci-check-failure

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -69,3 +69,5 @@ spec:
   params:
   - name: gitHubRepo
     value: $(extensions.repo)
+  - name: shortBuildUUID
+    value: $(extensions.shortBuildUUID)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -39,9 +39,6 @@ spec:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
-        ci.tekton.dev/repo: $(tt.params.gitHubRepo)
-        ci.tekton.dev/pr-number: $(tt.params.pullRequestNumber)
-        ci.tekton.dev/check-status: $(tt.params.gitHubCheckStatus)
     spec:
       serviceAccountName: tekton-ci-jobs
       podTemplate:

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -9,6 +9,8 @@ spec:
     description: The pullRequestID to comment to
   - name: buildUUID
     description: The buildUUID for the logs link
+  - name: shortBuildUUID
+    description: A truncated version of the buildUUID
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
   - name: gitRevision
@@ -33,7 +35,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: $(tt.params.buildUUID)-$(tt.params.gitHubCheckStatus)
+      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As part of https://github.com/tektoncd/plumbing/pull/969 I added some
extra labels, however the values in those params are not always fit to
be label values and are causing the taskrun to not be created.

Remove the extra labels but keep the new naming format.
Also restore the checkName as part of the GitHub notification taskrun, since
we may be running more than one CI job per GitHub event.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc