### PR TITLE
Document conditional error with permission script ✍️

### DIFF
--- a/adjustpermissions.py
+++ b/adjustpermissions.py
@@ -19,6 +19,12 @@ Example usage:
   python3 adjustpermissions.py --users "foo@something.com,bar@something.com"
 Or to remove access for foo@something.com and bar@something.com:
   python3 adjustpermissions.py --users "foo@something.com,bar@something.com --remove"
+
+Troubleshooting:
+* "The policy contains bindings with conditions..." - If you see this prompt, someone has added a conditional
+  policy to the IAM policies for the project. This is not currently supported by this script. The easiest solution
+  is to remove the conditional policy from the project (e.g. via the command line or via the IAM section of the
+  GCP UI)
 """
 import argparse
 import shlex


### PR DESCRIPTION
# Changes

While updating permissions so that @jerop can step in as a governing
board member while I am on leave, I ran into an interruption in the
script execution b/c there was a conditional IAM policy on
tekton-nightly. I traced this back to a conditional policy which gave
@priyawadhwa temporary access (via her Google account at the time) but
had already expired in 2021. After removing this conditional policy the
script ran just fine so I added a brief troubleshooting section to the
script's docs to try to explain this if anyone runs into it in the
future.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._