### PR TITLE
Fix regex triggering TestGrid prow job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -199,7 +199,7 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./tekton/images/test-runner/test.sh"
   - name: pull-tekton-plumbing-check-testgrid-config
-    run_if_changed: '^(prow/.*\.yaml)|(testgrid\.yaml)$'
+    run_if_changed: '^(prow/.*\.yaml)|(testgrid/.*\.yaml)$'
     decorate: true
     annotations:
       testgrid-create-test-group: "false"


### PR DESCRIPTION
# Changes

This commit updates the regex used for the TestGrid prow presubmit
to match the configuration files under /testgrid.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._