### PR TITLE
Update tekton resolution test runner to use go 1.17 image

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1106,7 +1106,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1132,7 +1132,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-resolution-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1160,7 +1160,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220328-f43f43b3b2@sha256:0defd8e6bd59591a0a43fc1843ccc7cc6e67471821ec48b84e10818e0a0df464 # golang 1.17.8
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
# Changes

Tekton resolution is updating to use latest version of knative to align
with tekton pipelines. Sourcing deps, building etc should now happen
with go 1.17 to match.

This commit updates the prow config for resolution to bring its go
version into step with pipelines.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._