### PR TITLE
Enable pipeline feature flags in robocat

### DIFF
--- a/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
@@ -2,5 +2,6 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - config-artifact-bucket.yaml
+- feature-flags.yaml
 resources:
 - tekton-storage-secret.yaml


### PR DESCRIPTION

# Changes


The deployment pipeline uses alpha features, so it requires alpha flags
to be on in the robocat cluster.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._