### PR TITLE
Update v1alpha1 Peribolos Task to v1beta1 Pipeline

### DIFF
--- a/tekton/resources/org-permissions/peribolos-run.yaml
+++ b/tekton/resources/org-permissions/peribolos-run.yaml
@@ -1,15 +1,24 @@
-apiVersion: tekton.dev/v1alpha1
-kind: TaskRun
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
 metadata:
   generateName: peribolos-run-
 spec:
-  taskRef:
-    name: peribolos
-  resources:
-    inputs:
-      - name: repo
-        resourceSpec:
-          type: git
-          params:
-          - name: url
-            value: https://github.com/tektoncd/community.git
+  pipelineRef:
+    name: peribolos-sync
+  params:
+  - name: url
+    value: https://github.com/tektoncd/community.git
+  - name: revision
+    value: main
+  workspaces:
+    - name: github-oauth
+      secret:
+        secretName: bot-token-github
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tekton/resources/org-permissions/peribolos-sync.yaml
+++ b/tekton/resources/org-permissions/peribolos-sync.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: peribolos-sync
+spec:
+  workspaces:
+  - name: shared-workspace
+  - name: github-oauth
+  params:
+  - name: url
+    default: https://github.com/tektoncd/community.git
+  - name: revision
+    default: main
+  tasks:
+  - name: clone-repo
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: $(params.url)
+    - name: revision
+      value: $(params.revision)
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+  - name: peribolos
+    runAfter: [clone-repo]
+    taskRef:
+      name: peribolos
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    - name: github-oauth
+      workspace: github-oauth

--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -4,10 +4,10 @@ metadata:
   name: peribolos-binding
 spec:
   params:
-  - name: gitrevision
-    value: $(body.head_commit.id)
-  - name: gitrepositoryurl
-    value: $(body.repository.url)
+    - name: gitrevision
+      value: $(body.head_commit.id)
+    - name: gitrepositoryurl
+      value: $(body.repository.url)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
@@ -15,29 +15,36 @@ metadata:
   name: peribolos-template
 spec:
   params:
-  - name: gitrevision
-    description: The git revision
-    default: main
-  - name: gitrepositoryurl
-    description: The git repository url
+    - name: gitrevision
+      description: The git revision
+      default: main
+    - name: gitrepositoryurl
+      description: The git repository url
   resourcetemplates:
-  - apiVersion: tekton.dev/v1alpha1
-    kind: TaskRun
-    metadata:
-      generateName: peribolos-run-
-    spec:
-      taskRef:
-        name: peribolos
-      resources:
-        inputs:
-          - name: repo
-            resourceSpec:
-              type: git
-              params:
-              - name: revision
-                value: $(tt.params.gitrevision)
-              - name: url
-                value: $(tt.params.gitrepositoryurl)
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: peribolos-run-
+      spec:
+        pipelineRef:
+          name: peribolos-sync
+        params:
+          - name: url
+            value: $(tt.params.gitrepositoryurl)
+          - name: revision
+            value: $(tt.params.gitrevision)
+        workspaces:
+          - name: github-oauth
+            secret:
+              secretName: bot-token-github
+          - name: shared-workspace
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: EventListener
@@ -50,6 +57,13 @@ spec:
       serviceType: LoadBalancer
   triggers:
     - name: peribolos-trigger
+      interceptors:
+        - cel:
+            filter: >-
+              body.action in ['push'] &&
+              body.repository.full_name == 'tektoncd/community' &&
+              body.repository.fork == false &&
+              body.base_ref == "refs/heads/main"
       bindings:
         - ref: peribolos-binding
       template:

--- a/tekton/resources/org-permissions/peribolos.yaml
+++ b/tekton/resources/org-permissions/peribolos.yaml
@@ -6,24 +6,22 @@ spec:
   params:
   - name: configPath
     default: org/org.yaml
-  resources:
-    inputs:
-      - name: repo
-        type: git
+  workspaces:
+  - name: source
+  - name: github-oauth
+    mountPath: /etc/github
   steps:
   - name: peribolos
     image: gcr.io/k8s-prow/peribolos:v20220203-9315ecd1a0
     command:
     - /bin/sh
+    env:
+    - name: WORKSPACE_SOURCE_PATH
+      value: $(workspaces.source.path)
+    - name: PARAM_CONFIG_PATH
+      value: $(params.configPath)
     args:
     - -c
     - |
       set -ex
-      /peribolos -config-path /workspace/repo/$(params.configPath) -fix-org -fix-org-members -fix-teams -fix-team-repos -fix-team-members -github-token-path /etc/github/bot-token -confirm=true
-    volumeMounts:
-    - name: github-oauth
-      mountPath: /etc/github
-  volumes:
-  - name: github-oauth
-    secret:
-      secretName: bot-token-github
+      /peribolos -config-path ${WORKSPACE_SOURCE_PATH}/${PARAM_CONFIG_PATH} -fix-org -fix-org-members -fix-teams -fix-team-repos -fix-team-members -github-token-path /etc/github/bot-token -confirm=true


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit our peribolos sync was using pipelineresources and
didn't have any filtering on the incoming github events.

This commit adds cel filtering to the peribolos trigger and updates the
sync to drop pipelineresources.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._