### PR TITLE
Sanitize param usage in some plumbing task script blocks

### DIFF
--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -56,42 +56,50 @@ spec:
           env:
           - name: KUBECONFIG
             value: /workspace/$(resources.inputs.targetCluster.name)/kubeconfig
+          - name: CONFIG_PATH
+            value: $(params.configPath)
+          - name: NAMESPACE
+            value: $(params.namespace)
+          - name: CONFIG_MAP_NAME
+            value: $(params.configMapName)
+          - name: CONFIG_MAP_KEY
+            value: $(params.configMapKey)
         steps:
         - name: fetch-current-config
           image: gcr.io/tekton-releases/dogfooding/kubectl
           script: |
             #!/bin/sh
             set -ex
-            kubectl get configmap -n $(params.namespace) \
-              $(params.configMapName) -o template \
-              --template='{{ index .data "$(params.configMapKey)" }}' > \
-               /workspace/$(params.configMapKey) || \
-               rm /workspace/$(params.configMapKey)
+            kubectl get configmap -n ${NAMESPACE} \
+              ${CONFIG_MAP_NAME} -o template \
+              --template='{{ index .data "${CONFIG_MAP_KEY}" }}' > \
+               /workspace/${CONFIG_MAP_KEY} || \
+               rm /workspace/${CONFIG_MAP_KEY}
         - name: deploy
           image: gcr.io/tekton-releases/dogfooding/kubectl
           script: |
             #!/bin/sh
             set -ex
-            if [ ! -f /workspace/$(params.configMapKey) ]; then
+            if [ ! -f /workspace/${CONFIG_MAP_KEY} ]; then
               echo "First time deployment"
-              kubectl create configmap $(params.configMapName) \
-                --from-file=$(params.configMapKey)=$(resources.inputs.source.path)/$(params.configPath) \
-                -n $(params.namespace)
+              kubectl create configmap ${CONFIG_MAP_NAME} \
+                --from-file=${CONFIG_MAP_KEY}=$(resources.inputs.source.path)/${CONFIG_PATH} \
+                -n ${NAMESPACE}
                 exit 0
             fi
             echo "diff [current-config] [new config]"
             has_diff=0
-            diff /workspace/$(params.configMapKey) \
-              $(resources.inputs.source.path)/$(params.configPath) || has_diff=1
+            diff /workspace/${CONFIG_MAP_KEY} \
+              $(resources.inputs.source.path)/${CONFIG_PATH} || has_diff=1
             if [ $has_diff -eq 0 ]; then
               echo "No change in config detected. Nothing to be done."
               exit 0
             fi
             # Apply configuration changes
-            kubectl create configmap $(params.configMapName) \
-              --from-file=$(params.configMapKey)=$(resources.inputs.source.path)/$(params.configPath) \
+            kubectl create configmap ${CONFIG_MAP_NAME} \
+              --from-file=${CONFIG_MAP_KEY}=$(resources.inputs.source.path)/${CONFIG_PATH} \
               --dry-run -o yaml | \
-              kubectl replace configmap $(params.configMapName) -n $(params.namespace) -f -
+              kubectl replace configmap ${CONFIG_MAP_NAME} -n ${NAMESPACE} -f -
       params:
       - name: configPath
         value: $(tt.params.configPath)

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -57,6 +57,14 @@ spec:
           env:
           - name: KUBECONFIG
             value: /workspace/$(resources.inputs.targetCluster.name)/kubeconfig
+          - name: FOLDER_PATH
+            value: $(params.folderPath)
+          - name: NAMESPACE
+            value: $(params.namespace)
+          - name: DEPLOY_METHOD
+            value: $(params.deployMethod)
+          - name: IS_OVERLAY
+            value: $(params.isOverlay)
         steps:
         - name: deploy-from-folder
           image: gcr.io/tekton-releases/dogfooding/kubectl
@@ -65,15 +73,15 @@ spec:
             set -ex
 
             # Determine whether to enforce namespace across resources
-            NAMESPACE_PARAM="-n $(params.namespace)"
-            [[ "$(params.namespace)" == "" ]] && NAMESPACE_PARAM=""
+            NAMESPACE_PARAM="-n ${NAMESPACE}"
+            [[ "${NAMESPACE}" == "" ]] && NAMESPACE_PARAM=""
 
             # Handle overlays
-            TARGET=$(resources.inputs.source.path)/$(params.folderPath)
-            if [[ "$(params.isOverlay)" == "true" ]]; then
+            TARGET=$(resources.inputs.source.path)/${FOLDER_PATH}
+            if [[ "${IS_OVERLAY}" == "true" ]]; then
               TARGET=target.yaml
               kustomize build \
-                $(resources.inputs.source.path)/$(params.folderPath) > $TARGET
+                $(resources.inputs.source.path)/${FOLDER_PATH} > $TARGET
             fi
 
             # Check if there is any diff
@@ -89,7 +97,7 @@ spec:
             # When deploying with replace, we need to do a create first,
             # to ensure new resources are created
             CREATE_OUTPUT=create.txt
-            if [[ "$(params.deployMethod)" == "replace" ]]; then
+            if [[ "${DEPLOY_METHOD}" == "replace" ]]; then
               kubectl create $NAMESPACE_PARAM -f $TARGET  2> $CREATE_OUTPUT || true
               # If there was some unexpected message in the error log, fail
               if egrep -v '(already exists|^Warning)' $CREATE_OUTPUT; then
@@ -99,7 +107,7 @@ spec:
             fi
 
             # Run the actual deployment. If it fails, it will fail the step.
-            kubectl "$(params.deployMethod)" $NAMESPACE_PARAM -f $TARGET
+            kubectl "${DEPLOY_METHOD}" $NAMESPACE_PARAM -f $TARGET
       params:
       - name: folderPath
         value: $(tt.params.folderPath)

--- a/tekton/resources/cd/helm-template.yaml
+++ b/tekton/resources/cd/helm-template.yaml
@@ -61,6 +61,18 @@ spec:
           env:
           - name: KUBECONFIG
             value: /workspace/$(resources.inputs.targetCluster.name)/kubeconfig
+          - name: CHART_NAME
+            value: $(params.chartName)
+          - name: CHART_VERSION
+            value: $(params.chartVersion)
+          - name: CHART_REPO
+            value: $(params.chartRepo)
+          - name: CHART_PARAMS
+            value: $(params.chartParams)
+          - name: NAMESPACE
+            value: $(params.namespace)
+          - name: PRE_DEPLOY_RESOURCES
+            value: $(params.preDeployResources)
         steps:
         - name: pre-deploy-from-url
           image: gcr.io/tekton-releases/dogfooding/kubectl
@@ -69,7 +81,7 @@ spec:
             set -ex
 
             # Check if we have something to be done
-            if [ "$(params.preDeployResources)" == "" ]; then
+            if [ "${PRE_DEPLOY_RESOURCES}" == "" ]; then
               echo "No pre-deploy resources to deploy, continue"
               exit 0
             fi
@@ -77,8 +89,8 @@ spec:
             # Apply the resources to the same namespace
             kubectl apply \
               --validate=false \
-              -n $(params.namespace) \
-              -f $(params.preDeployResources)
+              -n ${NAMESPACE} \
+              -f ${PRE_DEPLOY_RESOURCES}
 
         - name: helm-deploy
           image: alpine/helm:3.1.2
@@ -86,16 +98,16 @@ spec:
             #!/bin/sh
             set -ex
             echo "Running install/upgrade"
-            echo "with $(params.chartParams)"
+            echo "with ${CHART_PARAMS}"
             helm upgrade \
               --debug \
-              $(params.chartName)-tektoncd-maintained \
-              $(params.chartName) \
+              ${CHART_NAME}-tektoncd-maintained \
+              ${CHART_NAME} \
               --install \
-              --version $(params.chartVersion) \
-              --repo $(params.chartRepo) \
-              --namespace=$(params.namespace) \
-              --set "$(params.chartParams)" \
+              --version ${CHART_VERSION} \
+              --repo ${CHART_REPO} \
+              --namespace=${NAMESPACE} \
+              --set "${CHART_PARAMS}" \
               --wait --timeout 5m
       params:
       - name: chartName

--- a/tekton/resources/images/docker-multi-arch-template.yaml
+++ b/tekton/resources/images/docker-multi-arch-template.yaml
@@ -49,6 +49,10 @@ spec:
             value: /certs/client
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /secret/release.json
+          - name: PLATFORMS
+            value: $(tt.params.platforms)
+          - name: CONTEXT_PATH
+            value: $(tt.params.contextPath)
           image: gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest
           name: build-image-multi-arch
           script: |
@@ -62,15 +66,15 @@ spec:
 
             docker context create context1
 
-            docker buildx create context1 --name builder-buildx1 --driver docker-container --platform $(tt.params.platforms) --use
+            docker buildx create context1 --name builder-buildx1 --driver docker-container --platform ${PLATFORMS} --use
             docker buildx inspect --bootstrap --builder builder-buildx1
 
             cd $(resources.inputs.source.path)
             docker buildx build \
-            --platform $(tt.params.platforms) \
+            --platform ${PLATFORMS} \
             --tag $(resources.outputs.image.url) \
             --push \
-            $(tt.params.contextPath)
+            ${CONTEXT_PATH}
           volumeMounts:
           - mountPath: /certs/client
             name: dind-certs

--- a/tekton/resources/images/ko-multi-arch-template.yaml
+++ b/tekton/resources/images/ko-multi-arch-template.yaml
@@ -42,6 +42,12 @@ spec:
             value: /secret/release.json
           - name: KO_DOCKER_REPO
             value: $(tt.params.registry)/$(tt.params.namespace)
+          - name: PLATFORMS
+            value: $(tt.params.platforms)
+          - name: IMAGE_TAG
+            value: $(tt.params.imageTag)
+          - name: CONTEXT_PATH
+            value: $(tt.params.contextPath)
           image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
           name: build-image-multi-arch
           script: |
@@ -51,7 +57,7 @@ spec:
             gcloud auth configure-docker
 
             cd $(resources.inputs.source.path)
-            ko publish --platform $(tt.params.platforms) --base-import-paths --tags $(tt.params.imageTag) $(tt.params.contextPath)
+            ko publish --platform ${PLATFORMS} --base-import-paths --tags ${IMAGE_TAG} ${CONTEXT_PATH}
           volumeMounts:
           - mountPath: /secret
             name: gcp-secret

--- a/tekton/resources/nightly-release/tasks.yaml
+++ b/tekton/resources/nightly-release/tasks.yaml
@@ -46,9 +46,15 @@ spec:
       value: $(inputs.params.GOARCH)
     - name: GO111MODULE
       value: $(inputs.params.GO111MODULE)
+    - name: FLAGS
+      value: $(inputs.params.flags)
+    - name: PACKAGES
+      value: $(inputs.params.packages)
+    - name: PACKAGE
+      value: $(inputs.params.package)
     image: golang:$(inputs.params.version)
     name: unit-test
     resources: {}
     script: |
-      go test $(inputs.params.flags) $(inputs.params.packages)
-    workingDir: /workspace/src/$(inputs.params.package)
+      go test ${FLAGS} ${PACKAGES}
+    workingDir: /workspace/src/${PACKAGE}

--- a/tekton/resources/nightly-tests/base/deploy_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/base/deploy_tekton_component.yaml
@@ -12,6 +12,13 @@ spec:
   - name: extra-file
     description: extra file to install (for instance, interceptors.yaml for triggers)
     default: ""
+  env:
+  - name: PACKAGE
+    value: $(params.package)
+  - name: VERSION
+    value: $(params.version)
+  - name: EXTRA_FILE
+    value: $(params.extra-file)
   workspaces:
   - name: k8s-shared
     description: workspace for k8s config, configuration file is expected to have `config` name
@@ -25,12 +32,12 @@ spec:
     script: |
       #!/usr/bin/env sh
       set -exo pipefail
-      kubectl apply --filename https://storage.googleapis.com/tekton-releases-nightly/$(params.package)/$(params.version)/release.yaml
-      if [ "$(params.extra-file)" != "" ]; then
-        kubectl apply --filename https://storage.googleapis.com/tekton-releases-nightly/$(params.package)/$(params.version)/$(params.extra-file)
+      kubectl apply --filename https://storage.googleapis.com/tekton-releases-nightly/${PACKAGE}/${VERSION}/release.yaml
+      if [ "${EXTRA_FILE}" != "" ]; then
+        kubectl apply --filename https://storage.googleapis.com/tekton-releases-nightly/${PACKAGE}/${VERSION}/${EXTRA_FILE}
       fi
-      APPLICATION="tekton-$(params.package)"
-      if [ "$(params.package)" == "pipeline" ]; then
+      APPLICATION="tekton-${PACKAGE}"
+      if [ "${PACKAGE}" == "pipeline" ]; then
         APPLICATION="${APPLICATION}s"
       fi
       kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s -l app.kubernetes.io/part-of=$APPLICATION

--- a/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
@@ -33,13 +33,22 @@ spec:
       type: string
       description: create and delete actions are supported
       default: create
+  env:
+    - name: REMOTE_HOST
+      value: $(params.remote-host)
+    - name: REMOTE_USER
+      value: $(params.remote-user)
+    - name: REMOTE_PORT
+      value: $(params.remote-port)
+    - name: ACTION
+      value: $(params.action)
   steps:
     - name: ssh
       image: kroniak/ssh-client
       script: |
-        ssh -p $(params.remote-port) -o StrictHostKeyChecking=no -o LogLevel=ERROR $(params.remote-user)@$(params.remote-host) k8smanager $(params.action)
-        if [ "$(params.action)" == "create" ]; then
-          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P $(params.remote-port) $(params.remote-user)@$(params.remote-host):/root/data/share/config $(workspaces.k8s-shared.path)/config
-          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P $(params.remote-port) $(params.remote-user)@$(params.remote-host):/root/data/share/config.json $(workspaces.registry-shared.path)/config.json
-          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P $(params.remote-port) $(params.remote-user)@$(params.remote-host):/root/data/share/cert.pem $(workspaces.registry-shared.path)/cert.pem
+        ssh -p ${REMOTE_PORT} -o StrictHostKeyChecking=no -o LogLevel=ERROR ${REMOTE_USER}@${REMOTE_HOST} k8smanager ${ACTION}
+        if [ "${ACTION}" == "create" ]; then
+          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P ${REMOTE_PORT} ${REMOTE_USER}@${REMOTE_HOST}:/root/data/share/config $(workspaces.k8s-shared.path)/config
+          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P ${REMOTE_PORT} ${REMOTE_USER}@${REMOTE_HOST}:/root/data/share/config.json $(workspaces.registry-shared.path)/config.json
+          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P ${REMOTE_PORT} ${REMOTE_USER}@${REMOTE_HOST}:/root/data/share/cert.pem $(workspaces.registry-shared.path)/cert.pem
         fi

--- a/tekton/resources/nightly-tests/bastion-z/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/k8s_cluster_setup.yaml
@@ -31,8 +31,17 @@ spec:
   steps:
     - name: ssh
       image: kroniak/ssh-client
+      env:
+      - name: REMOTE_HOST
+        value: $(params.remote-host)
+      - name: REMOTE_PORT
+        value: $(params.remote-port)
+      - name: REMOTE_USER
+        value: $(params.remote-user)
+      - name: ACTION
+        value: $(params.action)
       script: |
-        ssh -p $(params.remote-port) -o StrictHostKeyChecking=no -o LogLevel=ERROR $(params.remote-user)@$(params.remote-host) k8smanager $(params.action)
-        if [ "$(params.action)" == "create" ]; then
-          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P $(params.remote-port) $(params.remote-user)@$(params.remote-host):/home/k8smanager/kubeconfig/kubeconfig.conf $(workspaces.k8s-shared.path)/config
+        ssh -p ${REMOTE_HOST} -o StrictHostKeyChecking=no -o LogLevel=ERROR ${REMOTE_USER}@${REMOTE_HOST} k8smanager ${ACTION}
+        if [ "${ACTION}" == "create" ]; then
+          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P ${REMOTE_PORT} ${REMOTE_USER}@${REMOTE_HOST}:/home/k8smanager/kubeconfig/kubeconfig.conf $(workspaces.k8s-shared.path)/config
         fi

--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -46,6 +46,8 @@ spec:
         value: $(params.package)
       - name: OLD_VERSION
         value: $(params.previous-release-tag)
+      - name: RELEASE_NAME
+        value: $(params.release-name)
   steps:
     - name: header
       image: gcr.io/tekton-releases/dogfooding/hub
@@ -55,7 +57,7 @@ spec:
         TEKTON_PROJECT=$(basename $PROJECT)
 
         cat <<EOF | tee $HOME/release.md
-        Tekton ${TEKTON_PROJECT^} release ${VERSION} "$(params.release-name)"
+        Tekton ${TEKTON_PROJECT^} release ${VERSION} "${RELEASE_NAME}"
 
         # 🎉 [Tag Line - to be done] 🎉
 

--- a/tekton/resources/release/base/install_tekton_release.yaml
+++ b/tekton/resources/release/base/install_tekton_release.yaml
@@ -43,11 +43,22 @@ spec:
         type: cluster
       - name: plumbing-library
         type: git
-
   stepTemplate:
     env:
       - name: KUBECONFIG
         value: /workspace/$(resources.inputs.k8s-cluster.name)/kubeconfig
+      - name: PROJECT_NAME
+        value: $(params.projectName)
+      - name: NAMESPACE
+        value: $(params.namespace)
+      - name: VERSION
+        value: $(params.version)
+      - name: ENVIRONMENT
+        value: $(params.environment)
+      - name: RELEASE_FILE
+        value: $(params.release-file)
+      - name: POST_RELEASE_FILE
+        value: $(params.post-release-file)
 
   steps:
 
@@ -60,29 +71,29 @@ spec:
       # Export KUBECONFIG so that it's available to pre-scripts too
       export KUBECONFIG
       # Set up RELEASE_ROOT
-      if [[ "$(params.version)" == "latest" ]]; then
-        RELEASE_ROOT=$(resources.inputs.release-bucket.path)/$(params.version)
+      if [[ "${VERSION}" == "latest" ]]; then
+        RELEASE_ROOT=$(resources.inputs.release-bucket.path)/${VERSION}
       else
-        RELEASE_ROOT=$(resources.inputs.release-bucket.path)/previous/$(params.version)
+        RELEASE_ROOT=$(resources.inputs.release-bucket.path)/previous/${VERSION}
       fi
 
       # Handle Overlays
-      OVERLAY_FOLDER=$(params.projectName)/overlays/$(params.environment)
+      OVERLAY_FOLDER=${PROJECT_NAME}/overlays/${ENVIRONMENT}
       APPLY_MODE="-k $OVERLAY_FOLDER"
 
       cd $(resources.inputs.plumbing-library.path)/tekton/cd
 
-      if [ ! -d $(params.projectName) ]; then
-        # There are is not base or project for $(params.projectName)
+      if [ ! -d ${PROJECT_NAME} ]; then
+        # There are is not base or project for ${PROJECT_NAME}
         # Apply the release as is
-        APPLY_MODE="--filename $RELEASE_ROOT/$(params.release-file)"
+        APPLY_MODE="--filename $RELEASE_ROOT/${RELEASE_FILE}"
       else
         # If the base exists, an overlay for the specified environment must exist
         if [ ! -d  "$OVERLAY_FOLDER" ]; then
-          echo "Environment $(params.environment) not found for project $(params.projectName)"
+          echo "Environment ${ENVIRONMENT} not found for project ${PARAM.PROJECT_NAME}"
           exit 1
         fi
-        cp $RELEASE_ROOT/$(params.release-file) $(params.projectName)/base/release.yaml
+        cp $RELEASE_ROOT/${RELEASE_FILE} ${PROJECT_NAME}/base/release.yaml
         find .
 
         # Execute pre-deploy scripts if any
@@ -96,12 +107,12 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -exo pipefail
-      APPLICATION="tekton-$(params.projectName)"
-      if [ "$(params.projectName)" == "pipeline" ]; then
+      APPLICATION="tekton-${PROJECT_NAME}"
+      if [ "${PROJECT_NAME}" == "pipeline" ]; then
         APPLICATION="${APPLICATION}s"
       fi
       # Wait for pods to be ready and CRDs to be established
-      kubectl wait --for condition=ready --timeout=120s pods -l app.kubernetes.io/part-of=$APPLICATION -n $(params.namespace)
+      kubectl wait --for condition=ready --timeout=120s pods -l app.kubernetes.io/part-of=$APPLICATION -n ${NAMESPACE}
       kubectl wait --for condition=established --timeout=60s crd -l app.kubernetes.io/part-of=$APPLICATION
 
 
@@ -110,14 +121,14 @@ spec:
     script: |
       #!/usr/bin/env bash
       set -exo pipefail
-      if [ "$(params.post-release-file)" != "" ]; then
+      if [ "${POST_RELEASE_FILE}" != "" ]; then
           # Set up RELEASE_ROOT
-          if [[ "$(params.version)" == "latest" ]]; then
-            RELEASE_ROOT=$(resources.inputs.release-bucket.path)/$(params.version)
+          if [[ "${VERSION}" == "latest" ]]; then
+            RELEASE_ROOT=$(resources.inputs.release-bucket.path)/${VERSION}
           else
-            RELEASE_ROOT=$(resources.inputs.release-bucket.path)/previous/$(params.version)
+            RELEASE_ROOT=$(resources.inputs.release-bucket.path)/previous/${VERSION}
           fi
-          kubectl apply --kubeconfig $KUBECONFIG -f $RELEASE_ROOT/$(params.post-release-file)
+          kubectl apply --kubeconfig $KUBECONFIG -f $RELEASE_ROOT/${POST_RELEASE_FILE}
       fi
 
 ---
@@ -140,15 +151,20 @@ spec:
 
   - name: compare-github-vs-bucket
     image: gcr.io/tekton-releases/tests/test-runner
+    env:
+    - name: PROJECT_NAME
+      value: $(params.projectName)
+    - name: VERSION
+      value: $(params.version)
     command:
     - /bin/sh
     args:
     - -ce
     - |
-      curl -L https://github.com/tektoncd/$(params.projectName)/releases/download/$(params.version)/release.yaml > /workspace/release-github.yaml
+      curl -L https://github.com/tektoncd/${PROJECT_NAME}/releases/download/${VERSION}/release.yaml > /workspace/release-github.yaml
       diff \
         /workspace/release-github.yaml \
-        $(resources.inputs.release-bucket.path)/$(params.projectName)/previous/$(params.version)/release.yaml # Diff exists with 0 only if there is no difference
+        $(resources.inputs.release-bucket.path)/${PROJECT_NAME}/previous/${VERSION}/release.yaml # Diff exists with 0 only if there is no difference
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
@@ -172,6 +188,16 @@ spec:
         type: cluster
       - name: plumbing-library
         type: git
+  stepTemplate:
+    env:
+    - name: PROJECT_NAME
+      value: $(params.projectName)
+    - name: NAMESPACE
+      value: $(params.namespace)
+    - name: VERSION
+      value: $(params.version)
+    - name: RESOURCES
+      value: $(params.resources)
   steps:
 
   - name: cleanup-resources
@@ -182,7 +208,7 @@ spec:
     - -ce
     - |
       # Make sure that everything is cleaned up in the current namespace.
-      for res in $(params.resources); do
+      for res in ${RESOURCES}; do
         kubectl delete --ignore-not-found=true ${res}.tekton.dev --all \
         --kubeconfig /workspace/$(resources.inputs.k8s-cluster.name)/kubeconfig
       done
@@ -199,7 +225,7 @@ spec:
     - |
       source $(resources.inputs.plumbing-library.path)/scripts/library.sh
 
-      kubectl delete --ignore-not-found=true -f "https://github.com/tektoncd/$(params.projectName)/releases/download/$(params.version)/release.yaml" \
+      kubectl delete --ignore-not-found=true -f "https://github.com/tektoncd/${PROJECT_NAME}/releases/download/${VERSION}/release.yaml" \
       --kubeconfig /workspace/$(resources.inputs.k8s-cluster.name)/kubeconfig
 
-      wait_until_object_does_not_exist namespace $(params.namespace)
+      wait_until_object_does_not_exist namespace ${NAMESPACE}

--- a/tekton/resources/release/base/prerelease_checks.yaml
+++ b/tekton/resources/release/base/prerelease_checks.yaml
@@ -25,6 +25,13 @@ spec:
   - name: releaseBucket
     description: >-
       The bucket where to look for the release, in the format gs://<bucket-name>/<project-name>
+  env:
+  - name: PACKAGE
+    value: $(params.package)
+  - name: VERSION_TAG
+    value: $(params.versionTag)
+  - name: RELEASE_BUCKET
+    value: $(params.releaseBucket)
   workspaces:
     - name: source-to-release
       description: The workspace where the repo has been cloned
@@ -35,9 +42,9 @@ spec:
         echo "Checking git tag"
         # Look for the tag in the list of tags
         git ls-remote --tags https://$(params.package) | \
-          grep "$(params.versionTag)$" || exit 0
+          grep "${VERSION_TAG}$" || exit 0
         # If the version was found fail
-        echo "Version $(params.versionTag) already tagged for $(params.package)"
+        echo "Version ${VERSION_TAG} already tagged for ${PACKAGE}"
         exit 1
     - name: check-release-file
       image: gcr.io/google.com/cloudsdktool/cloud-sdk:310.0.0@sha256:cb03669fcdb9191d55a6200f2911fff3baec0b8c39b156d95b68aabe975ac506
@@ -45,7 +52,7 @@ spec:
         echo "Checking release file"
         # Check if the release file already exists
         # gsutil retuns 1 if the object was not found
-        if gsutil stat $(params.releaseBucket)/previous/$(params.versionTag)/release.yaml; then
+        if gsutil stat ${RELEASE_BUCKET}/previous/${VERSION_TAG}/release.yaml; then
           echo "Release file already exists for $(params.versionTag) in the release bucket,"
           echo "but no git tag was found. To continue remove the release file first."
           exit 1
@@ -54,16 +61,16 @@ spec:
       image: python:3.6-alpine3.9
       script: |
         echo "Checking GitHub release"
-        PACKAGE=$(echo $(params.package) | cut -d/ -f2,3)
+        PACKAGE=$(echo ${PACKAGE} | cut -d/ -f2,3)
         # Check if the release exists on GitHub
         wget -q -O- --header 'Accept: application/vnd.github.v3+json' \
           https://api.github.com/repos/${PACKAGE}/releases | \
           python -c 'import sys; import json; print("\n".join([x["tag_name"] for x in json.load(sys.stdin)]))' | \
-          grep "$(params.versionTag)$" || exit 0
-        echo "Release $(params.versionTag) already exists for $(params.package)"
+          grep "${VERSION_TAG}$" || exit 0
+        echo "Release ${VERSION_TAG} already exists for ${PACKAGE}"
         exit 1
     - name: success-confirmation
       image: alpine
       script: |
-        echo "All pre-release checks for $(params.package) @ $(params.versionTag) where successful"
+        echo "All pre-release checks for ${PACKAGE} @ ${VERSION_TAG} where successful"
         echo "Happy releasing 😺"


### PR DESCRIPTION
# Changes

Prior to this commit we had several script blocks using the syntax
`$(params.foo)` to pull in param values. As per https://github.com/tektoncd/plumbing/issues/971
it is advised to pull these usages into environment variables to
improve robustness (unexpected characters in param values like quotes and ampersands
can cause confusing issues when a script runs) and to remove
one avenue of script injection in scenarios when a param includes
user-submitted content.

This PR patches resources in the cd, images, nightly-release,
nightly-tests and release/base directories to move param referencing
into environment variables.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._