### PR TITLE
Remove clusters.yaml from list of resources

### DIFF
--- a/tekton/resources/cd/kustomization.yaml
+++ b/tekton/resources/cd/kustomization.yaml
@@ -17,7 +17,6 @@ patches:
 
 resources:
 - bindings.yaml
-- clusters.yaml
 - configmap-template.yaml
 - eventlistener.yaml
 - folder-template.yaml


### PR DESCRIPTION
# Changes

The clusters.yaml file has been previously removed along with
PipelineResources in tekton/cd resources, but it was left over in the
kustomization.yaml file.

Fix this to restore deployment of resources.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._