### PR TITLE
Add pipelines to store job metadata in buckets

### DIFF
--- a/tekton/resources/ci/gubernator-metadata.yaml
+++ b/tekton/resources/ci/gubernator-metadata.yaml
@@ -1,0 +1,313 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gubernator-start
+spec:
+  description: >-
+    This task can be executed when a Tekton CI job is started, and it produces
+    the start metadata required by Gubernator, see https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout
+
+    Folder structure:
+    .
+    └── pr-logs
+      ├── directory                # symlinks for builds live here
+      │   └── job_name             # contains all symlinks for a job
+      │       ├── build_number.txt # contains one line: location of artifacts for the build
+      │       └── latest-build.txt # contains the latest build id of a job
+      └── pull
+          └── org_repo                     # jobs testing PRs for org/repo live here
+              └── pull_number              # jobs running for a PR with pull_number live here
+                  └── job_name             # all builds for the job for this pr live here
+                      └── build_number     # contains job artifacts, as above
+                      └── latest-build.txt # contains the latest build id of a job
+
+    Build number folder content:
+    .
+    └── started.json      # metadata uploaded once the build starts
+
+  workspaces:
+    - name: shared
+      description: Workspace where the data is written
+  params:
+    - name: package
+      description: The GitHub org/repo
+    - name: jobName
+      description: Name of the CI job
+    - name: jobRunName
+      description: The name (or number) of the job execution
+    - name: pullRequestNumber
+      description: The GitHub pull request number
+    - name: gitRevision
+      description: The git ref of the top commit in the pull request
+    - name: bucket
+      description: The object storage bucket
+      default: "gs://tekton-prow"
+  stepTemplate:
+    env:
+      - name: DIRECTORY_PATH
+        value: $(workspaces.shared.path)/pr-logs/directory/$(params.jobName)
+      - name: PULL_ROOT_PATH
+        value: $(workspaces.shared.path)/pr-logs/pull
+      - name: LATEST_BUILD_LEAF_PATH
+        value: $(params.pullRequestNumber)/$(params.jobName)
+      - name: PACKAGE
+        value: $(params.package)
+      - name: GIT_REVISION
+        value: $(params.gitRevision)
+      - name: BUCKET
+        value: $(params.bucket)
+      - name: BUILD_NUMBER
+        value: $(params.jobRunName)
+      - name: PR_NUMBER
+        value: $(params.pullRequestNumber)
+  steps:
+    - name: write-data
+      image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env sh
+        set -e
+
+        # Create the directory folder
+        mdkir -p "${DIRECTORY_PATH}"
+
+        # Add path to the artifacts in the ${BUILD_NUMBER}.txt
+        echo "${BUCKET}/pr-logs/pull/${PACKAGE/\//_}/JOB_LEAF_PATH" > "${DIRECTORY_PATH}/${BUILD_NUMBER}.txt"
+        # Add the ${BUILD_NUMBER} into latest-build.txt
+        echo "${BUILD_NUMBER}" > "${DIRECTORY_PATH}/latest-build.txt"
+
+        # Create the Pull Request / Build folder
+        BUILD_PATH="${PULL_ROOT_PATH}/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}"
+        mkdir -p "${BUILD_PATH}"
+        mkdir -p "${BUILD_PATH}/${BUILD_NUMBER}"
+
+        # Create the latest-build.txt
+        echo "${BUILD_NUMBER}" > "${BUILD_PATH}/latest-build.txt"
+
+        # Create the started.json file
+        # Use the "time now" to simplify the logic
+        cat <<EOF | tee "${BUILD_PATH}/${BUILD_NUMBER}/started.json"
+        {
+          "timestamp": $(date +%s),
+          "pull": "${PR_NUMBER}",
+          "repos": {
+            "${PACKAGE}": "${PR_NUMBER}:${GIT_REVISION}"
+          }
+        }
+        EOF
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gubernator-stop
+spec:
+  description: >-
+    This task can be executed when a Tekton CI job is finished, and it produces
+    the stop metadata required by Gubernator, see https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout
+
+    Folder structure:
+    .
+    └── pr-logs
+      └── pull
+          └── org_repo                     # jobs testing PRs for org/repo live here
+              └── pull_number              # jobs running for a PR with pull_number live here
+                  └── job_name             # all builds for the job for this pr live here
+                      └── build_number     # contains job artifacts, as above
+
+    Build number folder content:
+    .
+    ├── build-log.txt     # std{out,err} from the build
+    └── finished.json     # metadata uploaded once the build finishes
+
+  workspaces:
+    - name: shared
+      description: Workspace where the data is written
+  params:
+    - name: package
+      description: The GitHub org/repo
+    - name: jobName
+      description: Name of the CI job
+    - name: jobRunName
+      description: The name (or number) of the job execution
+    - name: jobStatus
+      description: "true if the CI job was successful else false"
+    - name: gitRevision
+      description: The git ref of the top commit in the pull request
+  stepTemplate:
+    env:
+      - name: PULL_ROOT_PATH
+        value: $(workspaces.shared.path)/pr-logs/pull
+      - name: LATEST_BUILD_LEAF_PATH
+        value: $(params.pullRequestNumber)/$(params.jobName)
+      - name: PACKAGE
+        value: $(params.package)
+      - name: GIT_REVISION
+        value: $(params.gitRevision)
+      - name: BUILD_NUMBER
+        value: $(params.jobRunName)
+      - name: JOB_STATUS
+        value: $(params.jobStatus)
+  steps:
+    - name: write-data
+      image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env sh
+        set -e
+
+        # Create the Pull Request / Build folder (it should already exists)
+        BUILD_PATH="${PULL_ROOT_PATH}/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}/${BUILD_NUMBER}"
+        mkdir -p "${BUILD_PATH}" || true
+
+        # Collect the build log - it will still be there unless the PipelineRun
+        # has been cancelled or there is some very aggressive Pod pruning happening
+        # This is specific to the Tekton dogfooding CI (hardcoded namespace)
+        tkn pr logs -n tekton-ci "${BUILD_NUMBER}" > "${BUILD_PATH}/build-log.txt
+
+        # Create the finished.json file
+        # Use the "time now" to simplify the logic
+        # Build the results from the status to simplify the logic
+        if [ "$JOB_STATUS" == "false" ]; then
+          JOB_RESULT="FAILURE"
+        else
+          JOB_RESULT="SUCCESS"
+        fi
+        cat <<EOF | tee "${BUILD_PATH}/finished.json"
+        {
+          "timestamp": $(date +%s),
+          "passed": "${JOB_STATUS}",
+          "result": "${JOB_RESULT}",
+          "revision": "${GIT_REVISION}"
+        }
+        EOF
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gubernator-start
+spec:
+  workspaces:
+    - name: shared
+      description: Workspace to host the new bucket files
+    - name: credentials
+      description: Credentials to upload to the bucket
+  params:
+    - name: package
+      description: The GitHub org/repo
+    - name: jobName
+      description: Name of the CI job
+    - name: jobRunName
+      description: The name (or number) of the job execution
+    - name: pullRequestNumber
+      description: The GitHub pull request number
+    - name: gitRevision
+      description: The git ref of the top commit in the pull request
+    - name: bucket
+      description: The object storage bucket
+      default: "gs://tekton-prow"
+  tasks:
+    - name: create-data
+      taskRef:
+        name: gubernator-start
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: package
+          value: $(params.package)
+        - name: jobName
+          value: $(params.jobName)
+        - name: jobRunName
+          value: $(params.jobRunName)
+        - name: pullRequestNumber
+          value: $(params.pullRequestNumber)
+        - name: gitRevision
+          value: $(params.gitRevision)
+        - name: bucket
+          value: $(params.bucket)
+    - name: upload-data
+      runAfter: ["create-data"]
+      taskRef:
+        name: gcs-upload
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.2
+      params:
+        - name: path
+          value: "."
+        - name: location
+          value: $(params.bucket)
+      workspaces:
+        - name: credentials
+          workspace: credentials
+        - name: source
+          workspace: sources
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gubernator-stop
+spec:
+  workspaces:
+    - name: shared
+      description: Workspace to host the new bucket files
+    - name: credentials
+      description: Credentials to upload to the bucket
+  params:
+    - name: package
+      description: The GitHub org/repo
+    - name: jobName
+      description: Name of the CI job
+    - name: jobRunName
+      description: The name (or number) of the job execution
+    - name: jobStatus
+      description: "true if the CI job was successful else false"
+    - name: gitRevision
+      description: The git ref of the top commit in the pull request
+    - name: bucket
+      description: The object storage bucket
+      default: "gs://tekton-prow"
+  tasks:
+    - name: create-data
+      taskRef:
+        name: gubernator-stop
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: package
+          value: $(params.package)
+        - name: jobName
+          value: $(params.jobName)
+        - name: jobRunName
+          value: $(params.jobRunName)
+        - name: jobStatus
+          value: $(params.jobStatus)
+        - name: gitRevision
+          value: $(params.gitRevision)
+    - name: upload-data
+      runAfter: ["create-data"]
+      taskRef:
+        name: gcs-upload
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.2
+      params:
+        - name: path
+          value: "."
+        - name: location
+          value: $(params.bucket)
+      workspaces:
+        - name: credentials
+          workspace: credentials
+        - name: source
+          workspace: sources

--- a/tekton/resources/ci/kustomization.yaml
+++ b/tekton/resources/ci/kustomization.yaml
@@ -5,3 +5,4 @@ commonAnnotations:
 resources:
 - bindings.yaml
 - github-template.yaml
+- gubernator-metadata.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Store the job metadata and logs in buckets in the format that
gubernator expects. This let us re-use the gubernator application to
manage and visualise logs for CI runs executed through Tekton.

These pipelines are not used that, some updates are required first
for the tekton-events event listener.

Partially addresses #1046

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
