### PR TITLE
Change the kind-e2e image to use test-runner as its parent

### DIFF
--- a/tekton/images/kind-e2e/Dockerfile
+++ b/tekton/images/kind-e2e/Dockerfile
@@ -14,21 +14,8 @@
 
 # Runtime image for common dependencies when running kind tests.
 
-FROM golang:1.17.11-alpine
+FROM gcr.io/tekton-releases/dogfooding/test-runner:latest
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
-
-WORKDIR /kind
-
-RUN GO111MODULE=on go get github.com/google/ko/cmd/ko@v0.6.2
-
-# common util tools
-RUN apk add --no-cache \
-  bash curl docker git jq openssl build-base
-
-# Install kubectl and make sure it's available in the PATH.
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /bin
-
-RUN curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.11.1/kind-$(uname)-amd64" && chmod +x ./kind && mv ./kind /bin
 
 COPY setup-kind.sh /usr/local/bin/kind-e2e
 

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -161,11 +161,12 @@ RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${K
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 
 # Extra tools through go get
+ARG KIND_VERSION=v0.11.1
 RUN GO111MODULE="on" go install github.com/google/go-licenses@latest && \
     GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \
     GO111MODULE="on" go get github.com/raviqqe/liche && \
     GO111MODULE="off" go get github.com/golang/dep/cmd/dep && \
-    GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
+    GO111MODULE="on" go get sigs.k8s.io/kind@${KIND_VERSION}
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
 ARG GOLANGCI_VERSION=1.42.0


### PR DESCRIPTION
# Changes

And update the kind version in test-runner.

This is prep for Prow kind e2e job support, making sure that we've got an image that's got the DinD support we have available in a Prow preset has `setup-kind.sh` copied to `/usr/local/bin/kind-e2e.sh`, without having to copy `setup-kind.sh` to multiple locations in git.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._