### PR TITLE
Fallback on presubmit-tests.sh when kind --e2e-env value does not exist

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1338,6 +1338,11 @@ presubmits:
             limits:
               cpu: 3500m
               memory: 8Gi
+          env:
+            - name: PIPELINE_FEATURE_GATE
+              value: "alpha"
+            - name: EMBEDDED_STATUS_GATE
+              value: "minimal"
   tektoncd/catalog:
   - name: pull-tekton-catalog-build-tests
     labels:

--- a/tekton/images/test-runner/setup-kind.sh
+++ b/tekton/images/test-runner/setup-kind.sh
@@ -76,6 +76,12 @@ while [[ $# -ne 0 ]]; do
   shift
 done
 
+# If E2E_ENV is set but the file doesn't exist, fall back on the old approach of invoking presubmit-tests.sh directly.
+if [[ "${E2E_ENV}" != "" && ! -f "${E2E_ENV}" ]]; then
+  ./test/presubmit-tests.sh --integration-tests
+  exit $?
+fi
+
 # The version map correlated with this version of KinD
 KIND_VERSION="v0.11.1"
 case ${K8S_VERSION} in


### PR DESCRIPTION
# Changes

This is to support backports to earlier releases of Pipeline.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._