### PR TITLE
Move gitHubRepoUnderscope to the right binding

### DIFF
--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -71,16 +71,5 @@ spec:
     value: $(extensions.repo)
   - name: shortBuildUUID
     value: $(extensions.shortBuildUUID)
----
-apiVersion: triggers.tekton.dev/v1alpha1
-kind: TriggerBinding
-metadata:
-  name: tekton-ci-github-repo-underscore
-spec:
-  params:
-  - name: gitHubRepo
-    value: $(extensions.repo)
   - name: gitHubRepoUnderscore
     value: $(extensions.repoUnderscore)
-  - name: shortBuildUUID
-    value: $(extensions.shortBuildUUID)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

gitHubRepoUnderscope is sitting in a binding that is not used
anywhere, causing log links to be broken. Move it to the
overlay binding so that it's picked up by the correct trigger
and template.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._