### PR TITLE
Add template and triggers for gubernator logs

### DIFF
--- a/tekton/ci/infra/0001_rbac.yaml
+++ b/tekton/ci/infra/0001_rbac.yaml
@@ -95,3 +95,44 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: tekton-ci-jobs-triggers
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-logs-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "namespaces"]
+  verbs: ["get", "list"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelines", "tasks", "pipelineruns", "pipelineresources", "taskruns", "conditions"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-ci-logs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-ci-logs-tekton-logs-reader
+subjects:
+- kind: ServiceAccount
+  name: tekton-ci-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-logs-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-ci-logs-triggers-minimal
+subjects:
+- kind: ServiceAccount
+  name: tekton-ci-logs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: triggers-minimal

--- a/tekton/ci/shared/gubernator-metadata.yaml
+++ b/tekton/ci/shared/gubernator-metadata.yaml
@@ -58,9 +58,9 @@ spec:
   stepTemplate:
     env:
       - name: DIRECTORY_PATH
-        value: $(workspaces.shared.path)/pr-logs/directory/$(params.jobName)
+        value: pr-logs/directory/$(params.jobName)
       - name: PULL_ROOT_PATH
-        value: $(workspaces.shared.path)/pr-logs/pull
+        value: pr-logs/pull
       - name: LATEST_BUILD_LEAF_PATH
         value: $(params.pullRequestNumber)/$(params.jobName)
       - name: PACKAGE
@@ -76,16 +76,16 @@ spec:
   steps:
     - name: write-data
       image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
-      workingDir: $(workspaces.source.path)
+      workingDir: $(workspaces.shared.path)
       script: |
         #!/usr/bin/env sh
         set -e
 
         # Create the directory folder
-        mdkir -p "${DIRECTORY_PATH}"
+        mkdir -p "${DIRECTORY_PATH}"
 
         # Add path to the artifacts in the ${BUILD_NUMBER}.txt
-        echo "${BUCKET}/pr-logs/pull/${PACKAGE/\//_}/JOB_LEAF_PATH" > "${DIRECTORY_PATH}/${BUILD_NUMBER}.txt"
+        echo "${BUCKET}/pr-logs/pull/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}/${BUILD_NUMBER}" > "${DIRECTORY_PATH}/${BUILD_NUMBER}.txt"
         # Add the ${BUILD_NUMBER} into latest-build.txt
         echo "${BUILD_NUMBER}" > "${DIRECTORY_PATH}/latest-build.txt"
 
@@ -145,7 +145,7 @@ spec:
     - name: pullRequestNumber
       description: The GitHub pull request number
     - name: jobStatus
-      description: "true if the CI job was successful else false"
+      description: "success if the CI job was successful else failure"
     - name: gitRevision
       description: The git ref of the top commit in the pull request
   stepTemplate:
@@ -165,7 +165,7 @@ spec:
   steps:
     - name: write-data
       image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
-      workingDir: $(workspaces.source.path)
+      workingDir: $(workspaces.shared.path)
       script: |
         #!/usr/bin/env sh
         set -e
@@ -177,12 +177,12 @@ spec:
         # Collect the build log - it will still be there unless the PipelineRun
         # has been cancelled or there is some very aggressive Pod pruning happening
         # This is specific to the Tekton dogfooding CI (hardcoded namespace)
-        tkn pr logs -n tekton-ci "${BUILD_NUMBER}" > "${BUILD_PATH}/build-log.txt
+        tkn pr logs -n tekton-ci "${BUILD_NUMBER}" > "${BUILD_PATH}/build-log.txt"
 
         # Create the finished.json file
         # Use the "time now" to simplify the logic
         # Build the results from the status to simplify the logic
-        if [ "$JOB_STATUS" == "false" ]; then
+        if [ "$JOB_STATUS" == "failure" ]; then
           JOB_RESULT="FAILURE"
         else
           JOB_RESULT="SUCCESS"
@@ -244,7 +244,7 @@ spec:
       runAfter: ["create-data"]
       taskRef:
         name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.2
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
       params:
         - name: path
           value: "."
@@ -274,7 +274,7 @@ spec:
     - name: jobRunName
       description: The name (or number) of the job execution
     - name: jobStatus
-      description: "true if the CI job was successful else false"
+      description: "success if the CI job was successful else failure"
     - name: pullRequestNumber
       description: The GitHub pull request number
     - name: gitRevision
@@ -306,7 +306,7 @@ spec:
       runAfter: ["create-data"]
       taskRef:
         name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.2
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
       params:
         - name: path
           value: "."

--- a/tekton/ci/shared/kustomization.yaml
+++ b/tekton/ci/shared/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - bindings.yaml
 - common-tasks.yaml
 - eventlistener.yaml
+- gubernator-metadata.yaml

--- a/tekton/resources/cd/ci-triggers.yaml
+++ b/tekton/resources/cd/ci-triggers.yaml
@@ -63,3 +63,69 @@ spec:
     - ref: tekton-ci-overlays
   template:
     ref: tekton-ci-github-check-update
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ci-job-started-logs-upload
+  labels:
+    ci.tekton.dev/trigger-type: ci-job.triggered
+spec:
+  interceptors:
+    - ref:
+        name: cel
+      params:
+        - name: "filter"
+          value: >-
+            header.match('ce-type', 'dev.tekton.event.taskrun.started.v1')
+  bindings:
+    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-check-pending
+    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+    - ref: tekton-ci-overlays
+  template:
+    ref: tekton-ci-gubernator-start
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ci-job-successful-logs-upload
+  labels:
+    ci.tekton.dev/trigger-type: ci-job.triggered
+spec:
+  interceptors:
+    - ref:
+        name: cel
+      params:
+        - name: "filter"
+          value: >-
+            header.match('ce-type', 'dev.tekton.event.taskrun.successful.v1')
+  bindings:
+    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-check-success
+    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+    - ref: tekton-ci-overlays
+  template:
+    ref: tekton-ci-gubernator-stop
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ci-job-failed-logs-upload
+  labels:
+    ci.tekton.dev/trigger-type: ci-job.triggered
+spec:
+  interceptors:
+    - ref:
+        name: cel
+      params:
+        - name: "filter"
+          value: >-
+            header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')
+  bindings:
+    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-check-failure
+    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
+    - ref: tekton-ci-overlays
+  template:
+    ref: tekton-ci-gubernator-stop

--- a/tekton/resources/ci/github-gubernator-template.yaml
+++ b/tekton/resources/ci/github-gubernator-template.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-ci-gubernator-start
+spec:
+  params:
+  - name: pullRequestNumber
+    description: The pullRequestID to comment to
+  - name: buildUUID
+    description: The buildUUID for the logs link
+  - name: shortBuildUUID
+    description: A truncated version of the buildUUID
+  - name: gitHubRepo
+    description: The gitHubRepo (org/repo)
+  - name: gitRevision
+    description: The sha of the HEAD commit in the PR
+  - name: checkName
+    description: Name of the CI Job (GitHub Check)
+  - name: gitHubCheckStatus
+    description: Can be 'pending', 'success' or 'failure'
+  - name: gitHubCheckDescription
+    description: A description to be displayed for the status of the check
+  - name: taskRunName
+    description: The name of the task run that triggered this
+  - name: taskRunNamespace
+    description: The namespace where the CI job was executed
+  - name: parentPipelineRunName
+    description: The name of the parent pipeline run - if any
+    default: ""
+  - name: parentPipelineRunTaskName
+    description: The name of the task in the parent pipeline run - if any
+    default: ""
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-logs-start
+      namespace: tekton-ci
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
+        ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      pipelineRef:
+        name: gubernator-start
+      params:
+        - name: package
+          value: $(tt.params.gitHubRepo)
+        - name: jobName
+          value: $(tt.params.checkName)
+        - name: jobRunName
+          value: $(tt.params.parentPipelineRunName)
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: gitRevision
+          value: $(tt.params.gitRevision)
+        - name: bucket
+          value: "gs://tekton-prow"
+      workspaces:
+        - name: shared
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+        - name: credentials
+          secret:
+            secretName: release-secret
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-ci-gubernator-stop
+spec:
+  params:
+  - name: pullRequestNumber
+    description: The pullRequestID to comment to
+  - name: buildUUID
+    description: The buildUUID for the logs link
+  - name: shortBuildUUID
+    description: A truncated version of the buildUUID
+  - name: gitHubRepo
+    description: The gitHubRepo (org/repo)
+  - name: gitRevision
+    description: The sha of the HEAD commit in the PR
+  - name: checkName
+    description: Name of the CI Job (GitHub Check)
+  - name: gitHubCheckStatus
+    description: Can be 'pending', 'success' or 'failure'
+  - name: gitHubCheckDescription
+    description: A description to be displayed for the status of the check
+  - name: taskRunName
+    description: The name of the task run that triggered this
+  - name: taskRunNamespace
+    description: The namespace where the CI job was executed
+  - name: parentPipelineRunName
+    description: The name of the parent pipeline run - if any
+    default: ""
+  - name: parentPipelineRunTaskName
+    description: The name of the task in the parent pipeline run - if any
+    default: ""
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-logs-stop
+      namespace: tekton-ci
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
+        ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+    spec:
+      serviceAccountName: tekton-ci-logs
+      pipelineRef:
+        name: gubernator-stop
+      params:
+        - name: package
+          value: $(tt.params.gitHubRepo)
+        - name: jobName
+          value: $(tt.params.checkName)
+        - name: jobRunName
+          value: $(tt.params.parentPipelineRunName)
+        - name: jobStatus
+          value: $(tt.params.gitHubCheckStatus)
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: gitRevision
+          value: $(tt.params.gitRevision)
+        - name: bucket
+          value: "gs://tekton-prow"
+      workspaces:
+        - name: shared
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+        - name: credentials
+          secret:
+            secretName: release-secret

--- a/tekton/resources/ci/kustomization.yaml
+++ b/tekton/resources/ci/kustomization.yaml
@@ -5,4 +5,4 @@ commonAnnotations:
 resources:
 - bindings.yaml
 - github-template.yaml
-- gubernator-metadata.yaml
+- github-gubernator-template.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Add templates and triggers to run pipelines that store logs
and metadata for gubernator on GCS buckets.

The target for now is set to a staging bucket for testing
purposes.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature
