### PR TITLE
Remove last lurking Tasks with apiVersion tekton.dev/v1alpha1

### DIFF
--- a/tekton/ci/shared/common-tasks.yaml
+++ b/tekton/ci/shared/common-tasks.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: check-git-files-changed
@@ -46,7 +46,7 @@ spec:
             grep -E "${REGEX}" && CHECK="passed"
         printf $CHECK > $(results.check.path)
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: check-name-matches


### PR DESCRIPTION
# Changes

I _think_ this should be the last references to `Pipeline`, `PipelineRun`, `Task`, or `TaskRun` with `apiVersion: tekton.dev/v1alpha1`.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._