### PR TITLE
Check if label.name startswith kind/

### DIFF
--- a/tekton/ci/shared/labels.yaml
+++ b/tekton/ci/shared/labels.yaml
@@ -14,7 +14,7 @@ spec:
         - name: filter
           value: >-
             body.repository.name in ['plumbing', 'pipeline', 'triggers', 'cli', 'dashboard', 'hub'] &&
-            body.label.startsWith('kind/')
+            body.label.name.startsWith('kind/')
   bindings:
     - ref: tekton-ci-github-base
     - ref: tekton-ci-webhook-pull-request


### PR DESCRIPTION
# Changes

Cheking label only does not work as label is a map in the input
event.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind  bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._