### PR TITLE
Default not readonly & tolerate missing permissions when removing

### DIFF
--- a/adjustpermissions.py
+++ b/adjustpermissions.py
@@ -60,9 +60,20 @@ def update_all_projects(users: List[str], projects: List[str], remove: bool, rea
   for user in users:
     for project in projects:
       for role in roles:
-        subprocess.check_call(shlex.split(
-            "gcloud projects {} {} --member user:{} --role {}".format(command, project, user, role)
-        ))
+        try:
+            subprocess.check_call(shlex.split(
+                "gcloud projects {} {} --member user:{} --role {}".format(command, project, user, role)
+            ))
+        except subprocess.CalledProcessError as e:
+            # when removing permissions, if the permission doesn't exist an error will be returned - but that's okay
+            # since the goal is to remove it (and if the permissions list has new entries since the permissions
+            # were granted, this will be hit)
+            if remove:
+                print("unable to run {} for project {} user {} role {}: {}".format( command, project, user, role, e),
+                     file=sys.stderr
+                )
+            else:
+                raise e
 
 
 def parse_boskos_projects() -> List[str]:

--- a/adjustpermissions.py
+++ b/adjustpermissions.py
@@ -12,6 +12,9 @@ This script will add the permissions allowed to folks on the governing board
 (https://github.com/tektoncd/community/blob/main/governance.md#permissions-and-access)
 to all GCP projects. It can also be used to remove permissions if needed.
 
+The script can also be used to add "readonly" permission if the `--readonly` flag
+is provided.
+
 This script requires the `gcloud` command line tool and the python
 `PyYaml` library.
 
@@ -77,7 +80,7 @@ if __name__ == '__main__':
                           help="The names of the users' accounts, usually their email address, comma separated")
   arg_parser.add_argument("--remove", action="store_true",
                           help="Use this flag to remove user access instead of adding it")
-  arg_parser.add_argument("--readonly", type=bool, default=True, help="Grant only read permissions")
+  arg_parser.add_argument("--readonly", type=bool, default=False, help="Grant only read permissions")
   args = arg_parser.parse_args()
 
   gcloud_required()


### PR DESCRIPTION
# Changes

1. Default to non-readonly roles for permission script 🔑

https://github.com/tektoncd/plumbing/pull/926 added a `--readonly` flag
for adding readonly user permissions, however it added it with defualt
"true" which means that by default when running this script to add or
remove permissions, it will only modify the read only permissions and
will leave any write permissions as-is.

This means that when I went to update the governing board permissions -
i.e. adding permissions for new members and removing permissions from
old members, the script did very little and I couldn't figure out why.

This commit switches the default to the writer roles - defaulting to
reader is probably a safer default, however I think it's a confusing
change given how the script has been used so far. Can be convinced that
instead we should keep the default and add better documentation and
examples (but someone else will probably need to pick that up!)

2. Tolerate errors when removing permissions 👌

When removing permissions, if the permission to be removed isn't
present, the script will stop. However, if the permission isn't there,
imo that is okay and if the permissions list changes at all, this error
could get it - imo it's better to keep running the script and just
report any errors that couldn't be removed.

I ran into this especially when I ran the remove script but only for
readonly mode - from that point on I could no longer run the script for
the broader permissions b/c it would encounter an error immediately
since the viewer role had already been removed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._