### PR TITLE
Make the peribolos trigger's cel filter more defensive

### DIFF
--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -60,10 +60,13 @@ spec:
       interceptors:
         - cel:
             filter: >-
-              body.action in ['push'] &&
-              body.repository.full_name == 'tektoncd/community' &&
-              body.repository.fork == false &&
-              body.base_ref == "refs/heads/main"
+              'action' in body &&
+              'repository' in body &&
+              'base_ref' in body &&
+              body['action'] == 'push' &&
+              body['repository']['full_name'] == 'tektoncd/community' &&
+              body['repository']['fork'] == false &&
+              body['base_ref'] == 'refs/heads/main'
       bindings:
         - ref: peribolos-binding
       template:


### PR DESCRIPTION

# Changes

The peribolos eventlistener is repeatedly logging the following error:

> error evaluating cel expression: expression \"body.action in ['push']
> && body.repository.full_name == 'tektoncd/community' &&
> body.repository.fork == false && body.base_ref ==
> \\\"refs/heads/main\\\"\" failed to evaluate: no such key: action

This commit attempts a more defensive style to the cel filter to make
it return true or false rather than print an evaluation error.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._