### PR TITLE
Freeze test runner version in prow config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -208,7 +208,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -234,7 +234,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -260,7 +260,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -312,7 +312,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -338,7 +338,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-cross-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -364,7 +364,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -390,7 +390,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -441,7 +441,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -467,7 +467,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-dashboard-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -493,7 +493,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -520,7 +520,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -546,7 +546,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-experimental-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -572,7 +572,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -602,7 +602,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -628,7 +628,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -654,7 +654,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -681,7 +681,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -712,7 +712,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -738,7 +738,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -789,7 +789,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -815,7 +815,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -841,7 +841,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -867,7 +867,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-alpha-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -921,7 +921,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -947,7 +947,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -973,7 +973,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1000,7 +1000,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1026,7 +1026,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-resolution-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1054,7 +1054,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1083,7 +1083,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-results-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1109,7 +1109,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-results-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1137,7 +1137,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-results-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1166,7 +1166,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1192,7 +1192,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-triggers-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1218,7 +1218,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1350,7 +1350,7 @@ periodics:
     path_alias: github.com/tektoncd/pipeline
   spec:
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
       imagePullPolicy: Always
       command:
         - /usr/local/bin/entrypoint.sh
@@ -1378,7 +1378,7 @@ periodics:
     path_alias: github.com/tektoncd/catalog
   spec:
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
       imagePullPolicy: Always
       command:
       - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We shall update the version of golang in our test-runner image,
however since the image is shared by many tests and they always
use the tag "latest", changing the version may brake many tests
out once.

Pin the version in all tests to tag "v20220316-golang-v1-16", so
that we may update the test runner image and then update the
tests one by one or in batches.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc