### PR TITLE
Move pods for jobs to test-pods namespace

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+prowjob_namespace: default
+pod_namespace: test-pods
+
 plank:
   job_url_template: 'https://tekton-releases.appspot.com/build/tekton-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://tekton-releases.appspot.com/pr/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.tekton.dev/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'


### PR DESCRIPTION
# Changes

We should have everything else configured for this just fine, but we didn't have the `pod_namespace` field set in config.yaml. I also explicitly set `prowjob_namespace`, where the CRDs will go, just to be safe.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._