### PR TITLE
Remove `/test all` from currently optional Pipeline kind-in-Prow jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1305,7 +1305,7 @@ presubmits:
     decorate: true
     optional: true
     rerun_command: "/test pull-tekton-pipeline-kind-integration-tests"
-    trigger: "(?m)^/test (all|pull-tekton-pipeline-kind-integration-tests|optional-kind),?(\\s+|$)"
+    trigger: "(?m)^/test (pull-tekton-pipeline-kind-integration-tests|optional-kind),?(\\s+|$)"
     spec:
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
@@ -1346,7 +1346,7 @@ presubmits:
     decorate: true
     optional: true
     rerun_command: "/test pull-tekton-pipeline-kind-alpha-integration-tests"
-    trigger: "(?m)^/test (all|pull-tekton-pipeline-kind-alpha-integration-tests|optional-kind),?(\\s+|$)"
+    trigger: "(?m)^/test (pull-tekton-pipeline-kind-alpha-integration-tests|optional-kind),?(\\s+|$)"
     spec:
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
@@ -1387,7 +1387,7 @@ presubmits:
     decorate: true
     optional: true
     rerun_command: "/test pull-tekton-pipeline-kind-yaml-tests"
-    trigger: "(?m)^/test (all|pull-tekton-pipeline-kind-yaml-tests|optional-kind),?(\\s+|$)"
+    trigger: "(?m)^/test (pull-tekton-pipeline-kind-yaml-tests|optional-kind),?(\\s+|$)"
     spec:
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
@@ -1428,7 +1428,7 @@ presubmits:
     decorate: true
     optional: true
     rerun_command: "/test pull-tekton-pipeline-kind-alpha-yaml-tests"
-    trigger: "(?m)^/test (all|pull-tekton-pipeline-kind-alpha-yaml-tests|optional-kind),?(\\s+|$)"
+    trigger: "(?m)^/test (pull-tekton-pipeline-kind-alpha-yaml-tests|optional-kind),?(\\s+|$)"
     spec:
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.


### PR DESCRIPTION
# Changes

Until https://github.com/tektoncd/pipeline/pull/5077 merges, these jobs will fail on any other PR, so we should make sure they can't accidentally get invoked via `/test all`.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._