### PR TITLE
Add daemonset to Prow cluster to tune sysctl for kind, go back to 3 worker nodes

### DIFF
--- a/docs/prow.md
+++ b/docs/prow.md
@@ -86,6 +86,10 @@ kubectl apply -f prow/ghproxy.yaml
 kubectl apply -f prow/prowjob-schemaless_customresourcedefinition.yaml
 kubectl apply -f prow/prow.yaml
 
+# Deploy daemonset to configure fs.inotify.max_user_[watches,instances] via sysctl.
+# This is to deal with kind having issues like https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
+kubectl apply -f prow/tune-sysctls_daemonset.yaml
+
 # Create Prow's configuration
 kubectl create configmap config --from-file=config.yaml=prow/config.yaml
 kubectl create configmap plugins --from-file=plugins.yaml=prow/plugins.yaml

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1266,7 +1266,7 @@ presubmits:
             - "--cluster-suffix"
             - "$(PULL_NUMBER)"
             - "--nodes"
-            - "2"
+            - "3"
             - "--e2e-script"
             - "./test/e2e-tests.sh"
             - --e2e-env
@@ -1307,7 +1307,7 @@ presubmits:
             - "--cluster-suffix"
             - "$(PULL_NUMBER)"
             - "--nodes"
-            - "2"
+            - "3"
             - "--e2e-script"
             - "./test/e2e-tests.sh"
             - --e2e-env
@@ -1348,7 +1348,7 @@ presubmits:
             - "--cluster-suffix"
             - "$(PULL_NUMBER)"
             - "--nodes"
-            - "2"
+            - "3"
             - "--e2e-script"
             - "./test/e2e-tests.sh"
             - --e2e-env
@@ -1389,7 +1389,7 @@ presubmits:
             - "--cluster-suffix"
             - "$(PULL_NUMBER)"
             - "--nodes"
-            - "2"
+            - "3"
             - "--e2e-script"
             - "./test/e2e-tests.sh"
             - --e2e-env

--- a/prow/tune-sysctls_daemonset.yaml
+++ b/prow/tune-sysctls_daemonset.yaml
@@ -1,0 +1,47 @@
+# a simple daemonset to tune sysctls
+# intended to be used in a prow build cluster
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tune-sysctls
+  namespace: kube-system
+  labels:
+    app: tune-sysctls
+spec:
+  selector:
+    matchLabels:
+      name: tune-sysctls
+  template:
+    metadata:
+      labels:
+        name: tune-sysctls
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      tolerations:
+        - operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: setsysctls
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                sysctl -w fs.inotify.max_user_watches=524288
+                sysctl -w fs.inotify.max_user_instances=512
+                sleep 10
+              done
+          image: alpine:3.6
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: sys
+              mountPath: /sys
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys


### PR DESCRIPTION
# Changes

https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files seems to be the root of cluster launch issues I've been seeing on the kind clusters. I found https://github.com/kubernetes/test-infra/pull/13515 as a solution to this - I took the current version of the daemonset added in that PR, added a sysctl call to set `fs.inotify.max_user_instances=512` as well, and documented it in docs/prow.md. I've applied this by hand to the Prow cluster already, and it appears to have done the trick.

This also reverts us back to 3 worker nodes per kind cluster, since decreasing the cluster size didn't solve the problem, and I saw some real drop in the kind jobs' speed with 2 nodes.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._