### PR TITLE
Update a couple Prow SA roles to match k8s/test-infra's setup

### DIFF
--- a/prow/prow.yaml
+++ b/prow/prow.yaml
@@ -845,6 +845,8 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - update
   - apiGroups:
       - ""
     resources:
@@ -885,6 +887,7 @@ rules:
       - prowjobs
     verbs:
       - create
+      - get
       - list
       - watch
 ---


### PR DESCRIPTION
# Changes

I noticed this in hook's logs:

```
{"author":"piyush-garg","component":"hook","error":"failed to list prowjobs for pr: prowjobs.prow.k8s.io is forbidden: User \"system:serviceaccount:default:hook\" cannot list resource \"prowjobs\" in API group \"prow.k8s.io\" in the namespace \"default\"","event-GUID":"761697e0-fd3c-11ec-8759-59acd949f680","event-type":"pull_request","file":"k8s.io/test-infra/prow/plugins/trigger/pull-request.go:150","func":"k8s.io/test-infra/prow/plugins/trigger.handlePR","level":"error","msg":"Failed to abort jobs for closed pull request","org":"tektoncd","plugin":"trigger","pr":891,"repo":"operator","severity":"error","time":"2022-07-06T15:01:07Z","url":"https://github.com/tektoncd/operator/pull/891"}
```

...and after checking, saw that the hook role didn't have `list` or `update` permissions for Prow jobs but did in https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/hook_rbac.yaml. I checked all the other `*_rbac.yaml`s there, and found one other difference, the tide role missing `get` for Prow jobs.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._