### PR TITLE
Update Dockerfiles using golang images to Go 1.16.13

### DIFF
--- a/pipelinerun-logs/Dockerfile
+++ b/pipelinerun-logs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.3-alpine3.12
+FROM golang:1.16.13-alpine3.15
 WORKDIR /go/src/pipelinerun-logs
 COPY . .
 RUN go build -o ./pipelinerun-logs ./cmd/http

--- a/tekton/images/coverage/Dockerfile
+++ b/tekton/images/coverage/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16.3 as buildcoverage
+FROM golang:1.16.13 as buildcoverage
 RUN git clone https://github.com/knative/test-infra /go/src/knative.dev/test-infra
 RUN make -C /go/src/knative.dev/test-infra/tools/coverage
 
-FROM golang:1.16.3
+FROM golang:1.16.13
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tekton/images/kind-e2e/Dockerfile
+++ b/tekton/images/kind-e2e/Dockerfile
@@ -14,7 +14,7 @@
 
 # Runtime image for common dependencies when running kind tests.
 
-FROM golang:1.16.10-alpine
+FROM golang:1.16.13-alpine
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 WORKDIR /kind

--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG GO_VERSION=1.16.3
-FROM golang:${GO_VERSION}-alpine3.12 as build
+ARG GO_VERSION=1.16.13
+FROM golang:${GO_VERSION}-alpine3.15 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates

--- a/tekton/images/ko/Dockerfile
+++ b/tekton/images/ko/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.16.3-alpine3.12
+FROM golang:1.16.13-alpine3.15
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 ENV GOROOT /usr/local/go

--- a/tekton/images/kubectl/Dockerfile
+++ b/tekton/images/kubectl/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.16.3-alpine3.12 as build
+FROM golang:1.16.13-alpine3.15 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates
@@ -25,7 +25,7 @@ ENV GOBIN=/usr/local/go/bin
 ENV GO111MODULE on
 RUN go get sigs.k8s.io/kustomize/kustomize/v3@v3.9.3
 
-FROM alpine:3.12
+FROM alpine:3.15
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 
 # Kustomize requires git when pulling remote resources

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build kubetest independently of the rest
-FROM docker.io/library/golang:1.16.3 as kubetest
+FROM docker.io/library/golang:1.16.13 as kubetest
 RUN git clone https://github.com/kubernetes/test-infra /go/src/k8s.io/test-infra
 # Using e685556b32c5fb7ab12c3277d41112d47ceac0cd because after that, the URL kubetest
 # uses needs extract credentials.
@@ -144,8 +144,8 @@ RUN ["/bin/chmod", "+x", "/workspace/get-kube.sh"]
 
 # END: test-infra import
 
-# Install Go 1.16.3
-ARG GO_VERSION=1.16.3
+# Install Go 1.16.13
+ARG GO_VERSION=1.16.13
 RUN curl https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz > go${GO_VERSION}.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.tar.gz && \
     rm go${GO_VERSION}.tar.gz


### PR DESCRIPTION
# Changes

Also had to update ones using `golang:1.16.3-alpine12` to `golang:1.16.13-alpine15`, since there's no `-alpine12` image for 1.16.13.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._