### PR TITLE
Fix k8s cluster creation for s390x tests

### DIFF
--- a/tekton/resources/nightly-tests/bastion-z/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/k8s_cluster_setup.yaml
@@ -41,7 +41,7 @@ spec:
       - name: ACTION
         value: $(params.action)
       script: |
-        ssh -p ${REMOTE_HOST} -o StrictHostKeyChecking=no -o LogLevel=ERROR ${REMOTE_USER}@${REMOTE_HOST} k8smanager ${ACTION}
+        ssh -p ${REMOTE_PORT} -o StrictHostKeyChecking=no -o LogLevel=ERROR ${REMOTE_USER}@${REMOTE_HOST} k8smanager ${ACTION}
         if [ "${ACTION}" == "create" ]; then
           scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -P ${REMOTE_PORT} ${REMOTE_USER}@${REMOTE_HOST}:/home/k8smanager/kubeconfig/kubeconfig.conf $(workspaces.k8s-shared.path)/config
         fi


### PR DESCRIPTION
# Changes

At this moment REMOTE_HOST env variable is used for port specification in k8s cluster creation task for s390x tests, which is wrong.
It should be REMOTE_PORT instead.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._