### PR TITLE
Experiment with requiring that Pipeline kind jobs can't be on the same node

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1300,6 +1300,7 @@ presubmits:
       preset-presubmit-sh: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+      pipeline-kind-experiment: "true"
     agent: kubernetes
     always_run: false
     decorate: true
@@ -1307,6 +1308,14 @@ presubmits:
     rerun_command: "/test pull-tekton-pipeline-kind-integration-tests"
     trigger: "(?m)^/test (pull-tekton-pipeline-kind-integration-tests|optional-kind),?(\\s+|$)"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: pipeline-kind-experiment
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1341,6 +1350,7 @@ presubmits:
       preset-presubmit-sh: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+      pipeline-kind-experiment: "true"
     agent: kubernetes
     always_run: false
     decorate: true
@@ -1348,6 +1358,14 @@ presubmits:
     rerun_command: "/test pull-tekton-pipeline-kind-alpha-integration-tests"
     trigger: "(?m)^/test (pull-tekton-pipeline-kind-alpha-integration-tests|optional-kind),?(\\s+|$)"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: pipeline-kind-experiment
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1382,6 +1400,7 @@ presubmits:
       preset-presubmit-sh: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+      pipeline-kind-experiment: "true"
     agent: kubernetes
     always_run: false
     decorate: true
@@ -1389,6 +1408,14 @@ presubmits:
     rerun_command: "/test pull-tekton-pipeline-kind-yaml-tests"
     trigger: "(?m)^/test (pull-tekton-pipeline-kind-yaml-tests|optional-kind),?(\\s+|$)"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: pipeline-kind-experiment
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1423,6 +1450,7 @@ presubmits:
       preset-presubmit-sh: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
+      pipeline-kind-experiment: "true"
     agent: kubernetes
     always_run: false
     decorate: true
@@ -1430,6 +1458,14 @@ presubmits:
     rerun_command: "/test pull-tekton-pipeline-kind-alpha-yaml-tests"
     trigger: "(?m)^/test (pull-tekton-pipeline-kind-alpha-yaml-tests|optional-kind),?(\\s+|$)"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: pipeline-kind-experiment
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always


### PR DESCRIPTION
# Changes

I'm trying to figure out why multiple concurrent jobs will sometimes fail a lot of tests at once. This doesn't seem to be CPU or memory contention specifically, since I've seen jobs be just fine when they're sharing the node with other non-kind beefy jobs, so let's try an experiment: make sure each Pipeline kind job is on its own node, to see if the underlying issue is in fact having multiple kind jobs on the same node.

If that hunch does turn out to be true, I'm not entirely sure what the solution will be. But it'll be good to know one way or the other.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._