### PR TITLE
Switch pipeline integration tests to golang 1.17.8

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -895,7 +895,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -921,7 +921,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -947,7 +947,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -973,7 +973,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-alpha-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
# Changes

Change the tekton pipeline integration tests (regular and alpha)
to the test-runner image with golang 1.17.8

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc