### PR TITLE
Kustomise patch does not work if no matching namespace

### DIFF
--- a/tekton/cd/triggers/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/triggers/overlays/dogfooding/feature-flags.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: feature-flags-triggers
+  namespace: tekton-pipelines
 data:
   enable-api-fields: "alpha"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The dogfooding overlay for triggers does not specify the namespace in
the config map for the feature flags, which causes the config map
patching to fail.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._