### PR TITLE
Fix two small issues with catlin script param detection

### DIFF
--- a/catlin/pkg/validator/task_validator.go
+++ b/catlin/pkg/validator/task_validator.go
@@ -28,7 +28,6 @@ import (
 const (
 	parameterSubstitution = `[_a-zA-Z][_a-zA-Z0-9.-]*(\[\*\])?`
 	braceMatchingRegex    = "(\\$(\\(%s.(?P<var>%s)\\)))"
-	parameterName         = `params\.(` + parameterSubstitution + `)`
 )
 
 type taskValidator struct {

--- a/catlin/pkg/validator/task_validator_test.go
+++ b/catlin/pkg/validator/task_validator_test.go
@@ -324,8 +324,8 @@ func TestTaskValidator_ScriptUsingParams(t *testing.T) {
 	assert.Equal(t, 2, len(result.Lints))
 
 	assert.Equal(t, Warning, result.Lints[0].Kind)
-	assert.Equal(t, `Step "s1" references "$(params.secret)" directly from its script block. Consider putting the param into an environment variable of the Step and accessing that environment variable in your script instead.`, result.Lints[0].Message)
+	assert.Equal(t, `Step "s1" references "$(params.secret)" directly from its script block. For reliability and security, consider putting the param into an environment variable of the Step and accessing that environment variable in your script instead.`, result.Lints[0].Message)
 
 	assert.Equal(t, Warning, result.Lints[1].Kind)
-	assert.Equal(t, `Step "s2" references "$(params.secret)" directly from its script block. Consider putting the param into an environment variable of the Step and accessing that environment variable in your script instead.`, result.Lints[1].Message)
+	assert.Equal(t, `Step "s2" references "$(params.secret)" directly from its script block. For reliability and security, consider putting the param into an environment variable of the Step and accessing that environment variable in your script instead.`, result.Lints[1].Message)
 }


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->


Prior to this commit catlin unit tests would fail because
the expected error message didn't exactly match the output
of the validator.

This commit removes an unused regex pattern and fixes the
unit test.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
