### PR TITLE
Increase CPU request for most Pipeline jobs to 4000m

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1155,7 +1155,7 @@ presubmits:
         - "--build-tests"
         resources:
           requests:
-            cpu: 2000m
+            cpu: 4000m
             memory: 4Gi
           limits:
             cpu: 4000m
@@ -1221,7 +1221,7 @@ presubmits:
         - "--integration-tests"
         resources:
           requests:
-            cpu: 2000m
+            cpu: 4000m
             memory: 4Gi
           limits:
             cpu: 4000m
@@ -1254,7 +1254,7 @@ presubmits:
         - "--integration-tests"
         resources:
           requests:
-            cpu: 2000m
+            cpu: 4000m
             memory: 4Gi
           limits:
             cpu: 4000m
@@ -1331,7 +1331,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2000m
+              cpu: 4000m
               memory: 4Gi
             limits:
               cpu: 4000m
@@ -1372,7 +1372,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2000m
+              cpu: 4000m
               memory: 4Gi
             limits:
               cpu: 4000m
@@ -1413,7 +1413,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2000m
+              cpu: 4000m
               memory: 4Gi
             limits:
               cpu: 4000m
@@ -1454,7 +1454,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 2000m
+              cpu: 4000m
               memory: 4Gi
             limits:
               cpu: 4000m


### PR DESCRIPTION
# Changes

The build and integration tests will all end up using as much CPU as we give them - `ko resolve` being the culprit. So if we're setting a limit of 4000m for those jobs, we should just set the request to 4000m as well.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._