### PR TITLE
Change the release note task for rekor 0.8.2

### DIFF
--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -85,7 +85,7 @@ spec:
         Obtain the attestation:
         ${BQ}${BQ}${BQ}shell
         REKOR_UUID=${REKOR_UUID}
-        rekor-cli get --uuid \$REKOR_UUID --format json | jq -r .Attestation | base64 --decode | jq
+        rekor-cli get --uuid \$REKOR_UUID --format json | jq -r .Attestation | jq .
         ${BQ}${BQ}${BQ}
 
         Verify that all container images in the attestation are in the release file:
@@ -94,7 +94,7 @@ spec:
         REKOR_UUID=${REKOR_UUID}
 
         # Obtains the list of images with sha from the attestation
-        REKOR_ATTESTATION_IMAGES=\$(rekor-cli get --uuid "\$REKOR_UUID" --format json | jq -r .Attestation | base64 --decode | jq -r '.subject[]|.name + ":${VERSION}@sha256:" + .digest.sha256')
+        REKOR_ATTESTATION_IMAGES=\$(rekor-cli get --uuid "\$REKOR_UUID" --format json | jq -r .Attestation | jq -r '.subject[]|.name + ":${VERSION}@sha256:" + .digest.sha256')
 
         # Download the release file
         curl "\$RELEASE_FILE" > release.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the latest version of rekor the attestation is not base64 encoded
anymore. Adapt the release notes template to account for that.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._