### PR TITLE
Use gke-gcloud-auth-plugin in test-runner

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -61,6 +61,10 @@ RUN apt update && apt install -y --no-install-recommends \
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
+# To deal with "error: The gcp auth plugin has been removed" in Google Cloud SDK 393.0.0, use the gke-gcloud-auth-plugin.
+# See https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
+
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
     tar xzf google-cloud-sdk.tar.gz -C / && \
     rm google-cloud-sdk.tar.gz && \
@@ -70,7 +74,7 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
         --path-update=false \
         --usage-reporting=false && \
     gcloud components update && \
-    gcloud components install alpha beta kubectl docker-credential-gcr && \
+    gcloud components install alpha beta kubectl docker-credential-gcr gke-gcloud-auth-plugin && \
     gcloud info | tee /gcloud-info.txt
 RUN docker-credential-gcr configure-docker
 


### PR DESCRIPTION
# Changes

Apparently, as of Google Cloud SDK 393.0.0, the gcp auth plugin was removed earlier than https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke would have indicated. Sigh. So let's work around this by installing gke-gcloud-auth-plugin and making sure that `USE_GKE_GCLOUD_AUTH_PLUGIN` is set in the environment for the test-runner image.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._