### PR TITLE
Change the kind e2e test to k8s 1.21

### DIFF
--- a/tekton/ci/jobs/e2e-kind.yaml
+++ b/tekton/ci/jobs/e2e-kind.yaml
@@ -105,7 +105,7 @@ spec:
       description: The command that was used to trigger testing
     - name: k8s-version
       type: string
-      description: The version of k8s (v1.20.x, v1.21.x or v1.22.x)
+      description: The version of k8s (e.g. v1.21.x, v1.22.x or v1.23.x)
     - name: e2e-script
       type: string
       description: the path to the e2e script in the sources

--- a/tekton/ci/pipeline/template.yaml
+++ b/tekton/ci/pipeline/template.yaml
@@ -34,11 +34,11 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      generateName: pull-pipeline-kind-k8s-v1-20-e2e-
+      generateName: pull-pipeline-kind-k8s-v1-21-e2e-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/kind: ci
-        tekton.dev/check-name: pull-pipeline-kind-k8s-v1-20-e2e
+        tekton.dev/check-name: pull-pipeline-kind-k8s-v1-21-e2e
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
         tekton.dev/gitRevision: "$(tt.params.gitRevision)"
@@ -68,11 +68,11 @@ spec:
         - name: fileFilterRegex
           value: '^(cmd/|examples/|images/|pkg/|test/|go\.)'
         - name: checkName
-          value: pull-pipeline-kind-k8s-v1-20-e2e
+          value: pull-pipeline-kind-k8s-v1-21-e2e
         - name: gitHubCommand
           value: $(tt.params.gitHubCommand)
         - name: k8s-version
-          value: v1.20.x
+          value: v1.21.x
         - name: e2e-script
           value: test/e2e-tests.sh
         - name: e2e-env


### PR DESCRIPTION
# Changes

The kind e2e test runs on k8s 1.20 which is not supported by Tekton
anymore. Switch to k8s 1.21 instead.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
