### PR TITLE
Use the deck/spyglass URL to view logs on CI jobs

### DIFF
--- a/tekton/resources/cd/ci-triggers.yaml
+++ b/tekton/resources/cd/ci-triggers.yaml
@@ -18,7 +18,7 @@ spec:
     - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
     - ref: tekton-ci-overlays
   template:
-    ref: tekton-ci-github-check-update
+    ref: tekton-ci-github-check-start
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
@@ -40,7 +40,7 @@ spec:
     - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
     - ref: tekton-ci-overlays
   template:
-    ref: tekton-ci-github-check-update
+    ref: tekton-ci-github-check-end
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
@@ -62,7 +62,7 @@ spec:
     - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
     - ref: tekton-ci-overlays
   template:
-    ref: tekton-ci-github-check-update
+    ref: tekton-ci-github-check-end
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -169,6 +169,8 @@ spec:
               value:
                 - key: repo
                   expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
+                - key: repoUnderscore
+                  expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1).split('/').join('_')
                 - key: shortBuildUUID
                   expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
       triggerSelector:

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -71,3 +71,16 @@ spec:
     value: $(extensions.repo)
   - name: shortBuildUUID
     value: $(extensions.shortBuildUUID)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: tekton-ci-github-repo-underscore
+spec:
+  params:
+  - name: gitHubRepo
+    value: $(extensions.repo)
+  - name: gitHubRepoUnderscore
+    value: $(extensions.repoUnderscore)
+  - name: shortBuildUUID
+    value: $(extensions.shortBuildUUID)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -2,7 +2,7 @@
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
 metadata:
-  name: tekton-ci-github-check-update
+  name: tekton-ci-github-check-start
 spec:
   params:
   - name: pullRequestNumber
@@ -57,6 +57,77 @@ spec:
           value: $(tt.params.gitRevision)
         - name: TARGET_URL
           value: https://dashboard.dogfooding.tekton.dev/#/namespaces/$(tt.params.taskRunNamespace)/pipelineruns/$(tt.params.parentPipelineRunName)?pipelineTask=$(tt.params.parentPipelineRunTaskName)
+        - name: DESCRIPTION
+          value: $(tt.params.gitHubCheckDescription)
+        - name: CONTEXT
+          value: $(tt.params.checkName)
+        - name: STATE
+          value: $(tt.params.gitHubCheckStatus)
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: tekton-ci-github-check-end
+spec:
+  params:
+  - name: pullRequestNumber
+    description: The pullRequestID to comment to
+  - name: buildUUID
+    description: The buildUUID for the logs link
+  - name: shortBuildUUID
+    description: A truncated version of the buildUUID
+  - name: gitHubRepo
+    description: The gitHubRepo (org/repo)
+  - name: gitHubRepoUnderscore
+    description: The gitHubRepoUnderscore (org_repo)
+  - name: gitRevision
+    description: The sha of the HEAD commit in the PR
+  - name: checkName
+    description: Name of the CI Job (GitHub Check)
+  - name: gitHubCheckStatus
+    description: Can be 'pending', 'success' or 'failure'
+  - name: gitHubCheckDescription
+    description: A description to be displayed for the status of the check
+  - name: taskRunName
+    description: The name of the task run that triggered this
+  - name: taskRunNamespace
+    description: The namespace where the CI job was executed
+  - name: parentPipelineRunName
+    description: The name of the parent pipeline run - if any
+    default: ""
+  - name: parentPipelineRunTaskName
+    description: The name of the task in the parent pipeline run - if any
+    default: ""
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
+      namespace: tekton-ci
+      labels:
+        prow.k8s.io/build-id: $(tt.params.buildUUID)
+        ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
+        ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+    spec:
+      serviceAccountName: tekton-ci-jobs
+      podTemplate:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+      taskRef:
+        name: github-set-status
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
+      params:
+        - name: REPO_FULL_NAME
+          value: $(tt.params.gitHubRepo)
+        - name: SHA
+          value: $(tt.params.gitRevision)
+        - name: TARGET_URL
+          value: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/$(tt.params.gitHubRepoUnderscore)/$(tt.params.pullRequestNumber)/$(tt.params.checkName)/$(tt.params.buildUUID)
         - name: DESCRIPTION
           value: $(tt.params.gitHubCheckDescription)
         - name: CONTEXT


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When Tekton CI job start, set the Tekton dashboard URL for the live
view of logs. When the CI job finishes, set the URL that points to
spyglass.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._