### PR TITLE
Add basic testgrid config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -198,7 +198,29 @@ presubmits:
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./tekton/images/test-runner/test.sh"
-
+  - name: pull-tekton-plumbing-check-testgrid-config
+    run_if_changed: '^(prow/.*\.yaml)|(testgrid\.yaml)$'
+    decorate: true
+    annotations:
+      testgrid-create-test-group: "false"
+    labels:
+      preset-presubmit-sh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/configurator:v20220412-66078146cd
+        command:
+        - configurator
+        args:
+        - --yaml=testgrid/config.yaml
+        - --default=testgrid/default.yaml
+        - --prow-config=prow/config.yaml
+        - --prow-job-config=prow/config.yaml
+        - --prowjob-url-prefix=https://github.com/tektoncd/plumbing/tree/main/prow/
+        - --update-description
+        - --validate-config-file
+        resources:
+          requests:
+            memory: "1Gi"
   tektoncd/catlin:
     - name: pull-tekton-catlin-build-tests
       labels:
@@ -302,7 +324,6 @@ presubmits:
           - "--cov-target=."
           - "--cov-threshold-percentage=0"
           - "--github-token=/etc/github-token/oauth"
-
   tektoncd/chains:
     - name: pull-tekton-chains-build-tests
       labels:
@@ -1366,6 +1387,33 @@ presubmits:
         - "--github-token=/etc/github-token/oauth"
 
 postsubmits:
+  tektoncd/plumbing:
+  - name: post-tekton-plumbing-upload-testgrid-config
+    branches:
+    - main
+    agent: kubernetes
+    decorate: true
+    annotations:
+      testgrid-create-test-group: "false"
+    labels:
+      preset-postsubmit-sh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/configurator:v20220412-66078146cd
+        command:
+        - configurator
+        args:
+        - --yaml=testgrid/config.yaml
+        - --default=testgrid/default.yaml
+        - --prow-config=prow/config.yaml
+        - --prow-job-config=prow/config.yaml
+        - --prowjob-url-prefix=https://github.com/tektoncd/plumbing/tree/main/prow/
+        - --update-description
+        - --oneshot
+        - --output=gcs://tekton-prow/testgrid/config.yaml
+        resources:
+          requests:
+            memory: "1Gi"
   tektoncd/catlin:
   - name: post-tekton-catlin-go-coverage
     branches:

--- a/testgrid/config.yaml
+++ b/testgrid/config.yaml
@@ -1,0 +1,27 @@
+# config proto: https://github.com/GoogleCloudPlatform/testgrid/blob/master/pb/config/config.proto
+dashboards:
+- dashboard_tab:
+  - code_search_path: https://github.com/tektoncd/pipeline/search
+    code_search_url_template:
+      url: https://github.com/tektoncd/pipeline/main/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://github.com/tektoncd/pipeline/issues/new
+    name: pull-tekton-pipeline-integration-tests
+    open_bug_template:
+      url: https://github.com/tektoncd/pipeline/issues/
+    open_test_template:
+      url: https://prow.tekton.dev/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.tekton.dev/job-history/<gcs_prefix>
+    test_group_name: pull-tekton-pipeline-integration-tests
+  name: tektoncd-pipeline
+test_groups:
+- name: pull-tekton-pipeline-integration-tests
+  gcs_prefix: tekton-prow/pr-logs/pull/tektoncd_pipeline/

--- a/testgrid/default.yaml
+++ b/testgrid/default.yaml
@@ -1,0 +1,38 @@
+# In this repository, if you don't set something in your configuration file or prow job, it will use the value here
+
+default_test_group:
+  days_of_results: 15 # Number of days of test results to gather and serve.
+  tests_name_policy: 2 # replace the name of the test
+  ignore_pending: false # Show in-progress tests.
+  ignore_skip: true # Don't show skipped tests by default.
+  column_header:
+    - configuration_value: Commit # Shows the commit number on column header
+    - configuration_value: infra-commit
+  num_columns_recent: 10
+  alert_stale_results_hours: 0 # Don't alert for staleness by default.
+  num_failures_to_alert: 3 # Consider a test failed if it has 3 or more consecutive failures.
+  num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes.
+  code_search_path: github.com/tektoncd/pipeline/search # URL for regression search links.
+
+default_dashboard_tab:
+  open_test_template: # The URL template to visit after clicking on a cell
+    url: https://prow.tekton.dev/view/gs/<gcs_prefix>/<changelist>
+  file_bug_template: # The URL template to visit when filing a bug
+    url: https://github.com/tektoncd/pipeline/issues/new
+    options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+  attach_bug_template: # The URL template to visit when attaching to an existing bug
+    url: # empty
+    options: #empty
+  open_bug_template: # The URL template to visit when visiting an associated bug
+    url: https://github.com/tektoncd/pipeline/issues/
+  results_text: See these results on Prow # Text to show in the about menu as a link to another view of the results
+  results_url_template: # The URL template to visit after clicking
+    url: https://prow.tekton.dev/job-history/<gcs_prefix>
+  code_search_path: github.com/tektoncd/pipeline/search # URL for regression search links.
+  num_columns_recent: 10
+  code_search_url_template: # The URL template to visit when searching for changelists
+    url: https://github.com/tektoncd/pipeline/compare/<start-custom-0>...<end-custom-0>


### PR DESCRIPTION
# Changes

This commit adds a basic testgrid configuration for Tekton's prow instance (under /testgrid),
and configuration for a prow job that runs Configurator (https://github.com/kubernetes/test-infra/tree/master/testgrid/cmd/configurator).
Configurator generates a configuration file that is used by Testgrid, based on our prow configuration and the config added to /testgrid,
and uploads it to the tekton-prow bucket in GCS. This job will run whenever our prow configuration is updated.

The goal of this commit is to get the infrastructure that creates a Testgrid configuration file working, so we can set up
a Tekton dashboard in the Kubernetes TestGrid instance. This configuration has been validated by Configurator, but
it's likely that not all of it is correct. However, this change will not break any existing Tekton prow jobs.
The negative consequences are just that our new dashboard tab would not be configured correctly.
This commit adds support only for the prow job "pull-tekton-pipelines-integration-test";
support for other prow jobs will be added in a subsequent commit after the TestGrid infrastructure is set up.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._