### PR TITLE
Add `catlin bump` feature to bump catalog entries

### DIFF
--- a/catlin/README.md
+++ b/catlin/README.md
@@ -20,4 +20,22 @@ This command validates
 catlin validate <path-to-resource-file>
 ```
 
+### Bump
+
+This command bumps the version of an existing resource in the catalog.
+After running this command a new version of the given resource will be
+created in its own directory and the latest version of that resource
+will be copied into it, ready for editing.
+
+```
+catlin bump <path-to-resource-directory>
+```
+
+This example bumps the version of git-clone:
+
+```bash
+$ catlin bump task/git-clone
+Copying task/git-clone/0.5 to task/git-clone/0.6
+```
+
 [tep]:https://github.com/tektoncd/community/blob/main/teps/0003-tekton-catalog-organization.md

--- a/catlin/go.mod
+++ b/catlin/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/google/go-containerregistry v0.1.1
+	github.com/otiai10/copy v1.7.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
 	github.com/tektoncd/pipeline v0.15.2

--- a/catlin/go.sum
+++ b/catlin/go.sum
@@ -876,8 +876,12 @@ github.com/openzipkin/zipkin-go v0.2.0/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb9NAWI=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
+github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
+github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/catlin/pkg/cmd/bump/bump.go
+++ b/catlin/pkg/cmd/bump/bump.go
@@ -1,0 +1,52 @@
+package bump
+
+import (
+	"fmt"
+	"path/filepath"
+
+	dircp "github.com/otiai10/copy"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/plumbing/catlin/pkg/app"
+	"github.com/tektoncd/plumbing/catlin/pkg/entry"
+)
+
+func Command(p app.CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:     "bump",
+		Args:    validResourcePath(),
+		Short:   "Bump version of existing catalog entry",
+		Long:    "Creates a new version of an existing catalog entry by copying its latest version into a new directory",
+		Example: "catlin bump task/ansible-runner",
+		RunE:    bumpVersion,
+	}
+}
+
+func bumpVersion(cmd *cobra.Command, args []string) error {
+	entryPath := args[0]
+	ent, err := entry.FromPath(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid catalog entry: %v", err)
+	}
+	latestVersion, err := ent.GetLatestVersion()
+	if err != nil {
+		return fmt.Errorf("error reading latest version of catalog entry: %v", err)
+	}
+	oldVersionPath := filepath.Join(entryPath, latestVersion.String())
+	newVersionPath := filepath.Join(entryPath, latestVersion.BumpMinor().String())
+	fmt.Printf("Copying %s to %s\n", oldVersionPath, newVersionPath)
+	dircp.Copy(oldVersionPath, newVersionPath)
+	return nil
+}
+
+func validResourcePath() cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf(`requires exactly one path to an existing catalog entry. e.g. "./task/foo-bar"`)
+		}
+
+		if _, err := entry.FromPath(args[0]); err != nil {
+			return fmt.Errorf("invalid catalog entry: %v", err)
+		}
+		return nil
+	}
+}

--- a/catlin/pkg/cmd/root.go
+++ b/catlin/pkg/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/plumbing/catlin/pkg/app"
+	"github.com/tektoncd/plumbing/catlin/pkg/cmd/bump"
 	"github.com/tektoncd/plumbing/catlin/pkg/cmd/linter"
 	"github.com/tektoncd/plumbing/catlin/pkg/cmd/validate"
 )
@@ -32,6 +33,7 @@ func Root(cli app.CLI) *cobra.Command {
 	cmd.AddCommand(
 		validate.Command(cli),
 		linter.Command(cli),
+		bump.Command(cli),
 	)
 
 	return cmd

--- a/catlin/pkg/entry/entry.go
+++ b/catlin/pkg/entry/entry.go
@@ -1,0 +1,65 @@
+package entry
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// Entry represents a resource in the catalog, such as "task/git-clone" or
+// "pipeline/build-and-deploy".
+type Entry struct {
+	fs fs.FS
+}
+
+// FromPath returns a catalog Entry from a given string path if that
+// path leads to a correctly-structured catalog entry on disk, or an
+// error if not.
+func FromPath(resourcePath string) (*Entry, error) {
+	entryFS := os.DirFS(resourcePath)
+	if _, err := getLatestVersion(entryFS); err != nil {
+		return nil, err
+	}
+	entry := &Entry{
+		fs: entryFS,
+	}
+	return entry, nil
+}
+
+// GetLatestVersion returns the Version with the greatest major/minor
+// values from the catalog entry's directory.
+func (entry *Entry) GetLatestVersion() (Version, error) {
+	if entry == nil {
+		return Version{}, fmt.Errorf("invalid catalog entry")
+	}
+	return getLatestVersion(entry.fs)
+}
+
+func getLatestVersion(entryFS fs.FS) (Version, error) {
+	versions, err := fs.ReadDir(entryFS, ".")
+	if err != nil {
+		return Version{}, fmt.Errorf("error reading catalog entry directory: %v", err)
+	}
+	latestVersion := zeroVersion
+	for _, versionDir := range versions {
+		name := versionDir.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if !versionDir.IsDir() {
+			continue
+		}
+		ver, err := ParseVersion(name)
+		if err != nil {
+			return latestVersion, fmt.Errorf("version parse error: %v", err)
+		}
+		if ver.Gt(latestVersion) {
+			latestVersion = ver
+		}
+	}
+	if latestVersion.Eq(zeroVersion) {
+		return latestVersion, fmt.Errorf("no versions found")
+	}
+	return latestVersion, nil
+}

--- a/catlin/pkg/entry/entry_test.go
+++ b/catlin/pkg/entry/entry_test.go
@@ -1,0 +1,62 @@
+package entry
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestGetLatestVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		entry           Entry
+		expectedVersion Version
+	}{{
+		name: "single catalog entry version parsed correctly",
+		entry: Entry{
+			fs: fstest.MapFS{
+				"0.1/test.yaml": &fstest.MapFile{},
+			},
+		},
+		expectedVersion: Version{0, 1},
+	}, {
+		name: "multiple catalog entry versions returns latest correctly",
+		entry: Entry{
+			fs: fstest.MapFS{
+				"0.2/test.yaml": &fstest.MapFile{},
+				"0.3/test.yaml": &fstest.MapFile{},
+				"0.1/test.yaml": &fstest.MapFile{},
+			},
+		},
+		expectedVersion: Version{0, 3},
+	}, {
+		name: "non-consecutive catalog entry versions returns latest correctly",
+		entry: Entry{
+			fs: fstest.MapFS{
+				"4.8/test.yaml": &fstest.MapFile{},
+				"0.2/test.yaml": &fstest.MapFile{},
+				"0.1/test.yaml": &fstest.MapFile{},
+			},
+		},
+		expectedVersion: Version{4, 8},
+	}, {
+		name: "catalog entry with versions starting after 0.1 returns latest correctly",
+		entry: Entry{
+			fs: fstest.MapFS{
+				"2.91/test.yaml":    &fstest.MapFile{},
+				"13.7/test.yaml":    &fstest.MapFile{},
+				"1.11111/test.yaml": &fstest.MapFile{},
+			},
+		},
+		expectedVersion: Version{13, 7},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			entryVersion, err := tc.entry.GetLatestVersion()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !entryVersion.Eq(tc.expectedVersion) {
+				t.Errorf("expected version %s received %s", tc.expectedVersion, entryVersion)
+			}
+		})
+	}
+}

--- a/catlin/pkg/entry/version.go
+++ b/catlin/pkg/entry/version.go
@@ -1,0 +1,60 @@
+package entry
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var zeroVersion = Version{0, 0}
+
+// Version represents a catalog entry's version in "major.minor" format.
+type Version struct {
+	Major int64
+	Minor int64
+}
+
+func (rv Version) Eq(other Version) bool {
+	return rv.Major == other.Major && rv.Minor == other.Minor
+}
+
+func (rv Version) Lt(other Version) bool {
+	if rv.Major < other.Major {
+		return true
+	}
+	return rv.Major == other.Major && rv.Minor < other.Minor
+}
+
+func (rv Version) Gt(other Version) bool {
+	if rv.Major > other.Major {
+		return true
+	}
+	return rv.Major == other.Major && rv.Minor > other.Minor
+}
+
+func (rv Version) String() string {
+	return fmt.Sprintf("%d.%d", rv.Major, rv.Minor)
+}
+
+func (rv Version) BumpMinor() Version {
+	return Version{
+		Major: rv.Major,
+		Minor: rv.Minor + 1,
+	}
+}
+
+func ParseVersion(from string) (Version, error) {
+	parsed := Version{}
+	version := strings.SplitN(from, ".", 2)
+	if len(version) != 2 {
+		return parsed, fmt.Errorf("incorrectly formatted version directory %q", from)
+	}
+	var err error
+	if parsed.Major, err = strconv.ParseInt(version[0], 10, 64); err != nil {
+		return parsed, fmt.Errorf("error parsing major version from %q: %v", from, err)
+	}
+	if parsed.Minor, err = strconv.ParseInt(version[1], 10, 64); err != nil {
+		return parsed, fmt.Errorf("error parsing minor version from %q: %v", from, err)
+	}
+	return parsed, nil
+}

--- a/catlin/pkg/entry/version_test.go
+++ b/catlin/pkg/entry/version_test.go
@@ -1,0 +1,262 @@
+package entry
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	for _, tc := range []struct {
+		from     string
+		expected Version
+	}{{
+		from:     "0.1",
+		expected: Version{0, 1},
+	}, {
+		from:     "0.8",
+		expected: Version{0, 8},
+	}, {
+		from:     "9.0",
+		expected: Version{9, 0},
+	}, {
+		from:     "3.14159",
+		expected: Version{3, 14159},
+	}, {
+		from:     "780001.2",
+		expected: Version{780001, 2},
+	}, {
+		from:     "00001.00004",
+		expected: Version{1, 4},
+	}} {
+		t.Run(tc.from, func(t *testing.T) {
+			parsed, err := ParseVersion(tc.from)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !parsed.Eq(tc.expected) {
+				t.Fatalf("expected %s received %s", tc.expected, parsed)
+			}
+		})
+	}
+}
+
+func TestParseVersionErrors(t *testing.T) {
+	for _, tc := range []struct {
+		from string
+	}{{
+		from: "abc0.1",
+	}, {
+		from: "0.abc8",
+	}, {
+		from: "_9.0",
+	}, {
+		from: "3.141_59",
+	}, {
+		from: "78,0001.2",
+	}, {
+		from: "00001.00,004",
+	}, {
+		from: "    1.9",
+	}, {
+		from: "1.9    ",
+	}, {
+		from: "this is not a version",
+	}, {
+		from: "1",
+	}, {
+		from: "1.",
+	}, {
+		from: ".1",
+	}, {
+		from: "1.1.1",
+	}, {
+		from: "o123.123",
+	}, {
+		from: "b1001.101",
+	}, {
+		from: "0x14.9",
+	}} {
+		t.Run(tc.from, func(t *testing.T) {
+			_, err := ParseVersion(tc.from)
+			if err == nil {
+				t.Fatalf("expected error but %q appears to have been parsed as valid", tc.from)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	for _, tc := range []struct {
+		expected string
+		from     Version
+	}{{
+		expected: "0.1",
+		from:     Version{0, 1},
+	}, {
+		expected: "0.8",
+		from:     Version{0, 8},
+	}, {
+		expected: "9.0",
+		from:     Version{9, 0},
+	}, {
+		expected: "3.14159",
+		from:     Version{3, 14159},
+	}, {
+		expected: "780001.2",
+		from:     Version{780001, 2},
+	}, {
+		expected: "1.4",
+		from:     Version{1, 4},
+	}} {
+		t.Run(tc.expected, func(t *testing.T) {
+			str := tc.from.String()
+			if str != tc.expected {
+				t.Fatalf("expected %s received %s", tc.expected, str)
+			}
+		})
+	}
+}
+
+func TestBumpMinor(t *testing.T) {
+	for _, tc := range []struct {
+		from     string
+		expected Version
+	}{{
+		from:     "0.1",
+		expected: Version{0, 2},
+	}, {
+		from:     "0.8",
+		expected: Version{0, 9},
+	}, {
+		from:     "9.0",
+		expected: Version{9, 1},
+	}, {
+		from:     "3.14159",
+		expected: Version{3, 14160},
+	}, {
+		from:     "780001.2",
+		expected: Version{780001, 3},
+	}, {
+		from:     "00001.00004",
+		expected: Version{1, 5},
+	}} {
+		t.Run(tc.from, func(t *testing.T) {
+			parsed, err := ParseVersion(tc.from)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			bumped := parsed.BumpMinor()
+			if !bumped.Eq(tc.expected) {
+				t.Fatalf("expected %s received %s", tc.expected, parsed)
+			}
+		})
+	}
+}
+
+func TestGt(t *testing.T) {
+	for _, tc := range []struct {
+		upper    Version
+		lower    Version
+		expected bool
+	}{{
+		upper:    Version{0, 2},
+		lower:    Version{0, 1},
+		expected: true,
+	}, {
+		upper:    Version{0, 9},
+		lower:    Version{0, 8},
+		expected: true,
+	}, {
+		upper:    Version{9, 1},
+		lower:    Version{6, 0},
+		expected: true,
+	}, {
+		upper:    Version{3, 14160},
+		lower:    Version{3, 1},
+		expected: true,
+	}, {
+		upper:    Version{780001, 3},
+		lower:    Version{780000, 3},
+		expected: true,
+	}, {
+		lower:    Version{0, 2},
+		upper:    Version{0, 1},
+		expected: false,
+	}, {
+		lower:    Version{0, 9},
+		upper:    Version{0, 8},
+		expected: false,
+	}, {
+		lower:    Version{9, 1},
+		upper:    Version{6, 0},
+		expected: false,
+	}, {
+		lower:    Version{3, 14160},
+		upper:    Version{3, 1},
+		expected: false,
+	}, {
+		lower:    Version{780001, 3},
+		upper:    Version{780000, 3},
+		expected: false,
+	}} {
+		t.Run(fmt.Sprintf("%s > %s", tc.upper, tc.lower), func(t *testing.T) {
+			if tc.upper.Gt(tc.lower) != tc.expected {
+				t.Fatalf("expected %s > %s to be %t", tc.upper, tc.lower, tc.expected)
+			}
+		})
+	}
+}
+
+func TestLt(t *testing.T) {
+	for _, tc := range []struct {
+		upper    Version
+		lower    Version
+		expected bool
+	}{{
+		upper:    Version{0, 2},
+		lower:    Version{0, 1},
+		expected: false,
+	}, {
+		upper:    Version{0, 9},
+		lower:    Version{0, 8},
+		expected: false,
+	}, {
+		upper:    Version{9, 1},
+		lower:    Version{6, 0},
+		expected: false,
+	}, {
+		upper:    Version{3, 14160},
+		lower:    Version{3, 1},
+		expected: false,
+	}, {
+		upper:    Version{780001, 3},
+		lower:    Version{780000, 3},
+		expected: false,
+	}, {
+		lower:    Version{0, 2},
+		upper:    Version{0, 1},
+		expected: true,
+	}, {
+		lower:    Version{0, 9},
+		upper:    Version{0, 8},
+		expected: true,
+	}, {
+		lower:    Version{9, 1},
+		upper:    Version{6, 0},
+		expected: true,
+	}, {
+		lower:    Version{3, 14160},
+		upper:    Version{3, 1},
+		expected: true,
+	}, {
+		lower:    Version{780001, 3},
+		upper:    Version{780000, 3},
+		expected: true,
+	}} {
+		t.Run(fmt.Sprintf("%s < %s", tc.lower, tc.upper), func(t *testing.T) {
+			if tc.upper.Lt(tc.lower) != tc.expected {
+				t.Fatalf("expected %s > %s to be %t", tc.upper, tc.lower, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Prior to this commit a user developing a new version of a catalog entry would have to
manually copy the existing latest version to a new version directory. e.g.
```
$ ls task/my-task -qh .
0.1  0.2  0.3  0.4  0.5  0.6
$ cp -R "task/my-task/0.6" "task/my-task/0.7"
```

This commit adds a command to Catlin to bump a catalog entry's version.
Example usage: `catlin bump ../../path/to/catalog/task/git-clone`

Contributes to https://github.com/tektoncd/catalog/issues/784

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._