### PR TITLE
Revert Pipeline unit test and go-coverage Prow jobs to 2000m/4gb requests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1104,11 +1104,11 @@ presubmits:
         - "--unit-tests"
         resources:
           requests:
-            cpu: 1000m
-            memory: 2Gi
-          limits:
             cpu: 2000m
             memory: 4Gi
+          limits:
+            cpu: 4000m
+            memory: 8Gi
   - name: pull-tekton-pipeline-integration-tests
     labels:
       preset-presubmit-sh: "true"
@@ -1206,11 +1206,11 @@ presubmits:
         - "--github-token=/etc/github-token/oauth"
         resources:
           requests:
-            cpu: 1000m
-            memory: 2Gi
-          limits:
             cpu: 2000m
             memory: 4Gi
+          limits:
+            cpu: 4000m
+            memory: 8Gi
   - name: pull-tekton-pipeline-kind-integration-tests
     labels:
       preset-presubmit-sh: "true"


### PR DESCRIPTION
# Changes

I saw some flakiness with the unit test job in particular since I made this change, seemingly caused by timeouts. To be safe, let's go back to 2000m/4Gi requests, 4000m/8Gi limits.

/kind misc

/assign @afrittoli @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._