### PR TITLE
Fix a few misplaced "env" in tasks

### DIFF
--- a/tekton/resources/nightly-tests/base/deploy_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/base/deploy_tekton_component.yaml
@@ -12,13 +12,6 @@ spec:
   - name: extra-file
     description: extra file to install (for instance, interceptors.yaml for triggers)
     default: ""
-  env:
-  - name: PACKAGE
-    value: $(params.package)
-  - name: VERSION
-    value: $(params.version)
-  - name: EXTRA_FILE
-    value: $(params.extra-file)
   workspaces:
   - name: k8s-shared
     description: workspace for k8s config, configuration file is expected to have `config` name
@@ -29,6 +22,12 @@ spec:
     env:
     - name: KUBECONFIG
       value: $(workspaces.k8s-shared.path)/config
+    - name: PACKAGE
+      value: $(params.package)
+    - name: VERSION
+      value: $(params.version)
+    - name: EXTRA_FILE
+      value: $(params.extra-file)
     script: |
       #!/usr/bin/env sh
       set -exo pipefail

--- a/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
@@ -33,18 +33,18 @@ spec:
       type: string
       description: create and delete actions are supported
       default: create
-  env:
-    - name: REMOTE_HOST
-      value: $(params.remote-host)
-    - name: REMOTE_USER
-      value: $(params.remote-user)
-    - name: REMOTE_PORT
-      value: $(params.remote-port)
-    - name: ACTION
-      value: $(params.action)
   steps:
     - name: ssh
       image: kroniak/ssh-client
+      env:
+        - name: REMOTE_HOST
+          value: $(params.remote-host)
+        - name: REMOTE_USER
+          value: $(params.remote-user)
+        - name: REMOTE_PORT
+          value: $(params.remote-port)
+        - name: ACTION
+          value: $(params.action)
       script: |
         ssh -p ${REMOTE_PORT} -o StrictHostKeyChecking=no -o LogLevel=ERROR ${REMOTE_USER}@${REMOTE_HOST} k8smanager ${ACTION}
         if [ "${ACTION}" == "create" ]; then

--- a/tekton/resources/release/base/prerelease_checks.yaml
+++ b/tekton/resources/release/base/prerelease_checks.yaml
@@ -25,13 +25,14 @@ spec:
   - name: releaseBucket
     description: >-
       The bucket where to look for the release, in the format gs://<bucket-name>/<project-name>
-  env:
-  - name: PACKAGE
-    value: $(params.package)
-  - name: VERSION_TAG
-    value: $(params.versionTag)
-  - name: RELEASE_BUCKET
-    value: $(params.releaseBucket)
+  stepTemplate:
+    env:
+    - name: PACKAGE
+      value: $(params.package)
+    - name: VERSION_TAG
+      value: $(params.versionTag)
+    - name: RELEASE_BUCKET
+      value: $(params.releaseBucket)
   workspaces:
     - name: source-to-release
       description: The workspace where the repo has been cloned


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A few recent PRs improved on the use of params replacement, by setting
up environment variables to be used in scripts instead of resolving
params directly in there. A few "env" however have been misplaced under
the task spec directly, instead of going in a step or stepTemplate.
This PR fixes the issue.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug