### PR TITLE
Bump to go 1.17.8 on images used by release pipelines

### DIFF
--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG GO_VERSION=1.17.7
+ARG GO_VERSION=1.17.8
 FROM golang:${GO_VERSION}-alpine3.15 as build
 LABEL description="Build container"
 

--- a/tekton/images/kubectl/Dockerfile
+++ b/tekton/images/kubectl/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17.7-alpine3.15 as build
+FROM golang:1.17.8-alpine3.15 as build
 LABEL description="Build container"
 
 RUN apk update && apk add --no-cache alpine-sdk ca-certificates


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Bump to go 1.17.8 on images used by release pipelines

    - ko-gcloud
    - ko
    - kubectl

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc