### PR TITLE
Use TriggerGroups and v1beta1 for tekton-events

### DIFF
--- a/tekton/resources/cd/ci-triggers.yaml
+++ b/tekton/resources/cd/ci-triggers.yaml
@@ -1,0 +1,56 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ci-job-started-github-notification
+  labels:
+    ci.tekton.dev/trigger-type: ci-job.triggered
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          header.match('ce-type', 'dev.tekton.event.taskrun.started.v1')
+  bindings:
+    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-check-pending
+    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+    - ref: tekton-ci-overlays
+  template:
+    ref: tekton-ci-github-check-update
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ci-job-success-github-notification
+  labels:
+    ci.tekton.dev/trigger-type: ci-job.triggered
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1')
+  bindings:
+    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-check-success
+    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+    - ref: tekton-ci-overlays
+  template:
+    ref: tekton-ci-github-check-update
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ci-job-failure-github-notification
+  labels:
+    ci.tekton.dev/trigger-type: ci-job.triggered
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')
+  bindings:
+    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-check-failure
+    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+    - ref: tekton-ci-overlays
+  template:
+    ref: tekton-ci-github-check-update

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: tekton-cd
@@ -93,7 +93,7 @@ spec:
       template:
         ref: publish-catalog
 ---
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: tekton-events
@@ -102,102 +102,48 @@ spec:
   resources:
     kubernetesResource:
       replicas: 3
-  triggers:
-    - name: cd-pipeline-failed
+  triggerGroups:
+    - name: cd-taskrun-failed
       interceptors:
-        - cel:
-            filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-cd' &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/trigger'] in ['configmaps', 'folders', 'helm']
-      bindings:
-      - ref: cd-pipeline-type
-      - ref: taskrun-meta
-      - ref: dashboard-url-dogfooding
-      template:
-        ref: cd-pipeline-failed-slack
-    - name: cd-pipeline-nightly-release-failed
+        - name: "Failed TaskRuns"
+          ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')
+      triggerSelector:
+        namespaceSelector:
+          matchNames:
+            - default
+        labelSelector:
+          matchLabels:
+            cd.tekton.dev/trigger-type: failure-notification
+    - name: ci-job-triggers
       interceptors:
-        - cel:
-            filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'].endsWith('nightly-release-cron') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/trigger'].endsWith('nightly-release-cron-trigger')
-      bindings:
-      - ref: cd-pipeline-type-nightly
-      - ref: pipelinerun-meta
-      - ref: dashboard-url-dogfooding
-      template:
-        ref: cd-pipeline-failed-slack
-    - name: github-check-start
-      interceptors:
-        - cel:
-            filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.started.v1') &&
-              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
-              !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
-              (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
-              'ownerReferences' in body.taskRun.metadata
-            overlays:
-              - key: repo
-                expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
-              - key: shortBuildUUID
-                expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
-      bindings:
-        - ref: tekton-ci-taskrun-cloudevent
-        - ref: tekton-ci-check-pending
-        - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
-        - ref: tekton-ci-overlays
-      template:
-        ref: tekton-ci-github-check-update
-    - name: github-check-success
-      interceptors:
-        - cel:
-            filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
-              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
-              (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
-              'ownerReferences' in body.taskRun.metadata
-            overlays:
-              - key: repo
-                expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
-              - key: shortBuildUUID
-                expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
-      bindings:
-        - ref: tekton-ci-taskrun-cloudevent
-        - ref: tekton-ci-check-success
-        - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
-        - ref: tekton-ci-overlays
-      template:
-        ref: tekton-ci-github-check-update
-    - name: github-check-failure
-      interceptors:
-        - cel:
-            filter: >-
-              header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1') &&
-              body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
-              body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
-              !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
-              (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
-              (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
-              'ownerReferences' in body.taskRun.metadata
-            overlays:
-              - key: repo
-                expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
-              - key: shortBuildUUID
-                expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
-      bindings:
-        - ref: tekton-ci-taskrun-cloudevent
-        - ref: tekton-ci-check-failure
-        - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
-        - ref: tekton-ci-overlays
-      template:
-        ref: tekton-ci-github-check-update
+        - name: "Tekton CI Jobs"
+          ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                body.taskRun.metadata.labels['tekton.dev/kind'] == 'ci' &&
+                body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-ci' &&
+                !('ci.tekton.dev/condition' in body.taskRun.metadata.annotations) &&
+                (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
+                (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
+                (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
+                'ownerReferences' in body.taskRun.metadata
+            - name: "overlays"
+              value:
+                - key: repo
+                  expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
+                - key: shortBuildUUID
+                  expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
+      triggerSelector:
+        namespaceSelector:
+          matchNames:
+            - default
+        labelSelector:
+          matchLabels:
+            ci.tekton.dev/trigger-type: ci-job.triggered

--- a/tekton/resources/cd/kustomization.yaml
+++ b/tekton/resources/cd/kustomization.yaml
@@ -27,3 +27,5 @@ resources:
 - notification-template.yaml
 - catalog-template.yaml
 - serviceaccount.yaml
+- notification-triggers.yaml
+- ci-triggers.yaml

--- a/tekton/resources/cd/notification-triggers.yaml
+++ b/tekton/resources/cd/notification-triggers.yaml
@@ -1,0 +1,37 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: slack-notification-of-cd-failure
+  labels:
+    cd.tekton.dev/trigger-type: failure-notification
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'] == 'tekton-cd' &&
+          body.taskRun.metadata.labels['triggers.tekton.dev/trigger'] in ['configmaps', 'folders', 'helm']
+  bindings:
+  - ref: cd-pipeline-type
+  - ref: taskrun-meta
+  - ref: dashboard-url-dogfooding
+  template:
+    ref: cd-pipeline-failed-slack
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: slack-notification-of-nightly-failure
+  labels:
+    cd.tekton.dev/trigger-type: failure-notification
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          body.taskRun.metadata.labels['triggers.tekton.dev/eventlistener'].endsWith('nightly-release-cron') &&
+          body.taskRun.metadata.labels['triggers.tekton.dev/trigger'].endsWith('nightly-release-cron-trigger')
+  bindings:
+  - ref: cd-pipeline-type-nightly
+  - ref: pipelinerun-meta
+  - ref: dashboard-url-dogfooding
+  template:
+    ref: cd-pipeline-failed-slack


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The tekton-events event listeners receives eventens from Tekton
generated CloudEvents. Migrate it to v1beta1 and start using
TriggerGroups to simplify its configuration, make it easier to
maintain and extend.

This paves the way for new triggers that will setup GCS buckets
in gubernator style to reuse that infra with Tekton jobs.

Related to #1046

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
