### PR TITLE
Add examples test on kind cluster

### DIFF
--- a/tekton/ci/pipeline/template.yaml
+++ b/tekton/ci/pipeline/template.yaml
@@ -80,3 +80,52 @@ spec:
           value: test/e2e-tests.sh
         - name: e2e-env
           value: test/e2e-tests-kind.env
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: pull-pipeline-kind-k8s-v1-21-examples-
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/kind: ci
+        tekton.dev/check-name: pull-pipeline-kind-k8s-v1-21-examples
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
+      annotations:
+        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
+        tekton.dev/gitURL: "$(tt.params.gitRepository)"
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      workspaces:
+        - name: sources
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 1Gi
+        - name: credentials
+          secret:
+            secretName: "release-secret"
+      pipelineRef:
+        name: kind-e2e
+      params:
+        - name: pullRequestNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: pullRequestBaseRef
+          value: $(tt.params.pullRequestBaseRef)
+        - name: gitRepository
+          value: "$(tt.params.gitRepository)"
+        - name: gitCloneDepth
+          value: $(tt.params.gitCloneDepth)
+        - name: fileFilterRegex
+          value: '^(cmd/|examples/|images/|pkg/|test/|go\.)'
+        - name: checkName
+          value: pull-pipeline-kind-k8s-v1-21-examples
+        - name: gitHubCommand
+          value: $(tt.params.gitHubCommand)
+        - name: k8s-version
+          value: v1.21.x
+        - name: e2e-script
+          value: test/examples-tests.sh
+        - name: e2e-env
+          value: test/examples-tests-kind.env


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds a new Pipelinerun using `kind-e2e` as the Pipeline,
this Pipelinerun will pass new `e2e-env` and `e2e-script` where users
can define the script to run yaml file examples. Before this commit
examples tests of Tekton Pipeline are in `e2e-tests.sh` and they are
quite flacky. By moving them to a seperate ci job we don't have to rerun
the whole integration test and can save time for developers.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind feature