### PR TITLE
Fix missing double quote in check-github-tasks-completed

### DIFF
--- a/tekton/ci/jobs/tekton-github-tasks-completed.yaml
+++ b/tekton/ci/jobs/tekton-github-tasks-completed.yaml
@@ -34,7 +34,7 @@ spec:
           # Check failed. Return exit code 1.
           # sys.exit(1)
         else:
-          print("Found no incomplete GitHub Tasks)
+          print("Found no incomplete GitHub Tasks")
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`tekton/ci/jobs/tekton-github-tasks-completed.yaml` was missing a closing double-quote, causing [errors like this](https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-ci/pipelineruns/check-github-tasks-completed-n4m57?pipelineTask=github-tasks-completed&step=check-github-tasks-completed).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._