### PR TITLE
Revert "prow: bump test-runners to an image that actually uses go 1.18.3."

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -498,7 +498,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -531,7 +531,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -564,7 +564,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -630,7 +630,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -663,7 +663,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-cross-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -696,7 +696,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -729,7 +729,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -763,7 +763,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -789,7 +789,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-dashboard-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -815,7 +815,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -924,7 +924,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -950,7 +950,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -976,7 +976,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1003,7 +1003,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1041,7 +1041,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1074,7 +1074,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1139,7 +1139,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1172,7 +1172,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1431,7 +1431,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1457,7 +1457,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-resolution-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1485,7 +1485,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1597,7 +1597,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1623,7 +1623,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-triggers-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1649,7 +1649,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1700,7 +1700,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-gen-crd-api-reference-docs-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220808-5dbf210387@sha256:f244459e61d307f9698579fd8bd7d52452fb40783c8baee13a0b56680d7924c3 # golang 1.18.3
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220721-5c0e8e0e7a@sha256:8680f99c4d068ef3eb2512d9d3a153049b40f719454e21dfa4aaf691d7de4db5 # golang 1.18.3
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This reverts commit 80875d194dbcbb783d5cd90b380016598264e790.

The change breaks build jobs on at least pipeline, operator and CLI.
We should do this incrementally along with fixes to the lintinig issues
or linting configuration.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._