### PR TITLE
Fix the label check

### DIFF
--- a/tekton/ci/shared/labels.yaml
+++ b/tekton/ci/shared/labels.yaml
@@ -27,6 +27,8 @@ apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: all-labels
+  annotations:
+    triggers.tekton.dev/old-escape-quotes: 'true'
 spec:
   params:
   - name: buildUUID
@@ -66,11 +68,11 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      generateName: check-github-tasks-completed-
+      generateName: check-pr-labels-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/source-event-id: $(tt.params.sourceEventId)
-        tekton.dev/check-name: check-github-tasks-completed
+        tekton.dev/check-name: check-pr-has-kind-label
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
@@ -78,11 +80,11 @@ spec:
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
     spec:
       pipelineRef:
-        name: tekton-github-tasks-completed
+        name: tekton-kind-label
       params:
-        - name: body
-          value: $(tt.params.body)
+        - name: labels
+          value: $(tt.params.labels)
         - name: checkName
-          value: check-github-tasks-completed
+          value: check-pr-has-kind-label
         - name: gitHubCommand
           value: $(tt.params.gitHubCommand)


### PR DESCRIPTION
# Changes

Currently the shared repo trigger that responds to PR and Comments runs
the github task and label checks which is ok.
The all-repo trigger that reponds to label events runs only the github
task check, but it should instead run the label check.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

Fixes: #1168

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._