### PR TITLE
Configure label color as strings

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -14,7 +14,7 @@ default:
     ##########################################################################
 
     # Signals to other contributors
-    - color: 7057ff
+    - color: "7057ff"
       description: Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.
       name: 'good first issue'
       target: issues
@@ -30,31 +30,31 @@ default:
       addedBy: anyone
 
     # Priorities
-    - color: fef2c0
+    - color: "fef2c0"
       description: Lowest priority. Possibly useful, but not yet enough support to actually get it done.  # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
       name: priority/awaiting-more-evidence
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: fbca04
+    - color: "fbca04"
       description: Higher priority than priority/awaiting-more-evidence.  # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
       name: priority/backlog
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: e11d21
+    - color: "e11d21"
       description: Highest priority. Must be actively worked on as someone's top priority right now.  # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
       name: priority/critical-urgent
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: eb6420
+    - color: "eb6420"
       description: Important over the long term, but may not be staffed and/or may need multiple releases to complete.
       name: priority/important-longterm
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: eb6420
+    - color: "eb6420"
       description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
       name: priority/important-soon
       target: both
@@ -62,49 +62,49 @@ default:
       addedBy: anyone
 
     # Areas
-    - color: 0052cc
+    - color: "0052cc"
       description: Indicates an issue or PR that deals with the API.
       name: area/api
       target: issues
       addedBy: label
-    - color: 7057ff
+    - color: "7057ff"
       description: Indicates an issue on release (process, tasks).
       name: area/release
       target: issues
       addedBy: label
-    - color: 10677f
+    - color: "10677f"
       description: Issues or PRs related to the plumbing infrastructure but needing attention in a non-plumbing repo.
       name: area/plumbing
       target: both
       addedBy: label
-    - color: c91856
+    - color: "c91856"
       description: Issues that are part of the project (or organization) roadmap (usually an epic)
       name: area/roadmap
       target: issues
       addedBy: label
-    - color: 3E4B9E
+    - color: "3E4B9E"
       description: Issues that should be considered as Epics (aka multiple sub-tasks, …)
       name: area/epic
       target: issues
       addedBy: label
-    - color: 009900
+    - color: "009900"
       description: Issues that are related to automation aspects of the website or other projects.
       name: area/automation
       target: issues
       addedBy: label
-    - color: 9933ff
+    - color: "9933ff"
       description: Issues or PRs that are related to performance aspects.
       name: area/performance
       target: both
       addedBy: label
-    - color: ba3b09
+    - color: "ba3b09"
       description: Issues or PRs that are related to Secure Software Supply Chain (S3C)
       name: area/s3c
       target: both
       addedBy: label
 
     # Kinds
-    - color: d876e3
+    - color: "d876e3"
       description: Issues or PRs that are questions around the project or a particular feature
       name: kind/question
       previously:
@@ -112,7 +112,7 @@ default:
       target: issues
       prowPlugin: label
       addedBy: anyone
-    - color: e11d21
+    - color: "e11d21"
       description: Categorizes issue or PR as related to a bug.
       name: kind/bug
       previously:
@@ -120,28 +120,28 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: f7c6c7
+    - color: "f7c6c7"
       description: Categorizes issue or PR as related to a flakey test # Please escalate this and treat it as an emergency.
       name: kind/flake
-    - color: c7def8
+    - color: "c7def8"
       description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
       name: kind/cleanup
       previously:
         - name: kind/friction
         - name: kind/technical-debt
-    - color: c7def8
+    - color: "c7def8"
       description: Categorizes issue or PR as related to design.
       name: kind/design
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: c7def8
+    - color: "c7def8"
       description: Categorizes issue or PR as related to a TEP (or needs a TEP).
       name: kind/tep
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: bfd4f2
+    - color: "bfd4f2"
       description: Categorizes issue or PR as related to documentation.
       name: kind/documentation
       previously:
@@ -150,7 +150,7 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: c7def8
+    - color: "c7def8"
       description: Categorizes issue or PR as related to a new feature.
       name: kind/feature
       previously:
@@ -159,19 +159,19 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: ef8fd9
+    - color: "ef8fd9"
       name: kind/misc
       description: Categorizes issue or PR as a miscellaneuous one.
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: 8F0891
+    - color: "8F0891"
       name: hacktoberfest-accepted
       description: Categorizes PRs as one accepted Hacktoberfest 2021
       target: prs
       prowPlugin: label
       addedBy: humans
-    - color: 8F0891
+    - color: "8F0891"
       name: Hacktoberfest
       description: Categorizes issue as one for Hacktoberfest 2021
       target: issues
@@ -180,44 +180,44 @@ default:
     # For further discussion in the next Productivity WG meeting
 
     # Would like to understand when this label should be used vs. using GitHub syntax or ZenHub
-    - color: d455d0
+    - color: "d455d0"
       description: Indicates an issue is a duplicate of other open issue.
       name: triage/duplicate
       previously:
         - name: duplicate
       target: both
     # needs-information seems like it serves the same function as kind/question or "waiting for response"
-    - color: d455d0
+    - color: "d455d0"
       description: Indicates an issue needs more information in order to work on it.
       name: triage/needs-information
       target: both
       addedBy: humans
-    - color: d455d0
+    - color: "d455d0"
       description: Indicates an issue that needs to be discussed during a working group call.
       name: triage/wg-discuss
       target: both
       addedBy: humans
 
     # Release notes (prow plugin)
-    - color: c2e0c6
+    - color: "c2e0c6"
       description: Denotes a PR that will be considered when it comes time to generate release notes.
       name: release-note
       target: prs
       prowPlugin: releasenote
       addedBy: prow
-    - color: c2e0c6
+    - color: "c2e0c6"
       description: Denotes a PR that introduces potentially breaking changes that require user action.  # These actions will be specifically called out when it comes time to generate release notes.
       name: release-note-action-required
       target: prs
       prowPlugin: releasenote
       addedBy: prow
-    - color: c2e0c6
+    - color: "c2e0c6"
       description: Denotes a PR that doesnt merit a release note.  # will be ignored when it comes time to generate release notes.
       name: release-note-none
       target: prs
       prowPlugin: releasenote
       addedBy: prow or member or author
-    - color: c2e0c6
+    - color: "c2e0c6"
       description: Used by dependabot - identifies all PRs created by dependabot
       name: dependencies
       target: prs
@@ -227,43 +227,43 @@ default:
     # These labels are modified by automation and should not be added manually
     ##########################################################################
 
-    - color: abea59
+    - color: "abea59"
       description: Indicates a PR has been approved by an approver from all required OWNERS files.
       name: approved
       target: prs
       prowPlugin: approve
       addedBy: approvers
-    - color: e11d21
+    - color: "e11d21"
       description: Indicates the PR's author has not signed the CNCF CLA.
       name: 'cncf-cla: no'
       target: prs
       prowPlugin: cla
       addedBy: prow
-    - color: 0c6a89
+    - color: "0c6a89"
       description: Indicates the PR's author has signed the CNCF CLA.
       name: 'cncf-cla: yes'
       target: prs
       prowPlugin: cla
       addedBy: prow
-    - color: e11d21
+    - color: "e11d21"
       description: Indicates that a PR should not merge because someone has issued a /hold command.
       name: do-not-merge/hold
       target: prs
       prowPlugin: hold
       addedBy: anyone
-    - color: e11d21
+    - color: "e11d21"
       description: Indicates that a PR should not merge because it has an invalid OWNERS file in it.
       name: do-not-merge/invalid-owners-file
       target: prs
       prowPlugin: verify-owners
       addedBy: prow
-    - color: e11d21
+    - color: "e11d21"
       description: Indicates that a PR should not merge because it's missing one of the release note labels.
       name: do-not-merge/release-note-label-needed
       target: prs
       prowPlugin: releasenote
       addedBy: prow
-    - color: e11d21
+    - color: "e11d21"
       description: Indicates that a PR should not merge because it is a work in progress.
       name: do-not-merge/work-in-progress
       target: prs
@@ -272,55 +272,55 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: 6aed75
+    - color: "6aed75"
       description: Indicates that a PR is ready to be merged.
       name: lgtm
       target: prs
       prowPlugin: lgtm
       addedBy: reviewers or members
-    - color: b60205
+    - color: "b60205"
       description: Indicates a PR that requires an org member to verify it is safe to test.  # This is to prevent spam/abuse of our CI system, and can be circumvented by becoming an org member. Org members can remove this label with the `/ok-to-test` command.
       name: needs-ok-to-test
       target: prs
       prowPlugin: trigger
       addedBy: prow
-    - color: e11d21
+    - color: "e11d21"
       description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
       name: needs-rebase
       target: prs
       prowPlugin: needs-rebase
       addedBy: prow
-    - color: 790604
+    - color: "790604"
       description: Indicates a PR needs to be cherry-pick to a release branch
       name: needs-cherry-pick
       target: prs
       prowPlugin: needs-cherry-pick
       addedBy: anyone
-    - color: 15dd18
+    - color: "15dd18"
       description: Indicates a non-member PR verified by an org member that is safe to test.  # This is the opposite of needs-ok-to-test and should be mutually exclusive.
       name: ok-to-test
       target: prs
       prowPlugin: trigger
       addedBy: prow
-    - color: ee9900
+    - color: "ee9900"
       description: Denotes a PR that changes 100-499 lines, ignoring generated files.
       name: size/L
       target: prs
       prowPlugin: size
       addedBy: prow
-    - color: eebb00
+    - color: "eebb00"
       description: Denotes a PR that changes 30-99 lines, ignoring generated files.
       name: size/M
       target: prs
       prowPlugin: size
       addedBy: prow
-    - color: 77bb00
+    - color: "77bb00"
       description: Denotes a PR that changes 10-29 lines, ignoring generated files.
       name: size/S
       target: prs
       prowPlugin: size
       addedBy: prow
-    - color: ee5500
+    - color: "ee5500"
       description: Denotes a PR that changes 500-999 lines, ignoring generated files.
       name: size/XL
       target: prs
@@ -332,7 +332,7 @@ default:
       target: prs
       prowPlugin: size
       addedBy: prow
-    - color: ee0000
+    - color: "ee0000"
       description: Denotes a PR that changes 1000+ lines, ignoring generated files.
       name: size/XXL
       target: prs
@@ -341,43 +341,43 @@ default:
 repos:
   tektoncd/catalog:
     labels:
-      - color: e11d21
+      - color: "e11d21"
         description: This pull-request cant be merged because it requires a specific version of pipeline
         name: do-not-merge/requires-unreleased-pipelines
         target: prs
         addedBy: humans
-      - color: DF0A6B
+      - color: "DF0A6B"
         description: This issue needs attention from the buildpacks team
         name: area/buildpacks
         target: issues
         addedBy: humans
   tektoncd/dashboard:
     labels:
-      - color: 160a72
+      - color: "160a72"
         description: This issue needs some help during design phase
         name: design-help-wanted
         target: issues
         addedBy: humans
   tektoncd/operator:
     labels:
-      - color: 160a72
+      - color: "160a72"
         description: This issue is used during working group to mark issues to be discussed
         name: grooming
         target: issues
         addedBy: humans
-      - color: 0c6a89
+      - color: "0c6a89"
         description: This issue targets the OpenShift Platform
         name: platform/openshift
         target: issues
         addedBy: humans
-      - color: 0c6a89
+      - color: "0c6a89"
         description: This issue targets the Kubernetes Platform
         name: platform/kubernetes
         target: issues
         addedBy: humans
   tektoncd/pipeline:
     labels:
-      - color: e11d21
+      - color: "e11d21"
         description: Categorizes issue or PR as related to the beta api
         name: kind/beta-blocking
         target: both
@@ -385,129 +385,129 @@ repos:
         addedBy: anyone
 
       # This label is automatically added by ZenHub
-      - color: 3E4B9E
+      - color: "3E4B9E"
         description: Issues that should be considered as Epics (aka multiple sub-tasks, …)
         name: Epic
         target: both
         addedBy: humans
   tektoncd/plumbing:
     labels:
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to code in /boskos
         name: area/boskos
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to code in /config
         name: area/config
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to prow
         name: area/prow
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to code in /label_sync
         name: area/label_sync
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to prow's tide component
         name: area/prow/tide
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to prow's hook component
         name: area/prow/hook
         target: both
         addedBy: label
-      - color: 0052cc
+      - color: "0052cc"
         description: Issues or PRs related to prow's pod-utilities component
         name: area/prow/pod-utilities
         target: both
         addedBy: label
   tektoncd/website:
     labels:
-      - color: e11d21
+      - color: "e11d21"
         description: Categorizes issue or PR as related to the beta api
         name: kind/beta-blocking
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: 0ffa16
+      - color: "0ffa16"
         description: Issues or PRs related to the Tektoncd Blog subproject
         name: area/blog
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to German language
         name: language/de
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to English language
         name: language/en
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Spanish language
         name: language/es
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to French language
         name: language/fr
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Hindi language
         name: language/hi
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Indonesian language
         name: language/id
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Italian language
         name: language/it
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Japanese language
         name: language/ja
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Korean language
         name: language/ko
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Norwegian language
         name: language/no
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Portuguese language
         name: language/pt
         target: both
         prowPlugin: label
         addedBy: anyone
-      - color: e9b3f9
+      - color: "e9b3f9"
         description: Issues or PRs related to Chinese language
         name: language/zh
         previously:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The automation label color was set to 009900 which the YAML parser
interpreted as the integer 9900 which caused 422 errors back from
GitHub.

Pass all color fields as strings to fix the issue and avoid similar
ones in future due to copy/paste.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._