### PR TITLE
Add the tekton.dev/pr-number to github notifications

### DIFF
--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -41,6 +41,7 @@ spec:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
       serviceAccountName: tekton-ci-jobs
       podTemplate:
@@ -112,6 +113,7 @@ spec:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
       serviceAccountName: tekton-ci-jobs
       podTemplate:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The tekton.dev/pr-number labels makes it possible to filter for
all github notifications and all taskruns in general associated
to a specific PR over time.

Useful for debugging github notifications.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._