### PR TITLE
CI Jobs: Use Environment Variables instead of Parameters

### DIFF
--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -20,10 +20,13 @@ spec:
     - name: find-changed-tasks
       image: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
       workingDir: $(workspaces.source.path)
+      env:
+      - name: GIT_CLONE_DEPTH
+        value: $(params.gitCloneDepth)
       script: |
         function detect_new_changed_tasks() {
           # detect for changes in the task manifest
-          git --no-pager diff --name-only HEAD~$(( $(params.gitCloneDepth) - 1 ))|grep 'task/[^\/]*/[^\/]*/*[^/]*.yaml'|xargs -I {} dirname {}
+          git --no-pager diff --name-only HEAD~$(( ${GIT_CLONE_DEPTH} - 1 ))|grep 'task/[^\/]*/[^\/]*/*[^/]*.yaml'|xargs -I {} dirname {}
         }
         all_tests=$(detect_new_changed_tasks |sort -u || true)
         final_tests=""

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -27,6 +27,9 @@ spec:
     volumeMounts:
       - name: label-config-v2
         mountPath: /etc/config
+    env:
+      - name: LABELS
+        value: $(params.labels)
     script: |
       #!/usr/bin/env python
 
@@ -34,7 +37,7 @@ spec:
       import yaml
       import sys
 
-      prLabelsText = """$(params.labels)"""
+      prLabelsText = os.getenv('LABELS')
       prLabels = json.loads(prLabelsText)
 
       availableLabels = None


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Today, the tasks and pipelines in ci/jobs use parameters in the scripts which are interpolated.

As described in #971, this is fragile and poses a security risk.

In this change, we migrate to using environment variables which  are not interpolated in scripts.

* [x]  ./tekton/ci/jobs/tekton-catalog-catlin-lint.yaml:
* [x]  ./tekton/ci/jobs/tekton-image-build.yaml:
* [x]  ./tekton/ci/jobs/tekton-kind-label.yaml:

Related issue: #971

cc @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._