### PR TITLE
Add release automation for pipeline-in-pod project

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - pipeline-to-taskrun-nightly
 - cloudevents-nightly
 - chains-nightly
+- pipeline-in-pod-nightly

--- a/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/README.md
@@ -1,0 +1,2 @@
+Cron Job to trigger the [ColocatedPipelineRun](https://github.com/tektoncd/experimental/tree/main/pipeline-in-pod) nightly build.
+Results are published to https://storage.cloud.google.com/tekton-releases-nightly/pipeline-in-pod/latest/release.yaml

--- a/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: nightly-cron-trigger
+spec:
+  schedule: "30 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: PROJECT_NAME
+                value: pipeline-in-pod
+          initContainers:
+          - name: git
+            env:
+              - name: GIT_REPO
+                value: github.com/tektoncd/experimental

--- a/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/release
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-pipeline-in-pod-nightly-release"

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
 - overlays/pipeline-to-taskrun
 - overlays/cloudevents
 - overlays/chains
+- overlays/pipeline-in-pod

--- a/tekton/resources/nightly-release/overlays/pipeline-in-pod/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-in-pod/kustomization.yaml
@@ -1,0 +1,18 @@
+namePrefix: pipeline-in-pod-
+bases:
+  - ../../base
+patchesJson6902:
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: TriggerTemplate
+      name: template
+    path: template.yaml
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: Trigger
+      name: nightly
+    path: trigger.yaml
+resources:
+  - github.com/tektoncd/experimental/tekton/?ref=main

--- a/tekton/resources/nightly-release/overlays/pipeline-in-pod/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-in-pod/template.yaml
@@ -1,0 +1,39 @@
+- op: add
+  path: /spec/resourcetemplates
+  value:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: pipeline-in-pod-release-nightly-
+      spec:
+        pipelineRef:
+          name: release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: gitRevision
+          value: $(tt.params.gitrevision)
+        - name: imageRegistry
+          value: $(tt.params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(tt.params.imageRegistryPath)
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        - name: serviceAccountPath
+          value: release.json
+        - name: subfolder
+          value: pipeline-in-pod
+        - name: releaseBucket
+          value: gs://tekton-releases-nightly/pipeline-in-pod
+        workspaces:
+          - name: workarea
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: release-secret
+            secret:
+              secretName: release-secret

--- a/tekton/resources/nightly-release/overlays/pipeline-in-pod/trigger.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-in-pod/trigger.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/interceptors
+  value:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+          body.params.release.projectName == 'pipeline-in-pod'


### PR DESCRIPTION
# Changes
This commit adds a nightly cronjob and triggers for the ColocatedPipelineRun custom task,
located in tektoncd/experimental/pipeline-in-pod. It uses the custom task release pipeline defined at the
top level of the experimental repo. The cronjob and triggers are copied from other custom task examples
in plumbing.

Needs https://github.com/tektoncd/experimental/pull/872

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._