### PR TITLE
Move PR label events to a dedicated trigger

### DIFF
--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -26,7 +26,7 @@ spec:
             - name: "filter"
               value: >-
                 body.repository.full_name.startsWith('tektoncd/') &&
-                body.action in ['opened', 'synchronize', 'labeled', 'unlabeled', 'reopened']
+                body.action in ['opened', 'synchronize', 'reopened']
             - name: "overlays"
               value:
                 - key: git_clone_depth
@@ -75,3 +75,38 @@ spec:
         labelSelector:
           matchLabels:
             ci.tekton.dev/trigger-type: github.issue-comment
+    - name: github-tektoncd-labels-group
+      interceptors:
+        - name: "Validate GitHub payload and filter on eventType"
+          ref:
+            name: "github"
+          params:
+            - name: "secretRef"
+              value:
+                secretName: ci-webhook
+                secretKey: secret
+            - name: "eventTypes"
+              value:
+                - "pull_request"
+        - name: "Filter the GitHub org and actions and add git_clone_depth"
+          ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                body.repository.full_name.startsWith('tektoncd/') &&
+                body.action in ['labeled', 'unlabeled']
+            - name: "overlays"
+              value:
+                - key: git_clone_depth
+                  expression: "string(body.pull_request.commits + 1.0)"
+        - name: "Add a build ID into the payload"
+          ref:
+            name: "build-id"
+      triggerSelector:
+        namespaceSelector:
+          matchNames:
+            - tekton-ci
+        labelSelector:
+          matchLabels:
+            ci.tekton.dev/trigger-type: github.labels

--- a/tekton/ci/shared/labels-trigger.yaml
+++ b/tekton/ci/shared/labels-trigger.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: all-issue-comment
+  labels:
+    ci.tekton.dev/trigger-type: github.labels
+spec:
+  interceptors:
+    - name: "Filter by repo"
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub']
+  bindings:
+    - ref: tekton-ci-github-base
+    - ref: tekton-ci-webhook-pull-request
+    - ref: tekton-ci-webhook-pr-labels
+    - ref: tekton-ci-clone-depth
+  template:
+    ref: all-ci-pipeline


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Today we run all CI pipelines everytime a label is changed,
because that triggers a pull request type of event.

With this change, we filter out label changes from the main PR
trigger group, create a new trigger group that matches only
label events and looks for triggers with a github.labels label.

The new trigger runs the all-tekton-ci tempate which includes
the label check as well as the github PR check list check.

Strictly speaking we only need the label check, so I'll move
the other check to a separate template in a follow-up PR

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._