### PR TITLE
Set requests/limits on post-tekton-pipeline-go-coverage

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1780,6 +1780,13 @@ postsubmits:
         args:
         - "--artifacts=$(ARTIFACTS)"
         - "--cov-threshold-percentage=0"
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 4Gi
+          limits:
+            cpu: 4000m
+            memory: 8Gi
   tektoncd/triggers:
   - name: post-tekton-triggers-go-coverage
     branches:


### PR DESCRIPTION
# Changes

I just happened to do one of my periodic checks on top pods in the Prow cluster by CPU, and saw one for `post-tekton-pipeline-go-coverage` using 15 CPUs worth. So...yeah, that should have requests/limits!

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._