### PR TITLE
Add nightly build for cloudevents

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/README.md
@@ -1,0 +1,2 @@
+Cron Job to trigger the Tekton CloudEvents nightly build.
+Results are published to https://storage.cloud.google.com/tekton-releases-nightly/cloudevents/latest/release.yaml

--- a/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-cron-trigger
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: PROJECT_NAME
+                value: cloudevents
+          initContainers:
+          - name: git
+            env:
+              - name: GIT_REPO
+                value: github.com/tektoncd/experimental

--- a/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/release
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-cloudevents-nightly-release"

--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - operator-nightly
 - wait-task-nightly
 - pipeline-to-taskrun-nightly
+- cloudevents-nightly

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - overlays/operator
 - overlays/wait-task
 - overlays/pipeline-to-taskrun
+- overlays/cloudevents

--- a/tekton/resources/nightly-release/overlays/cloudevents/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/cloudevents/kustomization.yaml
@@ -1,0 +1,18 @@
+namePrefix: cloudevents-
+bases:
+  - ../../base
+patchesJson6902:
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: TriggerTemplate
+      name: template
+    path: template.yaml
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: Trigger
+      name: nightly
+    path: trigger.yaml
+resources:
+  - github.com/tektoncd/experimental/cloudevents/tekton/?ref=main

--- a/tekton/resources/nightly-release/overlays/cloudevents/template.yaml
+++ b/tekton/resources/nightly-release/overlays/cloudevents/template.yaml
@@ -1,0 +1,35 @@
+- op: add
+  path: /spec/resourcetemplates
+  value:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: cloudevents-release-nightly-
+      spec:
+        pipelineRef:
+          name: release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: gitRevision
+          value: $(tt.params.gitrevision)
+        - name: imageRegistry
+          value: $(tt.params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(tt.params.imageRegistryPath)
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        - name: serviceAccountPath
+          value: release.json
+        workspaces:
+          - name: workarea
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: release-secret
+            secret:
+              secretName: release-secret

--- a/tekton/resources/nightly-release/overlays/cloudevents/trigger.yaml
+++ b/tekton/resources/nightly-release/overlays/cloudevents/trigger.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/interceptors
+  value:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+          body.params.release.projectName == 'cloudevents'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cloudevents is an experimental cloudevents controller for Tekton
resource. Add a nightly builds to make it easier to install.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc