### PR TITLE
Fix single quotes around REGEX

### DIFF
--- a/tekton/ci/shared/common-tasks.yaml
+++ b/tekton/ci/shared/common-tasks.yaml
@@ -41,9 +41,9 @@ spec:
         CHECK="failed"
         cd $(workspaces.input.path)
         git diff-tree --no-commit-id --name-only -r HEAD $BACK | \
-            grep -E '${REGEX}' > $(results.files.path) || true
+            grep -E "${REGEX}" > $(results.files.path) || true
         git diff-tree --no-commit-id --name-only -r HEAD $BACK | \
-            grep -E '${REGEX}' && CHECK="passed"
+            grep -E "${REGEX}" && CHECK="passed"
         printf $CHECK > $(results.check.path)
 ---
 apiVersion: tekton.dev/v1alpha1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The PR https://github.com/tektoncd/plumbing/pull/975/files introduced
the use of env variables to avoid param replacement in scripts, however
with env variables we need to use double quotes in a bash script.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc