### PR TITLE
Sync new peribolos pipeline to dogfooding

### DIFF
--- a/tekton/resources/org-permissions/kustomization.yaml
+++ b/tekton/resources/org-permissions/kustomization.yaml
@@ -5,3 +5,4 @@ commonAnnotations:
 resources:
 - peribolos.yaml
 - peribolos-trigger.yaml
+- peribolos-sync.yaml


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The kustomize definition for our org-permissions resources didn't
include the new peribolos-sync pipeline that was added yesterday. This
meant (I think) that the pipeline was not synced into dogfooding and our
peribolos stuff is currently not running.

This commit adds the peribolos-sync pipeline to the kustomization yaml
for the org-permissions resources. After this we should hopefully see
changes to org/org.yaml in community being picked up and run through the
peribolos-sync pipeline.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._