### PR TITLE
Deploy interceptors in triggers nightly

### DIFF
--- a/tekton/cronjobs/dogfooding/tekton/triggers-to-robotcat-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/triggers-to-robotcat-nightly/cronjob.yaml
@@ -22,3 +22,5 @@ spec:
                 value: "robocat"
               - name: RELEASE_BUCKET
                 value: "gs://tekton-releases-nightly"
+              - name: POST_RELEASE_FILE
+                value: "interceptors.yaml"


### PR DESCRIPTION
# Changes

The nightly deployment of triggers to the robocat clusters does
not include the interceptors, fixing that.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._