### PR TITLE
Add GitHub proxy deployment to the prow cluster

### DIFF
--- a/docs/prow.md
+++ b/docs/prow.md
@@ -78,6 +78,10 @@ kubectl apply -f boskos/boskos.yaml # Must be applied first to create the namesp
 kubectl apply -f boskos/boskos-config.yaml
 kubectl apply -f boskos/storage-class.yaml
 
+# Deploy GitHub Proxy
+kubectl apply -f prow/gce-ssd-retain_storageclass.yaml
+kubectl apply -f prow/ghproxy.yaml
+
 # Deploy Prow
 kubectl apply -f prow/prow.yaml
 

--- a/prow/gce-ssd-retain_storageclass.yaml
+++ b/prow/gce-ssd-retain_storageclass.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The 'gce-ssd-retain' storage class provisions a pd-ssd from GCE and
+# specifies the 'Retain' reclaim policy.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  namespace: default
+  name: gce-ssd-retain
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+reclaimPolicy: Retain

--- a/prow/ghproxy.yaml
+++ b/prow/ghproxy.yaml
@@ -1,0 +1,92 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  namespace: default
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  # gce-ssd-retain is specified in config/prow/cluster/gce-ssd-retain_storageclass.yaml
+  #
+  # If you are setting up your own Prow instance you can do any of the following:
+  # 1) Delete this to use the default storage class for your cluster.
+  # 2) Specify your own storage class.
+  # 3) If you are using GKE you can use the gce-ssd-retain storage class. It can be
+  #    created with: `kubectl create -f config/prow/cluster/gce-ssd-retain_storageclass.yaml
+  storageClassName: gce-ssd-retain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: ghproxy
+  labels:
+    app: ghproxy
+spec:
+  selector:
+    matchLabels:
+      app: ghproxy
+  replicas: 1  # TODO(fejta): this should be HA
+  template:
+    metadata:
+      labels:
+        app: ghproxy
+    spec:
+      containers:
+      - name: ghproxy
+        image: gcr.io/k8s-prow/ghproxy:v20220329-dee3fed4fa
+        args:
+        - --cache-dir=/cache
+        - --cache-sizeGB=99
+        - --serve-metrics=false
+        - --legacy-disable-disk-cache-partitions-by-auth-header=false
+        ports:
+        - name: main
+          containerPort: 8888
+        - name: metrics
+          containerPort: 9090
+        volumeMounts:
+        - name: cache
+          mountPath: /cache
+      volumes:
+      - name: cache
+        persistentVolumeClaim:
+          claimName: ghproxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ghproxy
+  namespace: default
+  name: ghproxy
+spec:
+  ports:
+  - name: main
+    port: 80
+    protocol: TCP
+    targetPort: 8888
+  - name: metrics
+    port: 9090
+  selector:
+    app: ghproxy
+  type: ClusterIP


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the deployment of GitHub proxy from k8s test-infra
https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/ghproxy.yaml

Identical to the original, except for the node selector, since we
don't have a dedicated node for gh-proxy, at least for now, and the
metrics generation, that has been disabled.

This is not used anywhere for now, but we shall integrate it in
all prow components.

We might want to consider running a single cluster for prow and tekton
in future so they can both benefit from a single in cluster gh-proxy

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature