### PR TITLE
Fix kind-label: import os

### DIFF
--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -36,6 +36,7 @@ spec:
       import json
       import yaml
       import sys
+      import os
 
       prLabelsText = os.getenv('LABELS')
       prLabels = json.loads(prLabelsText)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The check-kind-labels PipelineRuns are failing with this error:

> NameError: name 'os' is not defined

In this change, we import os which is needed in the python script.

Related PR: https://github.com/tektoncd/plumbing/pull/974

[Example](https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-ci/pipelineruns/check-pr-labels-rvgp8?pipelineTask=kind-label&step=check-labels)

/cc @sbwsg @dibyom @abayer 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._