### PR TITLE
Fix the trigger for check-github-tasks-completed on comment

### DIFF
--- a/tekton/ci/shared/trigger.yaml
+++ b/tekton/ci/shared/trigger.yaml
@@ -113,6 +113,6 @@ spec:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-comment
     - ref: tekton-ci-clone-depth
-    - ref: tekton-ci-webhook-pr-body
+    - ref: tekton-ci-webhook-issue-labels
   template:
     ref: check-github-tasks-completed


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The trigger is using the wrong bindings and failing consistently,
which means that the check-github-tasks-completed job cannot be
re-run by the "/test" command.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug
