### PR TITLE
Make Scripts Mac-Friendly

### DIFF
--- a/hack/tekton_ci.sh
+++ b/hack/tekton_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
 
 declare GITHUB_USER GITHUB_TOKEN GITHUB_ORG GITHUB_REPO

--- a/hack/tekton_in_kind.sh
+++ b/hack/tekton_in_kind.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
 
 declare TEKTON_PIPELINE_VERSION TEKTON_TRIGGERS_VERSION TEKTON_DASHBOARD_VERSION

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE POST_RELEASE_FILE

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Tekton Authors
 #

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Tekton Authors
 #

--- a/scripts/presubmit-tests.sh
+++ b/scripts/presubmit-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Tekton Authors
 #

--- a/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
+++ b/tekton/cd/pipeline/overlays/robocat/pre/100-inject-minio-creds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Grab Minio credentials and injects them in the storage secret used by
 # Tekton Pipeline


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Today, these scripts use `#!/bin/bash` which causes errors in Mac.

To make the scripts work for Mac, and any other operating system,
the scripts need to check the version of bash that's set as default
for the systems. So, this commit updates the scripts to use
`#!/usr/bin/env bash`. This allows Mac to use bash 4.

Related issues and pull requests in knative/test-infra: 
- https://github.com/knative/test-infra/pull/1350
- https://github.com/knative-sandbox/net-contour/issues/638
- https://github.com/knative/test-infra/issues/2143

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._