### PR TITLE
Use fixed name for notifications

### DIFF
--- a/tekton/resources/cd/bindings.yaml
+++ b/tekton/resources/cd/bindings.yaml
@@ -153,6 +153,8 @@ spec:
     value: $(body.taskRun.metadata.namespace)
   - name: runKind
     value: taskrun
+  - name: nameAndNamespace
+    value: $(extensions.nameAndNamespace)
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -143,6 +143,12 @@ spec:
             - name: "filter"
               value: >-
                 header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')
+            - name: "overlay"
+              value:
+              - key: nameAndNamespace
+                expression: >-
+                  (body.taskRun.metadata.name + "-" +
+                   body.taskRun.metadata.namespace).truncate(57)
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/resources/cd/notification-template.yaml
+++ b/tekton/resources/cd/notification-template.yaml
@@ -27,11 +27,13 @@ spec:
     description: The base URL of the Tekton dashboard
   - name: cdPipelineType
     description: The type of CD pipeline
+  - name: nameAndNamespace
+    description: runName + runNamespace truncated to 57 chars
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: TaskRun
     metadata:
-      generateName: send-to-webhook-slack-
+      name: $(tt.params.nameAndNamespace)-slack
     spec:
       taskRef:
         name: send-to-webhook-slack


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The slack notification task uses a generated name today, which means
that in some cases the notifications may be sent multiple times.

Use source taskrun <name>-<namespace> truncated to 57 chars + "-slack"
as a name, so that the notification name is different for each source
taskrun, but the notification can only be sent once.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>


/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._