### PR TITLE
Support release "latest" in install tekton release

### DIFF
--- a/tekton/resources/cd/install-tekton-release.yaml
+++ b/tekton/resources/cd/install-tekton-release.yaml
@@ -168,6 +168,10 @@ spec:
           workspace: resources
     - name: fetch-release
       runAfter: ['git-clone']
+      when:
+        - input: "$(params.version)"
+          operator: notin
+          values: ["latest"]
       taskRef:
         name: gcs-download
         bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
@@ -183,8 +187,29 @@ spec:
           workspace: resources
         - name: credentials
           workspace: credentials
+    - name: fetch-release-latest
+      runAfter: ['git-clone']
+      when:
+        - input: "$(params.version)"
+          operator: in
+          values: ["latest"]
+      taskRef:
+        name: gcs-download
+        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+      params:
+        - name: path
+          value: release
+        - name: location
+          value: $(params.releaseBucket)/$(params.version)
+        - name: typeDir
+          value: "true"
+      workspaces:
+        - name: output
+          workspace: resources
+        - name: credentials
+          workspace: credentials
     - name: install-tekton-release
-      runAfter: ['fetch-release']
+      runAfter: ['fetch-release', 'fetch-release-latest']
       taskRef:
         name: install-tekton-release
       params:


### PR DESCRIPTION
# Changes

Support installing a released called "latest" in the
install_tekton_release pipeline.

Use two mutually exclusive flavours of the fetch release pipeline
task, one that fetches "latest" and the other one "previous/<version>"
depending on the requested version.

The install task depends on both fetch tasks, which is possible now
that we have task scoped when expressions.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._