### PR TITLE
Try limiting the kind jobs to n2-standard-8-kind nodepool

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1316,6 +1316,13 @@ presubmits:
                   - key: pipeline-kind-experiment
                     operator: Exists
               topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1340,10 +1347,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 4000m
+              cpu: 7000m
               memory: 4Gi
             limits:
-              cpu: 4000m
+              cpu: 7000m
               memory: 8Gi
   - name: pull-tekton-pipeline-kind-alpha-integration-tests
     labels:
@@ -1366,6 +1373,13 @@ presubmits:
                   - key: pipeline-kind-experiment
                     operator: Exists
               topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1390,10 +1404,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 4000m
+              cpu: 7000m
               memory: 4Gi
             limits:
-              cpu: 4000m
+              cpu: 7000m
               memory: 8Gi
   - name: pull-tekton-pipeline-kind-yaml-tests
     labels:
@@ -1416,6 +1430,13 @@ presubmits:
                   - key: pipeline-kind-experiment
                     operator: Exists
               topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1440,10 +1461,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 4000m
+              cpu: 7000m
               memory: 4Gi
             limits:
-              cpu: 4000m
+              cpu: 7000m
               memory: 8Gi
   - name: pull-tekton-pipeline-kind-alpha-yaml-tests
     labels:
@@ -1466,6 +1487,13 @@ presubmits:
                   - key: pipeline-kind-experiment
                     operator: Exists
               topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
         - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Probably should change this to a specific tag once the job is stable.
           imagePullPolicy: Always
@@ -1490,10 +1518,10 @@ presubmits:
             privileged: true
           resources:
             requests:
-              cpu: 4000m
+              cpu: 7000m
               memory: 4Gi
             limits:
-              cpu: 4000m
+              cpu: 7000m
               memory: 8Gi
   tektoncd/catalog:
   - name: pull-tekton-catalog-build-tests


### PR DESCRIPTION
# Changes

These nodes are n2-standard-8s with local SSD ephemeral storage - by requesting 7 cpus, we guarantee that there can only be one job per node, and we're using SSD ephemeral storage to try to improve kind's performance.

This is still a work-in-progress, obviously - if this is the direction we end up going for real, we won't need the `podAntiAffinity`, for example.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._