### PR TITLE
kaniko4ci should handle changes in subdirectories for images

### DIFF
--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -43,6 +43,14 @@ spec:
       #!/busybox/sh
       # Setup the image name
       CONTEXT=$(dirname ${FQ_DOCKER_FILE}) # This works with a Dockerfile in the root of the context
+      # Loop until we find a directory with a Dockerfile in it
+      while [ ! -f "${CONTEXT}/Dockerfile" ]; do
+        if [ "${CONTEXT}" == "/" ]; then
+          echo "No Dockerfile found in ${FQ_DOCKER_FILE}'s directory or any of its parents"
+          exit 1
+        fi
+        CONTEXT=$(dirname ${CONTEXT})
+      done
       IMAGE_NAME=$(basename "${CONTEXT}"):pr-${PR_NUMBER}
       # Run the build
       /kaniko/executor \


### PR DESCRIPTION
# Changes

Right now, a change in `tekton/images/koparse/koparse/test_release.yaml` will result in kaniko4ci trying to build in `tekton/images/koparse/koparse`, but there's no Dockerfile there. So let's have the task traverse parent directories until it either finds a Dockerfile or gets to the root directory.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._