### PR TITLE
Make TestGrid plumbing presubmit non-optional

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -205,7 +205,6 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-presubmit-sh: "true"
-    optional: true
     spec:
       containers:
       - image: gcr.io/k8s-prow/configurator:v20220412-66078146cd


### PR DESCRIPTION
# Changes
This presubmit is working now, so we want to ensure that all changes to testgrid
and prow configuration result in a valid testgrid config.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._