### PR TITLE
Update kind version in test-runner image

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -161,11 +161,12 @@ RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${K
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 
 # Extra tools through go get
+ARG KIND_VERSION="v0.14.0"
 RUN GO111MODULE="on" go install github.com/google/go-licenses@latest && \
     GO111MODULE="on" go get github.com/jstemmer/go-junit-report && \
     GO111MODULE="on" go get github.com/raviqqe/liche && \
     GO111MODULE="off" go get github.com/golang/dep/cmd/dep && \
-    GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
+    GO111MODULE="on" go get sigs.k8s.io/kind@${KIND_VERSION}
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
 ARG GOLANGCI_VERSION=1.42.0


### PR DESCRIPTION
# Changes

I'm leaving the `kind` and `kind-e2e` images on v0.11.1 for now, but if I'm going to bump the `test-runner` one, might as well go to latest (v0.14.0).

Note, for what it's worth: here's how I was able to verify that this all actually worked locally (on my Linux box), after building `test-runner`, from `/home/abayer/go/src/github.com/tektoncd/pipeline` with my branch from https://github.com/tektoncd/pipeline/pull/5077 checked out:

```
docker run -v /var/run/docker.sock:/var/run/docker.sock -v /lib/modules:/lib/modules -v /sys/fs/cgroup:/sys/fs/cgroup -v $PWD:/home/prow/go/src/github.com/tektoncd/pipeline --workdir /home/prow/go/src/github.com/tektoncd/pipeline --net=host test-runner -- -- /usr/local/bin/kind-e2e --k8s-version v1.22.x --cluster-suffix whatever --nodes 3 --e2e-script test/e2e-tests.sh --e2e-env test/e2e-tests-kind-prow-full.env
```

/kind misc

/assign @vdemeester @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._