### PR TITLE
Use the build-id cluster interceptor

### DIFF
--- a/tekton/ci/plumbing/template.yaml
+++ b/tekton/ci/plumbing/template.yaml
@@ -5,7 +5,10 @@ metadata:
 spec:
   params:
   - name: buildUUID
-    description: UUID used to track a CI Pipeline Run in logs
+    description: >-
+      Tekton buildID, compatible with Prow's format (numeric)
+      Used to identify builds in a way that is compatible with Prow's
+      tooling like deck / spyglass
   - name: package
     description: org/repo
   - name: pullRequestNumber

--- a/tekton/ci/shared/bindings.yaml
+++ b/tekton/ci/shared/bindings.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   params:
   - name: buildUUID
-    value: $(header.X-GitHub-Delivery)
+    value: $(extensions.build-id.id)
   - name: package
     value: $(body.repository.full_name)
   - name: gitRepository
@@ -90,7 +90,7 @@ apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
   name: tekton-ci-webhook-pr-body
-  namespace: tektonci
+  namespace: tekton-ci
 spec:
   params:
     - name: body

--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -31,6 +31,9 @@ spec:
               value:
                 - key: git_clone_depth
                   expression: "string(body.pull_request.commits + 1.0)"
+        - name: "Add a build ID into the payload"
+          ref:
+            name: "build-id"
       triggerSelector:
         namespaceSelector:
           matchNames:
@@ -62,6 +65,9 @@ spec:
                 'pull_request' in body.issue &&
                 body.issue.state == 'open' &&
                 body.comment.body.matches('^/test($| [^ ]*[ ]*$)')
+        - name: "Add a build ID into the payload"
+          ref:
+            name: "build-id"
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/ci/shared/gubernator-metadata.yaml
+++ b/tekton/ci/shared/gubernator-metadata.yaml
@@ -48,6 +48,8 @@ spec:
       description: Name of the CI job
     - name: jobRunName
       description: The name (or number) of the job execution
+    - name: buildId
+      description: The prow-style buildId
     - name: pullRequestNumber
       description: The GitHub pull request number
     - name: gitRevision
@@ -69,8 +71,10 @@ spec:
         value: $(params.gitRevision)
       - name: BUCKET
         value: $(params.bucket)
-      - name: BUILD_NUMBER
+      - name: JOB_RUN_NAME
         value: $(params.jobRunName)
+      - name: BUILD_ID
+        value: $(params.buildId)
       - name: PR_NUMBER
         value: $(params.pullRequestNumber)
   steps:
@@ -84,22 +88,22 @@ spec:
         # Create the directory folder
         mkdir -p "${DIRECTORY_PATH}"
 
-        # Add path to the artifacts in the ${BUILD_NUMBER}.txt
-        echo "${BUCKET}/pr-logs/pull/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}/${BUILD_NUMBER}" > "${DIRECTORY_PATH}/${BUILD_NUMBER}.txt"
-        # Add the ${BUILD_NUMBER} into latest-build.txt
-        echo "${BUILD_NUMBER}" > "${DIRECTORY_PATH}/latest-build.txt"
+        # Add path to the artifacts in the ${BUILD_ID}.txt
+        echo "${BUCKET}/pr-logs/pull/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}/${BUILD_ID}" > "${DIRECTORY_PATH}/${BUILD_ID}.txt"
+        # Add the ${BUILD_ID} into latest-build.txt
+        echo "${BUILD_ID}" > "${DIRECTORY_PATH}/latest-build.txt"
 
         # Create the Pull Request / Build folder
         BUILD_PATH="${PULL_ROOT_PATH}/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}"
         mkdir -p "${BUILD_PATH}"
-        mkdir -p "${BUILD_PATH}/${BUILD_NUMBER}"
+        mkdir -p "${BUILD_PATH}/${BUILD_ID}"
 
         # Create the latest-build.txt
-        echo "${BUILD_NUMBER}" > "${BUILD_PATH}/latest-build.txt"
+        echo "${BUILD_ID}" > "${BUILD_PATH}/latest-build.txt"
 
         # Create the started.json file
         # Use the "time now" to simplify the logic
-        cat <<EOF | tee "${BUILD_PATH}/${BUILD_NUMBER}/started.json"
+        cat <<EOF | tee "${BUILD_PATH}/${BUILD_ID}/started.json"
         {
           "timestamp": $(date +%s),
           "pull": "${PR_NUMBER}",
@@ -142,6 +146,8 @@ spec:
       description: Name of the CI job
     - name: jobRunName
       description: The name (or number) of the job execution
+    - name: buildId
+      description: The prow-style buildId
     - name: pullRequestNumber
       description: The GitHub pull request number
     - name: jobStatus
@@ -158,8 +164,10 @@ spec:
         value: $(params.package)
       - name: GIT_REVISION
         value: $(params.gitRevision)
-      - name: BUILD_NUMBER
+      - name: JOB_RUN_NAME
         value: $(params.jobRunName)
+      - name: BUILD_ID
+        value: $(params.buildId)
       - name: JOB_STATUS
         value: $(params.jobStatus)
   steps:
@@ -171,13 +179,13 @@ spec:
         set -e
 
         # Create the Pull Request / Build folder (it should already exists)
-        BUILD_PATH="${PULL_ROOT_PATH}/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}/${BUILD_NUMBER}"
+        BUILD_PATH="${PULL_ROOT_PATH}/${PACKAGE/\//_}/${LATEST_BUILD_LEAF_PATH}/${BUILD_ID}"
         mkdir -p "${BUILD_PATH}" || true
 
         # Collect the build log - it will still be there unless the PipelineRun
         # has been cancelled or there is some very aggressive Pod pruning happening
         # This is specific to the Tekton dogfooding CI (hardcoded namespace)
-        tkn pr logs -n tekton-ci "${BUILD_NUMBER}" > "${BUILD_PATH}/build-log.txt"
+        tkn pr logs -n tekton-ci "${JOB_RUN_NAME}" > "${BUILD_PATH}/build-log.txt"
 
         # Create the finished.json file
         # Use the "time now" to simplify the logic
@@ -213,6 +221,8 @@ spec:
       description: Name of the CI job
     - name: jobRunName
       description: The name (or number) of the job execution
+    - name: buildId
+      description: The prow-style buildId
     - name: pullRequestNumber
       description: The GitHub pull request number
     - name: gitRevision
@@ -240,6 +250,8 @@ spec:
           value: $(params.gitRevision)
         - name: bucket
           value: $(params.bucket)
+        - name: buildId
+          value: $(params.buildId)
     - name: upload-data
       runAfter: ["create-data"]
       taskRef:
@@ -273,6 +285,8 @@ spec:
       description: Name of the CI job
     - name: jobRunName
       description: The name (or number) of the job execution
+    - name: buildId
+      description: The prow-style buildId
     - name: jobStatus
       description: "success if the CI job was successful else failure"
     - name: pullRequestNumber
@@ -302,6 +316,8 @@ spec:
           value: $(params.pullRequestNumber)
         - name: gitRevision
           value: $(params.gitRevision)
+        - name: buildId
+          value: $(params.buildId)
     - name: upload-data
       runAfter: ["create-data"]
       taskRef:

--- a/tekton/resources/ci/github-gubernator-template.yaml
+++ b/tekton/resources/ci/github-gubernator-template.yaml
@@ -52,6 +52,8 @@ spec:
           value: $(tt.params.checkName)
         - name: jobRunName
           value: $(tt.params.parentPipelineRunName)
+        - name: buildId
+          value: $(tt.params.buildUUID)
         - name: pullRequestNumber
           value: $(tt.params.pullRequestNumber)
         - name: gitRevision
@@ -124,6 +126,8 @@ spec:
           value: $(tt.params.checkName)
         - name: jobRunName
           value: $(tt.params.parentPipelineRunName)
+        - name: buildId
+          value: $(tt.params.buildUUID)
         - name: jobStatus
           value: $(tt.params.gitHubCheckStatus)
         - name: pullRequestNumber


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the build-id cluster interceptor to the root group interceptors
for tekton based CI.
Define a binding to pull the build id into a parameter.
Add this new parameter into the plumbing CI template (for now only
plumbing) and inject that into the existing prow build id
annotation. Change the gubernator jobs to use the value pulled from
the prow annotation as job number.

This should result in having the build id (prow style) in the path
to the logs in the GCS bucket, and ultimately in spyglass displaying
those logs.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._