### PR TITLE
Update the buildid cluster interceptor to lower

### DIFF
--- a/tekton/ci/cluster-interceptors/build-id/cmd/interceptor/main.go
+++ b/tekton/ci/cluster-interceptors/build-id/cmd/interceptor/main.go
@@ -50,7 +50,7 @@ func main() {
 	s := server.Server{
 		Logger: logger,
 	}
-	s.RegisterInterceptor("buildId", pkg.Interceptor{})
+	s.RegisterInterceptor("buildid", pkg.Interceptor{})
 	mux := http.NewServeMux()
 	mux.Handle("/", &s)
 	mux.HandleFunc("/ready", handler)

--- a/tekton/ci/cluster-interceptors/build-id/config/200-interceptor.yaml
+++ b/tekton/ci/cluster-interceptors/build-id/config/200-interceptor.yaml
@@ -21,4 +21,4 @@ spec:
     service:
       name: build-id-interceptor
       namespace: tekton-ci
-      path: "build-id"
+      path: "buildid"


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The cluster interceptor framework does not seem to work well with
upper/lower case. Also the current config does not match between
the register call and path set in the CRD.
Use "buildid" everywhere to avoid issues.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._