### PR TITLE
Use correct bucket for chains nightly

### DIFF
--- a/tekton/resources/nightly-release/overlays/chains/template.yaml
+++ b/tekton/resources/nightly-release/overlays/chains/template.yaml
@@ -21,6 +21,8 @@
           value: $(tt.params.versionTag)
         - name: serviceAccountPath
           value: release.json
+        - name: releaseBucket
+          value: gs://tekton-releases-nightly/chains
         workspaces:
           - name: workarea
             volumeClaimTemplate:


### PR DESCRIPTION
# Changes

The nightly builds of `release.yaml` are being sent to the regular bucket. This commit fixes the issue by explicitly defining which bucket to use.

The chains nightly builds were based on the pipelines nightly builds. There's a non-obvious difference between these two. While the release-pipeline for pipelines uses the [nightly bucket](https://github.com/tektoncd/pipeline/blob/68f2a66c9b2ffcc23ef262bac95d1eb3856021cf/tekton/release-pipeline.yaml#L23) as the default value, chains uses the [prod one](https://github.com/tektoncd/chains/blob/647e29892e2facd8897286fbc782bed74b2264c6/release/release-pipeline.yaml#L40).

# Submitter Checklist

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)