### PR TITLE
Stop using pipeline resources in create-release-draft

### DIFF
--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -27,6 +27,8 @@ spec:
     description: Release number and git tag to be applied (e.g. v0.888.1, with 'v')
   - name: previous-release-tag
     description: Previous release number - for author and PR list calculation
+  - name: rekor-uuid
+    description: The Rekor UUID associated to the attestation
   workspaces:
   - name: shared
     description: contains the cloned repo and the release files
@@ -49,6 +51,8 @@ spec:
         value: $(params.release-name)
       - name: GIT_REVISION
         value: $(params.git-revision)
+      - name: REKOR_UUID
+        value: $(params.rekor-uuid)
   steps:
     - name: header
       image: gcr.io/tekton-releases/dogfooding/hub
@@ -71,6 +75,33 @@ spec:
 
         \`\`\`
         kubectl apply -f https://storage.googleapis.com/tekton-releases/${TEKTON_PROJECT}/previous/${VERSION}/release.yaml
+        \`\`\`
+
+        ## Attestation
+
+        The Rekor UUID for this release is \`${REKOR_UUID}\`
+
+        Obtain the attestation:
+        \`\`\`shell
+        REKOR_UUID=${REKOR_UUID}
+        rekor-cli get --uuid \$REKOR_UUID --format json | jq -r .Attestation | base64 --decode | jq
+        \`\`\`
+
+        Verify that all container images in the attestation are in the release file:
+        \`\`\`shell
+        RELEASE_FILE=https://storage.googleapis.com/tekton-releases/${TEKTON_PROJECT}/previous/${VERSION}/release.yaml
+        REKOR_UUID=${REKOR_UUID}
+
+        # Obtains the list of images with sha from the attestation
+        REKOR_ATTESTATION_IMAGES=$(rekor-cli get --uuid "\$REKOR_UUID" --format json | jq -r .Attestation | base64 --decode | jq -r '.subject[]|.name + ":${VERSION}@sha256:" + .digest.sha256')
+
+        # Download the release file
+        curl "$RELEASE_FILE" > release.yaml
+
+        # For each image in the attestation, match it to the release file
+        for image in $REKOR_ATTESTATION_IMAGES; do
+          printf $image; grep -q $image release.yaml && echo " ===> ok" || echo " ===> no match";
+        done
         \`\`\`
 
         <!-- Any special upgrade notice
@@ -182,21 +213,21 @@ spec:
         [Fill list here]
         -->
 
-        # Fixes
+        ### Fixes
 
         $(awk -F";" '/kind\/bug/{ print "echo -e \"* :bug: "$3" ("$2")\n\n$(echo "$5" | base64 -d)\n\"" }' $HOME/pr-notes.csv | sh)
         $(awk -F";" '/kind\/flake/{ print "echo -e \"* :bug: "$3" ("$2")\n\n$(echo "$5" | base64 -d)\n\"" }' $HOME/pr-notes.csv | sh)
         $(awk -F";" '/kind\/bug/{ print "* :bug: "$3" ("$2")" }' $HOME/pr-no-notes.csv)
         $(awk -F";" '/kind\/flake/{ print "* :bug: "$3" ("$2")" }' $HOME/pr-no-notes.csv)
 
-        # Misc
+        ### Misc
 
         $(awk -F";" '/kind\/cleanup/{ print "echo -e \"* :hammer: "$3" ("$2")\n\n$(echo "$5" | base64 -d)\n\"" }' $HOME/pr-notes.csv | sh)
         $(awk -F";" '/kind\/misc/{ print "echo -e \"* :hammer: "$3" ("$2")\n\n$(echo "$5" | base64 -d)\n\"" }' $HOME/pr-notes.csv | sh)
         $(awk -F";" '/kind\/cleanup/{ print "* :hammer: "$3" ("$2")" }' $HOME/pr-no-notes.csv)
         $(awk -F";" '/kind\/misc/{ print "* :hammer: "$3" ("$2")" }' $HOME/pr-no-notes.csv)
 
-        # Docs
+        ### Docs
 
         $(awk -F";" '/kind\/documentation/{ print "echo -e \"* :book: "$3" ("$2")\n\n$(echo "$5" | base64 -d)\n\"" }' $HOME/pr-notes.csv | sh)
         $(awk -F";" '/kind\/documentation/{ print "* :book: "$3" ("$2")" }' $HOME/pr-no-notes.csv)
@@ -227,22 +258,24 @@ spec:
 
         cat <<EOF | tee -a $HOME/release.md
 
+        <!--
         ## Unsorted PR List
         $(egrep -v 'kind/(feature|documentation|cleanup|flake|bug|misc)' $HOME/pr.csv | awk -F";" '{ print "- "$3" ("$2")" }')
 
         To Be Done: Deprecation Notices, Backward Incompatible Changes
-
+        -->
         EOF
     - name: create-draft
       image: gcr.io/tekton-releases/dogfooding/hub
-      workingdir: $(workspaces.shared.path)/release
+      workingdir: $(workspaces.shared.path)/repo
       script: |
         #!/usr/bin/env bash
         set -ex
 
+        RELEASE_PATH="../release"
         TEKTON_PROJECT=$(basename $PROJECT)
         # List the files in the release folder
-        RELEASE_FILES=$(ls | awk '{ print "-a "$1" " }' | tr '\n' ' ')
+        RELEASE_FILES=$(find "${RELEASE_PATH}" -type f | awk '{ print "-a "$1 }' | tr '\n' ' ')
 
         hub release create --draft --prerelease \
           --commitish ${GIT_REVISION} ${RELEASE_FILES} \
@@ -266,9 +299,13 @@ spec:
     description: Previous release number - for author and PR list calculation
   - name: bucket
     description: GCS bucket where to get the release files from (e.g. gs://tekton-releases/pipeline)
+  - name: rekor-uuid
+    description: The Rekor UUID associated to the attestation
   workspaces:
     - name: shared
       description: Workspace where the git repo is prepared for testing
+    - name: credentials
+      description: GCS credentials
   tasks:
     - name: clone-repo
       taskRef:
@@ -289,7 +326,7 @@ spec:
         bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
       params:
         - name: path
-          value: $(workspaces.shared.path)
+          value: .
         - name: location
           value: $(params.bucket)/previous/$(params.release-tag)
         - name: typeDir
@@ -298,12 +335,14 @@ spec:
         - name: output
           workspace: shared
           subPath: release
+        - name: credentials
+          workspace: credentials
     - name: create-draft-release
       runAfter: ['clone-repo', 'clone-bucket']
       taskRef:
         name: create-draft-release
       workspaces:
-        - name: output
+        - name: shared
           workspace: shared
       params:
         - name: package
@@ -316,3 +355,5 @@ spec:
           value: $(params.release-tag)
         - name: previous-release-tag
           value: $(params.previous-release-tag)
+        - name: rekor-uuid
+          value: $(params.rekor-uuid)

--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -19,18 +19,17 @@ spec:
   params:
   - name: package
     description: package (and its children) under test
+  - name: git-revision
+    description: the git revision of the release
   - name: release-name
     description: The name of the release (e.g. Cat + Robot for pipeline)
   - name: release-tag
     description: Release number and git tag to be applied (e.g. v0.888.1, with 'v')
   - name: previous-release-tag
     description: Previous release number - for author and PR list calculation
-  resources:
-    inputs:
-      - name: source
-        type: git
-      - name: release-bucket
-        type: storage
+  workspaces:
+  - name: shared
+    description: contains the cloned repo and the release files
   stepTemplate:
     env:
       - name: GITHUB_TOKEN
@@ -48,6 +47,8 @@ spec:
         value: $(params.previous-release-tag)
       - name: RELEASE_NAME
         value: $(params.release-name)
+      - name: GIT_REVISION
+        value: $(params.git-revision)
   steps:
     - name: header
       image: gcr.io/tekton-releases/dogfooding/hub
@@ -59,7 +60,9 @@ spec:
         cat <<EOF | tee $HOME/release.md
         Tekton ${TEKTON_PROJECT^} release ${VERSION} "${RELEASE_NAME}"
 
+        <!-- For major releases, add a tag line
         # 🎉 [Tag Line - to be done] 🎉
+        -->
 
         -[Docs @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/docs)
         -[Examples @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/examples)
@@ -70,15 +73,15 @@ spec:
         kubectl apply -f https://storage.googleapis.com/tekton-releases/${TEKTON_PROJECT}/previous/${VERSION}/release.yaml
         \`\`\`
 
+        <!-- Any special upgrade notice
         ## Upgrade Notices
-
-        [TBD]
+        -->
 
         ## Changes
         EOF
     - name: filter-data
       image: gcr.io/tekton-releases/dogfooding/hub
-      workingdir: $(resources.inputs.source.path)
+      workingdir: $(workspaces.shared.path)/repo
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -87,7 +90,7 @@ spec:
         git fetch --unshallow
 
         # UPPER_THRESHOLD is the newest sha we are interested in
-        UPPER_THRESHOLD=$(inputs.resources.source.revision)
+        UPPER_THRESHOLD=${GIT_REVISION}
         # COMMON_ANCESTOR is the common ancestor between the OLD_VERSION and UPPER_THRESHOLD
         COMMON_ANCESTOR=$(git merge-base ${OLD_VERSION} ${UPPER_THRESHOLD})
         # OLD_RELEASE_SUBJECTS is the list of commit subjects cherry-picked (probably?) from main
@@ -157,6 +160,7 @@ spec:
         $(awk -F";" '/kind\/feature/{ print "echo -e \"* :sparkles: "$3" ("$2")\n\n$(echo "$5" | base64 -d)\n\"" }' $HOME/pr-notes.csv | sh)
         $(awk -F";" '/kind\/feature/{ print "* :sparkles: "$3" ("$2")" }' $HOME/pr-no-notes.csv)
 
+        <!-- Fill in deprecation notices when applicable
         # Deprecation Notices
 
         * :rotating_light: [Deprecation Notice Title]
@@ -164,7 +168,9 @@ spec:
         [Detailed deprecation notice description] (#Number).
 
         [Fill list here]
+        -->
 
+        <!-- Fill in backward incompatible changes when applicable
         # Backwards incompatible changes
 
         In current release:
@@ -174,6 +180,7 @@ spec:
         [Detailed change description] (#Number).
 
         [Fill list here]
+        -->
 
         # Fixes
 
@@ -198,7 +205,7 @@ spec:
 
     - name: authors
       image: gcr.io/tekton-releases/dogfooding/hub
-      workingdir: $(resources.inputs.source.path)
+      workingdir: $(workspaces.shared.path)/repo
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -213,7 +220,7 @@ spec:
         EOF
     - name: pr-data
       image: gcr.io/tekton-releases/dogfooding/hub
-      workingdir: $(inputs.resources.source.path)
+      workingdir: $(workspaces.shared.path)/repo
       script: |
         #!/usr/bin/env bash
         set -ex
@@ -228,13 +235,84 @@ spec:
         EOF
     - name: create-draft
       image: gcr.io/tekton-releases/dogfooding/hub
-      workingdir: $(resources.inputs.source.path)
+      workingdir: $(workspaces.shared.path)/release
       script: |
         #!/usr/bin/env bash
         set -ex
 
+        TEKTON_PROJECT=$(basename $PROJECT)
+        # List the files in the release folder
+        RELEASE_FILES=$(ls | awk '{ print "-a "$1" " }' | tr '\n' ' ')
+
         hub release create --draft --prerelease \
-          --commitish $(inputs.resources.source.revision) \
-          -a $(inputs.resources.release-bucket.path)/previous/${VERSION}/release.yaml \
-          -a $(inputs.resources.release-bucket.path)/previous/${VERSION}/release.notags.yaml \
+          --commitish ${GIT_REVISION} ${RELEASE_FILES} \
           --file $HOME/release.md ${VERSION}
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: release-draft
+spec:
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: git-revision
+    description: the git revision of the release
+  - name: release-name
+    description: The name of the release (e.g. Cat + Robot for pipeline)
+  - name: release-tag
+    description: Release number and git tag to be applied (e.g. v0.888.1, with 'v')
+  - name: previous-release-tag
+    description: Previous release number - for author and PR list calculation
+  - name: bucket
+    description: GCS bucket where to get the release files from (e.g. gs://tekton-releases/pipeline)
+  workspaces:
+    - name: shared
+      description: Workspace where the git repo is prepared for testing
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-clone
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.5
+      params:
+        - name: url
+          value: https://github.com/$(params.package)
+        - name: revision
+          value: $(params.git-revision)
+      workspaces:
+        - name: output
+          workspace: shared
+          subPath: repo
+    - name: clone-bucket
+      taskRef:
+        name: gcs-download
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+      params:
+        - name: path
+          value: $(workspaces.shared.path)
+        - name: location
+          value: $(params.bucket)/previous/$(params.release-tag)
+        - name: typeDir
+          value: "true"
+      workspaces:
+        - name: output
+          workspace: shared
+          subPath: release
+    - name: create-draft-release
+      runAfter: ['clone-repo', 'clone-bucket']
+      taskRef:
+        name: create-draft-release
+      workspaces:
+        - name: output
+          workspace: shared
+      params:
+        - name: package
+          value: $(params.package)
+        - name: git-revision
+          value: $(params.git-revision)
+        - name: release-name
+          value: $(params.release-name)
+        - name: release-tag
+          value: $(params.release-tag)
+        - name: previous-release-tag
+          value: $(params.previous-release-tag)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Create a pipeline that uses git-clone, gcs-download and
create-release-draft instead of the single task with PipelineResources.

Update the template slightly to mark optional fields as comments.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc