### PR TITLE
Fix PipelineRef in Operator nightly

### DIFF
--- a/tekton/resources/nightly-release/overlays/operator/template.yaml
+++ b/tekton/resources/nightly-release/overlays/operator/template.yaml
@@ -7,7 +7,7 @@
         generateName: operator-release-nightly-
       spec:
         pipelineRef:
-          name: operator-nightly-release
+          name: operator-release
         params:
         - name: package
           value: $(tt.params.gitrepository)


### PR DESCRIPTION
Rename the PipelineRef in Operator nightly Triggertemplate

As the same pipeline is used for versioned releases and
nightly releases for the operator now, the PipelineRef name will
be same as in the versioned release PipelineRuns

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._