### PR TITLE
Update DNS manager version

### DIFF
--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -143,7 +143,7 @@ DNS records for the `tekton.dev` are hosted by Netlify. [Gardeners External DNS 
 is installed in the `dogfooding` cluster in the `dns-manager` namespace, and it watches for `DNSEntries` and annotated
 ingresses and services in all namespaces.
 
-DNS Manager is installed using helm as follows:
+DNS Manager is installed from the v0.11.4 tag using helm as follows:
 
 ```shell
 # From a cloned https://github.com/gardener/external-dns-management
@@ -151,7 +151,12 @@ helm install dns-manager charts/external-dns-management \
   --namespace=dns-manager \
   --set configuration.disableNamespaceRestriction=true \
   --set configuration.identifier=tekton-dogfooding-default \
-  --set vpa.enabled=false
+  --set vpa.enabled=false \
+  --set createCRDs=true \
+  --set resources.requests.memory=64Mi \
+  --set resources.limits.memory=256Mi \
+  --set 'custom.volumes:' \
+  --set 'custom.volumeMounts:'
 ```
 
 The DNS Provider for Netlify is installed through the following resource:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updated DNS manager to v0.11.4 on the dogfooding cluster.
The new version handles annotations on `v1` ingresses.

A few changes to the configuration where required:
-  `createCRDs: true` to replace those using v1beta1 CRD with v1 CRD
- `resources.*.memory` to increase memory request / limit as the controller was being killed with OOM



Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc