### PR TITLE
Fix: determine whether the destination path already exists before clone

### DIFF
--- a/tekton/images/test-runner/entrypoint.sh
+++ b/tekton/images/test-runner/entrypoint.sh
@@ -17,8 +17,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Workaround for https://github.com/google/licenseclassifier/issues/20
-git clone https://github.com/google/licenseclassifier ${GOPATH}/src/github.com/google/licenseclassifier
+DIR="${GOPATH}/src/github.com/google/licenseclassifier"
+
+if [ -d "$DIR" ]; then
+    echo "$DIR is not Empty. Skip clone..."
+else
+    # Workaround for https://github.com/google/licenseclassifier/issues/20
+    git clone https://github.com/google/licenseclassifier $DIR
+fi
 
 # actually start bootstrap and the job, under the runner (which handles dind etc.)
 /usr/local/bin/runner.sh "$@"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
If directory ${GOPATH}/src/github.com/google/licenseclassifier exists and is not empty we should skip clone again or will cause an error.

Related Issue: https://github.com/tektoncd/pipeline/issues/5193

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._