### PR TITLE
Add max pod age Sinker configuration

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -90,6 +90,8 @@ tide:
     tektoncd/triggers: rebase
     tektoncd/website: rebase
   target_url: https://prow.tekton.dev/tide
+sinker:
+  max_pod_age: 3h
 
 presets:
 - labels:


### PR DESCRIPTION
# Changes

This will delete `ProwJob`-created pods 3 hours after they've been started, rather than the default of 1 day. This should help a bit with the Prow cluster autoscaling down.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._