### PR TITLE
Fix xml test report for alpine

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -256,7 +256,7 @@ function report_go_test() {
   echo "Finished run, return code is ${failed}"
   # Install go-junit-report if necessary.
   run_go_tool github.com/jstemmer/go-junit-report go-junit-report --help > /dev/null 2>&1
-  local xml=$(mktemp ${ARTIFACTS}/junit_XXXXXXXX.xml)
+  local xml="$(mktemp ${ARTIFACTS}/junit_XXXXXXXX).xml"
   cat "${report}" \
       | go-junit-report \
       | sed -e "s#\"github.com/tektoncd/${REPO_NAME}/#\"#g" \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Alpine ships the busybox version of mktemp which expects the template
to end with XXXXXX. Move the ".xml" part out of the template name to
make the xml test report working on alpine - for Kind tests.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc