### PR TITLE
Add extra disk space for dashboard nightly tests to resolve current failure

### DIFF
--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 4Gi
+                storage: 5Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 4Gi
+                storage: 5Gi
       # this workspace will be used to store ssh key
       - name: ssh-secret
         secret:


### PR DESCRIPTION
# Changes

At this moment dashboard nightly tests are failing for Z and P with `no space left on device` error. 
The fix adds extra disk space to the pipelinerun to resolve this problem.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._