### PR TITLE
Fix context_path in CronJob of Tekton

### DIFF
--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/cronjob.yaml
@@ -21,4 +21,4 @@ spec:
                 - name: TARGET_IMAGE
                   value: gcr.io/tekton-releases/dogfooding/catlin:latest
                 - name: CONTEXT_PATH
-                  value: catlin
+                  value: "."


### PR DESCRIPTION
# Changes

Since catlin has been moved to it's own repository, the image build
cronjob's context needs to be updated with the new context.

/kind bug

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._