### PR TITLE
Fix args for testgrid postsubmit prow job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1406,7 +1406,6 @@ postsubmits:
         - --yaml=testgrid/config.yaml
         - --default=testgrid/default.yaml
         - --prow-config=prow/config.yaml
-        - --prow-job-config=prow/config.yaml
         - --prowjob-url-prefix=https://github.com/tektoncd/plumbing/tree/main/prow/
         - --update-description
         - --oneshot


### PR DESCRIPTION
# Changes
This commit removes the "prow-job-config" argument from the testgrid postsubmit.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._