### PR TITLE
Updates the context path for catlin nightly cronjob

### DIFF
--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
@@ -24,4 +24,4 @@ spec:
                 - name: TARGET_IMAGE
                   value: gcr.io/tekton-releases/dogfooding/catlin
                 - name: CONTEXT_PATH
-                  value: catlin
+                  value: "."


### PR DESCRIPTION
As we are moving catlin to an independent repo, we need to update
the values of repo name and context path for catlin nightly cronjob

Reference PR:- https://github.com/tektoncd/plumbing/pull/1023

Signed-off-by: Puneet Punamiya <ppunamiy@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._