### PR TITLE
Add back add-pr-body to catalog-issue-comment

### DIFF
--- a/tekton/ci/catalog/trigger.yaml
+++ b/tekton/ci/catalog/trigger.yaml
@@ -29,6 +29,19 @@ spec:
     - cel:
         filter: >-
           body.repository.full_name == 'tektoncd/catalog'
+        overlays:
+        - key: add_pr_body.pull_request_url
+          expression: "body.issue.pull_request.url"
+    - webhook:
+        objectRef:
+          kind: Service
+          name: add-pr-body
+          apiVersion: v1
+          namespace: tekton-ci
+    - cel:
+        overlays:
+        - key: git_clone_depth
+          expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The trigger needs this interceptor to get the PR body.
This was probably a miss from #968 since the other issue comment
triggers all have the interceptor added back.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._