### PR TITLE
Replace shortBuildUUID with shortSourceEventId

### DIFF
--- a/tekton/ci/catalog/template.yaml
+++ b/tekton/ci/catalog/template.yaml
@@ -6,6 +6,8 @@ spec:
   params:
     - name: buildUUID
       description: UUID used to track a CI Pipeline Run in logs
+    - name: sourceEventId
+      description: The event ID from the SCM (e.g. X-GitHub-Delivery)
     - name: pullRequestNumber
       description: The pullRequestNumber
     - name: pullRequestUrl
@@ -35,6 +37,7 @@ spec:
         generateName: pull-catalog-catlin-run-
         labels:
           prow.k8s.io/build-id: $(tt.params.buildUUID)
+          tekton.dev/source-event-id: $(tt.params.sourceEventId)
           tekton.dev/kind: ci
           tekton.dev/check-name: pull-catalog-catlin-lint
           tekton.dev/pr-number: $(tt.params.pullRequestNumber)
@@ -75,6 +78,7 @@ spec:
         generateName: pull-catalog-diff-task-run-
         labels:
           prow.k8s.io/build-id: $(tt.params.buildUUID)
+          tekton.dev/source-event-id: $(tt.params.sourceEventId)
           tekton.dev/kind: ci
           tekton.dev/pr-number: $(tt.params.pullRequestNumber)
         annotations:

--- a/tekton/ci/community/template.yaml
+++ b/tekton/ci/community/template.yaml
@@ -6,6 +6,8 @@ spec:
   params:
   - name: buildUUID
     description: UUID used to track a CI Pipeline Run in logs
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -37,6 +39,7 @@ spec:
       generateName: pull-community-teps-lint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/kind: ci
         tekton.dev/check-name: pull-community-teps-lint
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
@@ -79,6 +82,7 @@ spec:
       generateName: pull-community-org-validation-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/kind: ci
         tekton.dev/check-name: pull-community-org-validation
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)

--- a/tekton/ci/pipeline/template.yaml
+++ b/tekton/ci/pipeline/template.yaml
@@ -6,6 +6,8 @@ spec:
   params:
   - name: buildUUID
     description: UUID used to track a CI Pipeline Run in logs
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -37,6 +39,7 @@ spec:
       generateName: pull-pipeline-kind-k8s-v1-21-e2e-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/kind: ci
         tekton.dev/check-name: pull-pipeline-kind-k8s-v1-21-e2e
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)

--- a/tekton/ci/plumbing/template.yaml
+++ b/tekton/ci/plumbing/template.yaml
@@ -9,6 +9,8 @@ spec:
       Tekton buildID, compatible with Prow's format (numeric)
       Used to identify builds in a way that is compatible with Prow's
       tooling like deck / spyglass
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -40,6 +42,7 @@ spec:
       generateName: plumbing-unit-tests-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/check-name: plumbing-unit-tests
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
         tekton.dev/kind: ci
@@ -90,6 +93,7 @@ spec:
       generateName: plumbing-image-build-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/check-name: plumbing-image-build
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
         tekton.dev/kind: ci
@@ -134,6 +138,7 @@ spec:
       generateName: tekton-golang-lint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/check-name: plumbing-golang-lint
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
@@ -180,6 +185,7 @@ spec:
       generateName: tekton-yamllint-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/check-name: plumbing-yamllint
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)

--- a/tekton/ci/shared/bindings.yaml
+++ b/tekton/ci/shared/bindings.yaml
@@ -7,6 +7,8 @@ spec:
   params:
   - name: buildUUID
     value: $(extensions.build-id.id)
+  - name: sourceEventId
+    value: $(header.X-GitHub-Delivery)
   - name: package
     value: $(body.repository.full_name)
   - name: gitRepository

--- a/tekton/ci/shared/template.yaml
+++ b/tekton/ci/shared/template.yaml
@@ -6,6 +6,8 @@ spec:
   params:
   - name: buildUUID
     description: UUID used to track a CI Pipeline Run in logs
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -37,6 +39,7 @@ spec:
       generateName: request-pr-docs-reviewer-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
         tekton.dev/gitRevision: "$(tt.params.gitRevision)"
@@ -83,6 +86,8 @@ spec:
   params:
   - name: buildUUID
     description: UUID used to track a CI Pipeline Run in logs
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -110,6 +115,7 @@ spec:
       generateName: check-pr-labels-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/check-name: check-pr-has-kind-label
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
@@ -137,6 +143,8 @@ spec:
   params:
   - name: buildUUID
     description: UUID used to track a CI Pipeline Run in logs
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -164,6 +172,7 @@ spec:
       generateName: check-github-tasks-completed-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/check-name: check-github-tasks-completed
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)

--- a/tekton/ci/website/template.yaml
+++ b/tekton/ci/website/template.yaml
@@ -6,6 +6,8 @@ spec:
   params:
   - name: buildUUID
     description: UUID used to track a CI Pipeline Run in logs
+  - name: sourceEventId
+    description: The event ID from the SCM (e.g. X-GitHub-Delivery)
   - name: package
     description: org/repo
   - name: pullRequestNumber
@@ -37,6 +39,7 @@ spec:
       generateName: pull-website-python-unit-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
+        tekton.dev/source-event-id: $(tt.params.sourceEventId)
         tekton.dev/kind: ci
         tekton.dev/check-name: pull-community-python-unit
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -171,8 +171,8 @@ spec:
                   expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1)
                 - key: repoUnderscore
                   expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1).split('/').join('_')
-                - key: shortBuildUUID
-                  expression: body.taskRun.metadata.labels['prow.k8s.io/build-id'].truncate(13)
+                - key: shortSourceEventID
+                  expression: body.taskRun.metadata.labels['tekton.dev/source-event-id'].truncate(13)
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -69,7 +69,7 @@ spec:
   params:
   - name: gitHubRepo
     value: $(extensions.repo)
-  - name: shortBuildUUID
-    value: $(extensions.shortBuildUUID)
+  - name: shortSourceEventID
+    value: $(extensions.shortSourceEventID)
   - name: gitHubRepoUnderscore
     value: $(extensions.repoUnderscore)

--- a/tekton/resources/ci/github-gubernator-template.yaml
+++ b/tekton/resources/ci/github-gubernator-template.yaml
@@ -9,8 +9,8 @@ spec:
     description: The pullRequestID to comment to
   - name: buildUUID
     description: The buildUUID for the logs link
-  - name: shortBuildUUID
-    description: A truncated version of the buildUUID
+  - name: shortSourceEventID
+    description: A truncated version of the sourceEventId
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
   - name: gitRevision
@@ -35,7 +35,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-logs-start
+      name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-logs-start
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
@@ -83,8 +83,8 @@ spec:
     description: The pullRequestID to comment to
   - name: buildUUID
     description: The buildUUID for the logs link
-  - name: shortBuildUUID
-    description: A truncated version of the buildUUID
+  - name: shortSourceEventID
+    description: A truncated version of the sourceEventId
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
   - name: gitRevision
@@ -109,7 +109,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-logs-stop
+      name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-logs-stop
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -9,8 +9,8 @@ spec:
     description: The pullRequestID to comment to
   - name: buildUUID
     description: The buildUUID for the logs link
-  - name: shortBuildUUID
-    description: A truncated version of the buildUUID
+  - name: shortSourceEventID
+    description: A truncated version of the sourceEventId
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
   - name: gitRevision
@@ -35,7 +35,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
+      name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
@@ -78,8 +78,8 @@ spec:
     description: The pullRequestID to comment to
   - name: buildUUID
     description: The buildUUID for the logs link
-  - name: shortBuildUUID
-    description: A truncated version of the buildUUID
+  - name: shortSourceEventID
+    description: A truncated version of the sourceEventId
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
   - name: gitHubRepoUnderscore
@@ -106,7 +106,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      name: $(tt.params.shortBuildUUID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
+      name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The CI notification and log upload jobs used a shortened version of the
build ID to make their name unique per source event (from GitHub).
The build ID has been replace with a prow style build ID for the
spyglass integration, which has broken the name uniqueness since the
short version of the prow build ID is repeated.

Add the sourceEventId (X-GitHub-Delivery) to the bindings and templates
and use that as a source for the shortSourceEventId and ultimately to
make taskrun names unique.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
