### PR TITLE
Remove `conditions` from release tooling

### DIFF
--- a/tekton/ci/infra/0001_rbac.yaml
+++ b/tekton/ci/infra/0001_rbac.yaml
@@ -105,7 +105,7 @@ rules:
   resources: ["pods", "pods/log", "namespaces"]
   verbs: ["get", "list"]
 - apiGroups: ["tekton.dev"]
-  resources: ["pipelines", "tasks", "pipelineruns", "pipelineresources", "taskruns", "conditions"]
+  resources: ["pipelines", "tasks", "pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["get"]
 ---
 apiVersion: v1

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -190,7 +190,7 @@ rules:
   resources: ["roles", "rolebindings"]
   verbs: ["*"]
 - apiGroups: ["tekton.dev"]
-  resources: ["tasks", "pipelines", "conditions", "pipelineresources"]
+  resources: ["tasks", "pipelines", "pipelineresources"]
   verbs: ["*"]
 - apiGroups: ["triggers.tekton.dev"]
   resources: ["eventlisteners", "triggerbindings", "triggertemplates"]

--- a/tekton/resources/nightly-tests/bastion-z/cleanup_tekton.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/cleanup_tekton.yaml
@@ -7,7 +7,7 @@ spec:
   - name: package
   - name: resources
     description: space separated list of resources to be deleted
-    default: "conditions pipelineresources tasks pipelines taskruns pipelineruns"
+    default: "pipelineresources tasks pipelines taskruns pipelineruns"
   - name: plumbing-path
     description: path in the workspace for plumbing source code
     default: src/github.com/tektoncd/plumbing

--- a/tekton/resources/release/README.md
+++ b/tekton/resources/release/README.md
@@ -306,7 +306,7 @@ tkn pipeline start \
   --param=version=<version> \
   --param=projectName=<tekton-project> \
   --param=namespace=tekton-pipelines \
-  --param=resources="conditions pipelineresources tasks pipelines taskruns pipelineruns" \
+  --param=resources="pipelineresources tasks pipelines taskruns pipelineruns" \
   --param=container-registry=docker-registry.default.svc:5000 \
   --param=package=github.com/tektoncd/pipeline \
   --resource=bucket=<tekton-bucket-resource> \

--- a/tekton/resources/release/base/save-release-logs.yaml
+++ b/tekton/resources/release/base/save-release-logs.yaml
@@ -61,7 +61,7 @@ rules:
   resources: ["pods", "pods/log", "namespaces"]
   verbs: ["get", "list"]
 - apiGroups: ["tekton.dev"]
-  resources: ["pipelines", "tasks", "pipelineruns", "pipelineresources", "taskruns", "conditions"]
+  resources: ["pipelines", "tasks", "pipelineruns", "pipelineresources", "taskruns"]
   verbs: ["get"]
 ---
 apiVersion: v1


### PR DESCRIPTION
# Changes

Starting with Pipeline v0.37.0, after https://github.com/tektoncd/pipeline/pull/4942 merges, `conditions` will no longer be part of Pipeline. This removes references to `conditions` from the release tooling.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._