### PR TITLE
Add nightly build for the add-pr-body interceptor

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/README.md
@@ -1,0 +1,2 @@
+Cron Job to trigger the add-pr-body custom interceptor nightly build.
+Results are published to https://storage.cloud.google.com/tekton-releases-nightly/task-loops/latest/release.yaml

--- a/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-cron-trigger
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: PROJECT_NAME
+                value: add-pr-body-ci
+          initContainers:
+          - name: git
+            env:
+              - name: GIT_REPO
+                value: github.com/tektoncd/plumbing

--- a/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/release
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-add-pr-body-ci-nightly-release"

--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - cel-nightly
 - pipelines-in-pipelines-nightly
 - add-pr-body-nightly
+- add-pr-body-ci-nightly
 - add-team-members-nightly
 - operator-nightly
 - wait-task-nightly

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - overlays/cel
 - overlays/pipelines-in-pipelines
 - overlays/add-pr-body
+- overlays/add-pr-body-ci
 - overlays/add-team-members
 - overlays/operator
 - overlays/wait-task

--- a/tekton/resources/nightly-release/overlays/add-pr-body-ci/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/add-pr-body-ci/kustomization.yaml
@@ -1,0 +1,18 @@
+namePrefix: add-pr-body-ci-
+bases:
+  - ../../base
+patchesJson6902:
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: TriggerTemplate
+      name: template
+    path: template.yaml
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: Trigger
+      name: nightly
+    path: trigger.yaml
+resources:
+  - github.com/tektoncd/plumbing/tekton/ci/cluster-interceptors/add-pr-body/tekton/?ref=main

--- a/tekton/resources/nightly-release/overlays/add-pr-body-ci/template.yaml
+++ b/tekton/resources/nightly-release/overlays/add-pr-body-ci/template.yaml
@@ -1,0 +1,35 @@
+- op: add
+  path: /spec/resourcetemplates
+  value:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: add-pr-body-ci-release-nightly-
+      spec:
+        pipelineRef:
+          name: release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: gitRevision
+          value: $(tt.params.gitrevision)
+        - name: imageRegistry
+          value: $(tt.params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(tt.params.imageRegistryPath)
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        - name: serviceAccountPath
+          value: release.json
+        workspaces:
+          - name: workarea
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: release-secret
+            secret:
+              secretName: release-secret

--- a/tekton/resources/nightly-release/overlays/add-pr-body-ci/trigger.yaml
+++ b/tekton/resources/nightly-release/overlays/add-pr-body-ci/trigger.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/interceptors
+  value:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+          body.params.release.projectName == 'add-pr-body-ci'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The ClusterInterceptor version of the add-pr-body interceptor now
gets its own nightly build. The legacy one is deprecated and may
be removed in time.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
