### PR TITLE
Update pull request template to include kind

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,13 @@
 # Changes
 
 <!-- Describe your changes here- ideally you can get that description straight from
-your descriptive commit message(s)! -->
+your descriptive commit message(s)!
+
+In addition, categorize the changes you're making using the "/kind" Prow command, example:
+
+/kind <kind>
+Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
+-->
 
 # Submitter Checklist
 


### PR DESCRIPTION
# Changes
Pull requests to plumbing must have a "kind" label. This commit updates the PR
template to remind authors to include this label in their PR.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._