### PR TITLE
Update deprecated v1beta1 ingresses

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,9 @@ of interest for the team that maintain the Tekton own CI/CD setup as well as
 for anyone interested in using Tekton to run (part of) their own CI/CD
 infrastructure.
 
-* [Clusters](#clusters)
-* [GCP Projects](#gcp-projects)
-* [DNS](#dns)
+- [Clusters](#clusters)
+- [GCP Projects](#gcp-projects)
+- [DNS](#dns)
 
 ## Clusters
 
@@ -32,6 +32,7 @@ Automation for the `tektoncd` org runs in a GKE cluster which
 have access to.
 
 There are several GCP projects used by Tekton:
+
 - The GCP project that is used for GKE, storage, etc. is called
   [`tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases). It has several GKE clusters:
   - The GKE cluster that is used for [`Prow`](prow/README.md), `Tekton`, and [`boskos`](boskos/README.md) is called
@@ -56,7 +57,6 @@ pip3 install -r ./teps/tools/requirements.txt
 # Add or remove permissions
 python3 -m adjustpermissions --users "user1@example.com,user2@example.com"
 ```
-
 
 ## DNS
 

--- a/docs/dogfooding.md
+++ b/docs/dogfooding.md
@@ -73,7 +73,7 @@ kubectl get ingress <ingress-name>
 A full example of an ingress with HTTPS certificate and DNS name provisioning:
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -93,9 +93,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
         path: /*
+        pathType: ImplementationSpecific
 ```
 
 ## Node Pools

--- a/docs/prow.md
+++ b/docs/prow.md
@@ -23,12 +23,12 @@ Prow and the PR process, and see [Prow's own docs](https://github.com/kubernetes
 Secrets which have been applied to the prow cluster but are not committed here are:
 
 - `GitHub` personal access tokens:
- - `bot-token-github` in the default namespace
- - `bot-token-github` in the github-admin namespace
- - `hmac-token` for authenticating GitHub
- - `oauth-token` which is a GitHub access token for [`tekton-robot`](https://github.com/tekton-robot),
-   used by Prow itself as well as by containers started by Prow via [the Prow config](../prow/config.yaml).
-   See [the GitHub secret Prow docs](https://github.com/kubernetes/test-infra/blob/068e83ba2f8e9261c0af4cee598c70b92775945f/prow/getting_started_deploy.md#create-the-github-secrets).
+  - `bot-token-github` in the default namespace
+  - `bot-token-github` in the github-admin namespace
+  - `hmac-token` for authenticating GitHub
+  - `oauth-token` which is a GitHub access token for [`tekton-robot`](https://github.com/tekton-robot),
+    used by Prow itself as well as by containers started by Prow via [the Prow config](../prow/config.yaml).
+    See [the GitHub secret Prow docs](https://github.com/kubernetes/test-infra/blob/068e83ba2f8e9261c0af4cee598c70b92775945f/prow/getting_started_deploy.md#create-the-github-secrets).
 - `GCP` secrets:
   - `test-account` is a token for the service account
     `prow-account@tekton-releases.iam.gserviceaccount.com`. This account can

--- a/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -18,6 +18,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
         path: /*
+        pathType: ImplementationSpecific

--- a/tekton/cd/dashboard/overlays/robocat/ingress.yaml
+++ b/tekton/cd/dashboard/overlays/robocat/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -18,6 +18,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: tekton-dashboard
-          servicePort: 9097
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
         path: /*
+        pathType: ImplementationSpecific

--- a/tekton/cd/results/overlays/dogfooding/ingress.yaml
+++ b/tekton/cd/results/overlays/dogfooding/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -19,6 +19,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: tekton-results-api-service
-          servicePort: 50051
+          service:
+            name: tekton-results-api-service
+            port:
+              number: 50051
         path: /*
+        pathType: ImplementationSpecific

--- a/tekton/ci/infra/ingress.yaml
+++ b/tekton/ci/infra/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -17,6 +17,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: el-tekton-ci
-          servicePort: 8080
+          service:
+            name: el-tekton-ci
+            port:
+              number: 8080
         path: /*
+        pathType: ImplementationSpecific

--- a/tekton/mario-bot/ingress.yaml
+++ b/tekton/mario-bot/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -18,6 +18,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: el-mario-image-builder
-          servicePort: 8080
+          service:
+            name: el-mario-image-builder
+            port:
+              number: 8080
         path: /*
+        pathType: ImplementationSpecific


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The beta1 ingresses are deprecated and will be removed in k8s 1.22.
Since we're now running 1.21 we need update all ingresses.

Prow cluster is running 1.18 for now, so prow's ingress is still
not updated.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc