### PR TITLE
Update Prow to the latest versions used by k8s

### DIFF
--- a/boskos/boskos.yaml
+++ b/boskos/boskos.yaml
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 # Boskos deployment for Tekton Prow instance
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dynamicresourcelifecycles.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
 spec:
   group: boskos.k8s.io
   names:
@@ -25,29 +27,74 @@ spec:
     plural: dynamicresourcelifecycles
     singular: dynamicresourcelifecycle
   scope: Namespaced
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
-  additionalPrinterColumns:
-  - name: Type
-    type: string
-    description: The dynamic resource type.
-    JSONPath: .spec.config.type
-  - name: Min-Count
-    type: integer
-    description: The minimum count requested.
-    JSONPath: .spec.min-count
-  - name: Max-Count
-    type: integer
-    description: The maximum count requested.
-    JSONPath: .spec.max-count
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The dynamic resource type.
+          jsonPath: .spec.config.type
+        - name: Min-Count
+          type: integer
+          description: The minimum count requested.
+          jsonPath: .spec.min-count
+        - name: Max-Count
+          type: integer
+          description: The maximum count requested.
+          jsonPath: .spec.max-count
+      schema:
+        openAPIV3Schema:
+          description: Defines the lifecycle of a dynamic resource. All
+            Resource of a given type will be constructed using the same
+            configuration
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                state:
+                  type: string
+                max-count:
+                  description: Maxiumum number of resources expected. This
+                    maximum may be temporarily exceeded while resources are in
+                    the process of being deleted, though this is only expected
+                    when MaxCount is lowered.
+                  type: integer
+                  format: int32
+                min-count:
+                  description: Minimum number of resources to be used as a
+                    buffer. Resources in the process of being deleted and
+                    cleaned up are included in this count.
+                  type: integer
+                  format: int32
+                lifespan:
+                  description: Lifespan of a resource, time after which the
+                    resource should be reset
+                  type: integer
+                  format: int64
+                config:
+                  description: Config information about how to create the
+                    object
+                  type: object
+                  properties:
+                    type:
+                      description: The dynamic resource type
+                      type: string
+                    content:
+                      type: string
+                needs:
+                  description: Define the resource needs to create the object
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: resources.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
 spec:
   group: boskos.k8s.io
   names:
@@ -56,27 +103,54 @@ spec:
     plural: resources
     singular: resource
   scope: Namespaced
-  version: v1
   versions:
   - name: v1
     served: true
     storage: true
-  additionalPrinterColumns:
-  - name: Type
-    type: string
-    description: The resource type.
-    JSONPath: .spec.type
-  - name: State
-    type: string
-    description: The current state of the resource.
-    JSONPath: .status.state
-  - name: Owner
-    type: string
-    description: The current owner of the resource.
-    JSONPath: .status.owner
-  - name: Last-Updated
-    type: date
-    JSONPath: .status.lastUpdate
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The resource type.
+      jsonPath: .spec.type
+    - name: State
+      type: string
+      description: The current state of the resource.
+      jsonPath: .status.state
+    - name: Owner
+      type: string
+      description: The current owner of the resource.
+      jsonPath: .status.owner
+    - name: Last-Updated
+      type: date
+      jsonPath: .status.lastUpdate
+    schema:
+      openAPIV3Schema:
+        description: Abstracts any resource type that can be tracked by boskos
+        type: object
+        properties:
+          spec:
+            description: Holds information that are not likely to change
+            type: object
+            properties:
+              type:
+                type: string
+          status:
+            description: Holds information that are likely to change
+            type: object
+            properties:
+              state:
+                type: string
+              owner:
+                type: string
+              lastUpdate:
+                type: string
+                format: date-time
+              userData:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              expirationDate:
+                type: string
+                format: date-time
 ---
 apiVersion: v1
 kind: Namespace
@@ -115,7 +189,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 # Boskos
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: boskos
@@ -135,7 +209,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-staging-boskos/boskos:v20200819-984516e
+        image: gcr.io/k8s-staging-boskos/boskos:v20220628-f099c7d
         args:
         - --config=/etc/config/config
         - --namespace=test-pods
@@ -181,7 +255,7 @@ spec:
   type: NodePort
 ---
 # Janitor
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: boskos-janitor
@@ -190,6 +264,9 @@ metadata:
   namespace: test-pods
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: boskos-janitor
   template:
     metadata:
       labels:
@@ -199,8 +276,9 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-staging-boskos/janitor:v20200819-984516e
+        image: gcr.io/k8s-staging-boskos/janitor:v20220628-f099c7d
         args:
+        - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gke-project
         - --pool-size=10
         - --
@@ -216,7 +294,7 @@ spec:
           secretName: test-account
 ---
 # Reaper
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: boskos-reaper
@@ -224,16 +302,19 @@ metadata:
     app: boskos-reaper
   namespace: test-pods
 spec:
+  selector:
+    matchLabels:
+      app: boskos-reaper
   replicas: 1  # one canonical source of resources
   template:
     metadata:
       labels:
         app: boskos-reaper
     spec:
-      serviceAccountName: "boskos"
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-staging-boskos/reaper:v20200819-984516e
+        image: gcr.io/k8s-staging-boskos/reaper:v20220628-f099c7d
         args:
+        - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gke-project

--- a/docs/prow.md
+++ b/docs/prow.md
@@ -83,11 +83,12 @@ kubectl apply -f prow/gce-ssd-retain_storageclass.yaml
 kubectl apply -f prow/ghproxy.yaml
 
 # Deploy Prow
+kubectl apply -f prow/prowjob-schemaless_customresourcedefinition.yaml
 kubectl apply -f prow/prow.yaml
 
-# Update Prow with the right configuration
-kubectl create configmap config --from-file=config.yaml=prow/config.yaml --dry-run -o yaml | kubectl replace configmap config -f -
-kubectl create configmap plugins --from-file=plugins.yaml=prow/plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
+# Create Prow's configuration
+kubectl create configmap config --from-file=config.yaml=prow/config.yaml
+kubectl create configmap plugins --from-file=plugins.yaml=prow/plugins.yaml
 ```
 
 ### Ingress
@@ -129,6 +130,11 @@ For `tektoncd` this is configured at the Org level.
 
 Update the value of the webhook with `http://ingress-address/hook`
 (see [kicking the tires](#kicking-the-tires) to get the ingress IP).
+
+### OAuth Setup
+
+OAuth Setup is done following the [official guide](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/deck/github_oauth_setup.md).
+The "Prow" OAuth GitHub application is defined in the `tektoncd` GitHub org.
 
 ## Updating Prow itself
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16,9 +16,9 @@ prowjob_namespace: default
 pod_namespace: test-pods
 
 plank:
-  job_url_template: 'https://tekton-releases.appspot.com/build/tekton-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  job_url_template: 'https://prow.tekton.dev/view/gs/tekton-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_templates:
-    '*': '[Full PR test history](https://tekton-releases.appspot.com/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.tekton.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
+    '*': '[Full PR test history](https://prow.tekton.dev/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.tekton.dev/pr?query=is%3Apr%20state%3Aopen%20author%3A{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
   job_url_prefix_config:
     '*': https://prow.tekton.dev/view/
   pod_pending_timeout: 60m
@@ -238,9 +238,7 @@ deck:
         config:
           runner_configs:
             "default":
-              pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow-builds"
-            "test-infra-trusted":
-              pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow"
+              pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-a/prow/test-pods/{{ .Name }}/details?project=tekton-releases"
       required_files:
         - ^podinfo\.json$
       optional_files:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17,20 +17,41 @@ pod_namespace: test-pods
 
 plank:
   job_url_template: 'https://tekton-releases.appspot.com/build/tekton-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
-  report_template: '[Full PR test history](https://tekton-releases.appspot.com/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.tekton.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
+  report_templates:
+    '*': '[Full PR test history](https://tekton-releases.appspot.com/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.tekton.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
+  job_url_prefix_config:
+    '*': https://prow.tekton.dev/view/
   pod_pending_timeout: 60m
-  default_decoration_config:
-    timeout: 7200000000000 # 2h
-    grace_period: 15000000000 # 15s
-    utility_images:
-      clonerefs: "gcr.io/k8s-prow/clonerefs:v20190731-e3f7b9853"
-      initupload: "gcr.io/k8s-prow/initupload:v20190731-e3f7b9853"
-      entrypoint: "gcr.io/k8s-prow/entrypoint:v20190731-e3f7b9853"
-      sidecar: "gcr.io/k8s-prow/sidecar:v20190731-e3f7b9853"
-    gcs_configuration:
-      bucket: "tekton-prow"
-      path_strategy: "explicit"
-    gcs_credentials_secret: "test-account"
+  pod_unscheduled_timeout: 5m
+  default_decoration_configs:
+    '*':
+      timeout: 2h
+      grace_period: 15s
+      utility_images:
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220628-aa928caf31"
+        initupload: "gcr.io/k8s-prow/initupload:v20220628-aa928caf31"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220628-aa928caf31"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220628-aa928caf31"
+      gcs_configuration:
+        bucket: "tekton-prow"
+        path_strategy: "explicit"
+        default_org: "tektoncd"
+        default_repo: "pipeline"
+      gcs_credentials_secret: "test-account"
+      resources:
+        clonerefs:
+          requests:
+            cpu: 100m
+        initupload:
+          requests:
+            cpu: 100m
+        place_entrypoint:
+          requests:
+            cpu: 100m
+        sidecar:
+          requests:
+            cpu: 100m
+
 branch-protection:
   orgs:
     tektoncd:
@@ -42,7 +63,24 @@ branch-protection:
       protect: true
       # Admins can overrule checks
       enforce_admins: false
+      # Enforce EasyCLA for all repos
+      required_status_checks:
+        contexts:
+        - EasyCLA
+      repos:
+        pipeline:
+          required_status_checks:
+            contexts:
+            - check-pr-has-kind-label
+
+sinker:
+  resync_period: 1m
+  max_prowjob_age: 48h
+  terminated_pod_ttl: 30m
+  max_pod_age: 3h
+
 tide:
+  sync_period: 2m
   queries:
   - repos:
     - tektoncd/catalog
@@ -90,8 +128,128 @@ tide:
     tektoncd/triggers: rebase
     tektoncd/website: rebase
   target_url: https://prow.tekton.dev/tide
-sinker:
-  max_pod_age: 3h
+  priority:
+  - labels: ["kind/flake", "priority/critical-urgent"]
+  - labels: ["kind/failing-test", "priority/critical-urgent"]
+  - labels: ["kind/bug", "priority/critical-urgent"]
+  pr_status_base_urls:
+    '*': https://prow.tekton.dev/pr
+
+deck:
+  spyglass:
+    size_limit: 200000000 # 200MB
+    gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
+    testgrid_config: gs://tekton-prow/testgrid/config
+    testgrid_root: https://testgrid.k8s.io/
+    lenses:
+    - lens:
+        name: metadata
+      required_files:
+      - ^(?:started|finished)\.json$
+      optional_files:
+      - ^(?:podinfo|prowjob)\.json$
+    - lens:
+        name: buildlog
+        config:
+          highlighter:
+            endpoint: http://halogen.default.svc.cluster.local
+            pin: true
+            auto: false
+          highlight_regexes:
+          - Automatic merge failed
+          - cannot convert.+to type
+          - "cannot use.+as.+(type|value)"
+          - Cluster failed to initialize
+          - cluster unreachable
+          - "compilepkg: error"
+          - configuration error
+          - contact Google support
+          - could not apply prowjob annotations
+          - could not find the referenced.+TestGroup
+          - could not write config
+          - "couldn't load prow config:"
+          - curl.+Failed to connect
+          - DATA RACE
+          - dirty working directory
+          - ^E\d{4} \d\d:\d\d:\d\d\.\d+
+          - "(Error|ERROR|error)s?:"
+          - Error.+executing benchmarks
+          - Expected.+got
+          - FAILED. See logs
+          - failed to acquire k8s binaries
+          - failed to solve
+          - (FAIL|Failure \[)\b
+          - fatal error
+          - flag provided but not defined
+          - Full Stack Trace
+          - got.+expected
+          - hash mismatch
+          - Hit an unsupported type
+          - imported but not used
+          - Incompatible changes
+          - incorrect boilerplate
+          - indent-error-flow
+          - INSTALLATION FAILED
+          - is a misspelling
+          - LimitExceeded
+          - "make:.+Error"
+          - Master not detected
+          - Merge conflict
+          - not enough arguments in call
+          - panic\b
+          - Previous (write|read)
+          - Process did not finish before.+timeout
+          - race detected
+          - security token.+invalid
+          - "signal: killed"
+          - Something went wrong
+          - too few arguments
+          - too many errors
+          - "[Tt]imed out"
+          - type.+has no field
+          - unable to start the controlplane
+          - "undefined:"
+          - Unfortunately, an error
+          - unused.+deadcode
+          - "[Uu]nexpected error"
+          - verify.+failed
+          - want.+got
+          - Your cluster may not be fully functional
+          - ^\s+\^$
+          - \[(0;)?31m
+          - "^diff " # [+-]{3}\\s" has too much noise from go test output and set -x
+          - • Failure
+          # This highlights the start of bazel tests/runs to skip go importing noise.
+          - "^INFO: Analyzed \\d+ targets"
+      required_files:
+        - ^.*build-log\.txt$
+    - lens:
+        name: junit
+      required_files:
+        - ^artifacts(/.*/|/)junit.*\.xml$ # https://regex101.com/r/vCSegS/1
+    - lens:
+        name: coverage
+      required_files:
+        - ^artifacts/filtered\.cov$
+      optional_files:
+        - ^artifacts/filtered\.html$
+    - lens:
+        name: podinfo
+        config:
+          runner_configs:
+            "default":
+              pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow-builds"
+            "test-infra-trusted":
+              pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow"
+      required_files:
+        - ^podinfo\.json$
+      optional_files:
+        - ^prowjob\.json$
+    - lens:
+        name: links
+      required_files:
+        - artifacts/.*\.link\.txt
+  tide_update_period: 1s
 
 presets:
 - labels:

--- a/prow/ingress.yaml
+++ b/prow/ingress.yaml
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     acme.cert-manager.io/http01-edit-in-place: "true"
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: prow.tekton.dev
+    dns.gardener.cloud/ttl: "3600"
   name: ing
   namespace: default
 spec:
@@ -25,13 +27,20 @@ spec:
     hosts:
     - prow.tekton.dev
   rules:
-  - http:
+  - host: prow.tekton.dev
+    http:
       paths:
       - backend:
-          serviceName: deck
-          servicePort: 80
+          service:
+            name: deck
+            port:
+              number: 80
         path: /*
+        pathType: ImplementationSpecific
       - backend:
-          serviceName: hook
-          servicePort: 8888
+          service:
+            name: hook
+            port:
+              number: 8888
         path: /hook
+        pathType: ImplementationSpecific

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -20,36 +20,41 @@ approve:
 
 plugins:
   tektoncd:
-  - approve
-  - assign
-  - blunderbuss
-  - buildifier
-  - cat
-  - dog
-  - golint
-  - heart
-  - help
-  - hold
-  - label
-  - lgtm
-  - lifecycle
-  - milestone
-  - project
-  - retitle
-  - size
-  - skip
-  - trigger
-  - verify-owners
-  - wip
-  - yuks
+    plugins:
+      - approve
+      - assign
+      - blunderbuss
+      - buildifier
+      - cat
+      - dog
+      - golint
+      - heart
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - milestone
+      - project
+      - retitle
+      - size
+      - skip
+      - trigger
+      - verify-owners
+      - wip
+      - yuks
   tektoncd/pipeline:
-  - release-note
+    plugins:
+      - release-note
   tektoncd/cli:
-  - release-note
+    plugins:
+      - release-note
   tektoncd/operator:
-  - release-note
+    plugins:
+      - release-note
   tektoncd/triggers:
-  - release-note
+    plugins:
+      - release-note
 
 external_plugins:
   tektoncd:

--- a/prow/prow.yaml
+++ b/prow/prow.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Tekton Authors
+# Copyright 2019-2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,94 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: prowjobs.prow.k8s.io
-spec:
-  group: prow.k8s.io
-  version: v1
-  names:
-    kind: ProwJob
-    singular: prowjob
-    plural: prowjobs
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
-              - "presubmit"
-              - "postsubmit"
-              - "periodic"
-              - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
-              - "triggered"
-              - "pending"
-              - "success"
-              - "failure"
-              - "aborted"
-              - "error"
-          anyOf:
-          - not:
-              properties:
-                state:
-                  type: string
-                  enum:
-                  - "success"
-                  - "failure"
-                  - "error"
-                  - "aborted"
-          - required:
-            - completionTime
-  additionalPrinterColumns:
-  - name: Job
-    type: string
-    description: The name of the job being run.
-    JSONPath: .spec.job
-  - name: BuildId
-    type: string
-    description: The ID of the job being run.
-    JSONPath: .status.build_id
-  - name: Type
-    type: string
-    description: The type of job being run.
-    JSONPath: .spec.type
-  - name: Org
-    type: string
-    description: The org for which the job is running.
-    JSONPath: .spec.refs.org
-  - name: Repo
-    type: string
-    description: The repo for which the job is running.
-    JSONPath: .spec.refs.repo
-  - name: Pulls
-    type: string
-    description: The pulls for which the job is running.
-    JSONPath: ".spec.refs.pulls[*].number"
-  - name: StartTime
-    type: date
-    description: When the job started running.
-    JSONPath: .status.startTime
-  - name: CompletionTime
-    type: date
-    description: When the job finished running.
-    JSONPath: .status.completionTime
-  - name: State
-    description: The state of the job.
-    type: string
-    JSONPath: .status.state
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -125,14 +37,19 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20190731-e3f7b9853
+        image: gcr.io/k8s-prow/hook:v20220628-aa928caf31
         imagePullPolicy: Always
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8888
+          - name: metrics
+            containerPort: 9090
         volumeMounts:
         - name: hmac
           mountPath: /etc/webhook
@@ -179,55 +96,96 @@ metadata:
   name: hook
   namespace: default
 spec:
-  clusterIP: 10.55.254.214
   externalTrafficPolicy: Cluster
   ports:
-  - nodePort: 30298
+  - name: main
     port: 8888
     protocol: TCP
     targetPort: 8888
+  - name: metrics
+    port: 9090
+    protocol: TCP
   selector:
     app: hook
   sessionAffinity: None
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
-  name: plank
+  name: prow-controller-manager
   labels:
-    app: plank
+    app: prow-controller-manager
 spec:
-  replicas: 1 # Do not scale up.
+  # Mutually exclusive with plank. Only one of them may have more than zero replicas.
+  replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: prow-controller-manager
   template:
     metadata:
       labels:
-        app: plank
+        app: prow-controller-manager
     spec:
-      serviceAccountName: "plank"
+      serviceAccountName: prow-controller-manager
       containers:
-      - name: plank
-        image: gcr.io/k8s-prow/plank:v20190731-e3f7b9853
+      - name: prow-controller-manager
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220628-aa928caf31
         args:
-        - --dry-run=false
         - --config-path=/etc/config/config.yaml
+        - --dry-run=false
+        - --enable-controller=plank
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
-        - name: oauth
-          mountPath: /etc/github
-          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        livenessProbe: # Pod is killed if this fails 3 times.
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        readinessProbe: # Pod is not considered ready (for rolling deploy and request routing) if this fails 3 times.
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 3
       volumes:
-      - name: oauth
-        secret:
-          secretName: oauth-token
       - name: config
         configMap:
           name: config
+      - name: oauth
+        secret:
+          secretName: oauth-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: prow-controller-manager
+  namespace: default
+  name: prow-controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  selector:
+    app: prow-controller-manager
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -249,9 +207,13 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20190731-e3f7b9853
+        image: gcr.io/k8s-prow/sinker:v20220628-aa928caf31
+        ports:
+        - name: metrics
+          containerPort: 9090
         args:
         - --config-path=/etc/config/config.yaml
+        - --dry-run=false
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -260,6 +222,20 @@ spec:
       - name: config
         configMap:
           name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: sinker
+  namespace: default
+  name: sinker
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+  selector:
+    app: sinker
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -287,17 +263,41 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20190731-e3f7b9853
+        image: gcr.io/k8s-prow/deck:v20220628-aa928caf31
         args:
         - --config-path=/etc/config/config.yaml
-        - --tide-url=http://tide/
+        - --tide-url=http://tide:8888/
         - --hook-url=http://hook:8888/plugin-help
+        - --redirect-http-to=prow.tekton.dev
+        - --oauth-url=/github-login
+        - --spyglass=true
+        - --rerun-creates-job
+        - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-oauth-config-file=/etc/githuboauth/secret
+        - --cookie-secret=/etc/cookie/secret
+        - --plugin-config=/etc/plugins/plugins.yaml
         ports:
-          - name: http
-            containerPort: 8080
+        - name: http
+          containerPort: 8080
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: config
           mountPath: /etc/config
+          readOnly: true
+        - name: oauth-config
+          mountPath: /etc/githuboauth
+          readOnly: true
+        - name: oauth-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: cookie-secret
+          mountPath: /etc/cookie
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
           readOnly: true
         livenessProbe:
           httpGet:
@@ -316,6 +316,18 @@ spec:
       - name: config
         configMap:
           name: config
+      - name: oauth-config
+        secret:
+          secretName: github-oauth-config
+      - name: oauth-token
+        secret:
+          secretName: oauth-token
+      - name: cookie-secret
+        secret:
+          secretName: cookie
+      - name: plugins
+        configMap:
+          name: plugins
 ---
 apiVersion: v1
 kind: Service
@@ -323,13 +335,15 @@ metadata:
   name: deck
   namespace: default
 spec:
-  clusterIP: 10.55.250.236
   externalTrafficPolicy: Cluster
   ports:
-  - nodePort: 31957
+  - name: main
     port: 80
     protocol: TCP
     targetPort: 8080
+  - name: metrics
+    port: 9090
+    protocol: TCP
   selector:
     app: deck
   sessionAffinity: None
@@ -358,9 +372,13 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20190731-e3f7b9853
+        image: gcr.io/k8s-prow/horologium:v20220628-aa928caf31
         args:
         - --config-path=/etc/config/config.yaml
+        - --dry-run=false
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -369,6 +387,21 @@ spec:
       - name: config
         configMap:
           name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: horologium
+  namespace: default
+  name: horologium
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  selector:
+    app: horologium
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -392,13 +425,21 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20190731-e3f7b9853
+        image: gcr.io/k8s-prow/tide:v20220628-aa928caf31
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
+        - --config-path=/etc/config/config.yaml
+        # - --history-uri=gs://tekton-prow/tide-history.json
+        # - --status-path=gs://tekton-prow/tide-status-checkpoint.yaml
         ports:
           - name: http
             containerPort: 8888
+          - name: metrics
+            containerPort: 9090
         volumeMounts:
         - name: oauth
           mountPath: /etc/github
@@ -420,13 +461,14 @@ metadata:
   name: tide
   namespace: default
 spec:
-  clusterIP: 10.55.243.29
   externalTrafficPolicy: Cluster
   ports:
-  - nodePort: 31878
-    port: 80
+  - name: main
+    port: 8888
     protocol: TCP
-    targetPort: 8888
+  - name: metrics
+    port: 9090
+    protocol: TCP
   selector:
     app: tide
   sessionAffinity: None
@@ -526,7 +568,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "deck"
+  name: deck
 rules:
   - apiGroups:
       - "prow.k8s.io"
@@ -535,23 +577,17 @@ rules:
     verbs:
       - get
       - list
+      - watch
       # Required when deck runs with `--rerun-creates-job=true`
       # **Warning:** Only use this for non-public deck instances, this allows
       # anyone with access to your Deck instance to create new Prowjobs
       # - create
-  # Added this permission b/c we are making our pods in `default`
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
-  name: "deck"
+  name: deck
 rules:
   - apiGroups:
       - ""
@@ -579,6 +615,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -593,120 +630,174 @@ subjects:
 - kind: ServiceAccount
   name: "horologium"
 ---
-kind: ServiceAccount
 apiVersion: v1
+kind: ServiceAccount
 metadata:
   namespace: default
-  name: "plank"
+  name: "prow-controller-manager"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: default
-  name: "plank"
+  name: "prow-controller-manager"
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - prow-controller-manager-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - prow-controller-manager-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - prow.k8s.io
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+  - patch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: "prow-controller-manager"
+rules:
+- apiGroups:
+   - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+  - get
+  - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: "prow-controller-manager"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "prow-controller-manager"
+subjects:
+- kind: ServiceAccount
+  name: "prow-controller-manager"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: "prow-controller-manager"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "prow-controller-manager"
+subjects:
+- kind: ServiceAccount
+  name: "prow-controller-manager"
+  namespace: default
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  namespace: default
+  name: "sinker"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: "sinker"
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
+    - delete
+    - list
+    - watch
+    - get
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: "sinker"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
       - get
-      - create
-      - list
-      - update
-  # Added this permission b/c we are making our pods in `default`
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - delete
-      - list
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: test-pods
-  name: "plank"
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - delete
-      - list
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: default
-  name: "plank"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: "plank"
-subjects:
-- kind: ServiceAccount
-  name: "plank"
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: test-pods
-  name: "plank"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: "plank"
-subjects:
-- kind: ServiceAccount
-  name: "plank"
-  namespace: default
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  namespace: default
-  name: "sinker"
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: default
-  name: "sinker"
-rules:
-  - apiGroups:
-      - "prow.k8s.io"
-    resources:
-      - prowjobs
-    verbs:
-      - delete
-      - list
-  # Added this permission b/c we are making our pods in `default`
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - delete
-      - list
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: test-pods
-  name: "sinker"
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - delete
-      - list
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -795,6 +886,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -903,11 +995,17 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20190814-9981dc3c5
+        image: gcr.io/k8s-prow/crier:v20220628-aa928caf31
         args:
         - --github-workers=1
         - --config-path=/etc/config/config.yaml
+        - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
+        - --kubernetes-blob-storage-workers=1
+        ports:
+        - name: metrics
+          containerPort: 9090
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -922,6 +1020,21 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crier
+  namespace: default
+  name: crier
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  selector:
+    app: crier
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -990,7 +1103,7 @@ spec:
       serviceAccountName: prow-pipeline
       containers:
       - name: pipeline
-        image: gcr.io/k8s-prow/pipeline:v20190814-9981dc3c5
+        image: gcr.io/k8s-prow/pipeline:v20220628-aa928caf31
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml
@@ -1023,11 +1136,14 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20190731-e3f7b9853
+        image: gcr.io/k8s-prow/needs-rebase:v20220628-aa928caf31
         imagePullPolicy: Always
         args:
         - --dry-run=false
+        - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
+        - --update-period=6h
         ports:
           - name: http
             containerPort: 8888

--- a/prow/prowjob-schemaless_customresourcedefinition.yaml
+++ b/prow/prowjob-schemaless_customresourcedefinition.yaml
@@ -1,0 +1,95 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
+spec:
+  group: prow.k8s.io
+  names:
+    kind: ProwJob
+    singular: prowjob
+    plural: prowjobs
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
+                - "presubmit"
+                - "postsubmit"
+                - "periodic"
+                - "batch"
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              state:
+                type: string
+                enum:
+                - "triggered"
+                - "pending"
+                - "success"
+                - "failure"
+                - "aborted"
+                - "error"
+            anyOf:
+            - not:
+                properties:
+                  state:
+                    enum:
+                    - "success"
+                    - "failure"
+                    - "error"
+            - required:
+              - completionTime
+    additionalPrinterColumns:
+    - name: Job
+      type: string
+      description: The name of the job being run.
+      jsonPath: .spec.job
+    - name: BuildId
+      type: string
+      description: The ID of the job being run.
+      jsonPath: .status.build_id
+    - name: Type
+      type: string
+      description: The type of job being run.
+      jsonPath: .spec.type
+    - name: Org
+      type: string
+      description: The org for which the job is running.
+      jsonPath: .spec.refs.org
+    - name: Repo
+      type: string
+      description: The repo for which the job is running.
+      jsonPath: .spec.refs.repo
+    - name: Pulls
+      type: string
+      description: The pulls for which the job is running.
+      jsonPath: ".spec.refs.pulls[*].number"
+    - name: StartTime
+      type: date
+      description: When the job started running.
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      description: When the job finished running.
+      jsonPath: .status.completionTime
+    - name: State
+      description: The state of the job.
+      type: string
+      jsonPath: .status.state

--- a/tekton/ci/interceptors/github/examples/trigger.yaml
+++ b/tekton/ci/interceptors/github/examples/trigger.yaml
@@ -11,7 +11,7 @@ spec:
       interceptors:
         - ref:
             name: "github-simple"
-          params: # rename this to config?
+          params:  # rename this to config?
             - name: config
               value:
                 # Interceptor specific config

--- a/tekton/ci/jobs/e2e-kind.yaml
+++ b/tekton/ci/jobs/e2e-kind.yaml
@@ -171,7 +171,7 @@ spec:
         - name: input
           workspace: sources
     - name: e2e-tests
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
       - input: $(tasks.check-name-matches.results.check)
         operator: in
         values: ["passed"]

--- a/tekton/ci/jobs/tekton-docs-reviews.yaml
+++ b/tekton/ci/jobs/tekton-docs-reviews.yaml
@@ -57,7 +57,7 @@ spec:
         - name: input
           workspace: sources
     - name: request-pr-reviewer
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
       - input: $(tasks.check-git-files-changed.results.check)
         operator: in
         values: ["passed"]

--- a/tekton/ci/jobs/tekton-golang-lint.yaml
+++ b/tekton/ci/jobs/tekton-golang-lint.yaml
@@ -83,7 +83,7 @@ spec:
         - name: input
           workspace: sources
     - name: lint
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
         - input: $(tasks.check-name-matches.results.check)
           operator: in
           values: ["passed"]

--- a/tekton/ci/jobs/tekton-golang-tests.yaml
+++ b/tekton/ci/jobs/tekton-golang-tests.yaml
@@ -81,7 +81,7 @@ spec:
         - name: input
           workspace: sources
     - name: unit-tests
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
       - input: $(tasks.check-name-matches.results.check)
         operator: in
         values: ["passed"]

--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -132,7 +132,7 @@ spec:
         - name: input
           workspace: sources
     - name: images-build
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
       - input: $(tasks.check-name-matches.results.check)
         operator: in
         values: ["passed"]

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -91,7 +91,7 @@ spec:
         - name: checkName
           value: $(params.checkName)
     - name: kind-label
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
       - input: $(tasks.check-name-matches.results.check)
         operator: in
         values: ["passed"]

--- a/tekton/ci/jobs/tekton-python-unit-tests.yaml
+++ b/tekton/ci/jobs/tekton-python-unit-tests.yaml
@@ -67,7 +67,7 @@ spec:
         - name: input
           workspace: sources
     - name: unit-tests
-      when: # implicit dependency on the check tasks
+      when:  # implicit dependency on the check tasks
       - input: $(tasks.check-name-matches.results.check)
         operator: in
         values: ["passed"]

--- a/tekton/ci/jobs/tekton-yamllint.yaml
+++ b/tekton/ci/jobs/tekton-yamllint.yaml
@@ -46,7 +46,7 @@ spec:
       - name: checkName
         value: $(params.checkName)
   - name: check-git-files-changed
-    runAfter: [git-clone] # expects source to be populated by git-clone (TEP-0063)
+    runAfter: [git-clone]  # expects source to be populated by git-clone (TEP-0063)
     taskRef:
       name: check-git-files-changed
     params:

--- a/tekton/ci/plumbing/template.yaml
+++ b/tekton/ci/plumbing/template.yaml
@@ -66,7 +66,7 @@ spec:
         - name: gitCloneDepth
           value: $(tt.params.gitCloneDepth)
         - name: fileFilterRegex
-          value: "**" # always run for now
+          value: "**"  # always run for now
         - name: checkName
           value: plumbing-unit-tests
         - name: gitHubCommand


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update Prow to the latest versions used by k8s

Update various Prow and related microservices to the latest
versions used in k8s test-infra.
Reference manifests: https://github.com/kubernetes/test-infra/tree/master/config/prow

- plank has been replaced by prow controller manager
- deck includes spyglass which shall replace gubernator (not removed
  yet)
- updated all the container images
- add metric ports and services
- added ghproxy everywhere
- created a Tektoncd wide GitHub oauth app, which is used by deck.
  Documented associated process and created the secrets on the cluster.

The k8s test-infra runs boskos janitor, but only for aws and non-gke
resources, while we run it today for gke-resources only.
My impression is that it's merely a naming difference, since upstream
does not configure any gke-resource, only gce-resource. I'm leaving
the existing naming for now, but in future we may want to align to
test-infra upstream naming. I imaging the logic being:
- GCE resources: projects
- GKE resources (dynamic): clusters

The Spyglass configuration seems to be working ok, but over time we
may have to tune the highlight regexes for Tekton specific messages.

Tide has now the ability to flush some data to a GCS bucket, but I
could not figure out how to give tide access to the bucket, so I did
not configure it for now. We can do so as a follow-up.

Once this is merged, we may consider splitting the manifests similar to
what k8s test-infra does, to make it easier in future to compare and
update where necessary:
- one manifest for prow configs
- one manifest for prow jobs
- for each component, one manifest each for deployment, service, rbac

Fix a few yamllint warnings too.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._