### PR TITLE
Bump golangci-lint in test-runner to v1.47.2 to support Go 1.18

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -173,7 +173,7 @@ RUN GO111MODULE="on" go install github.com/google/go-licenses@latest && \
     GO111MODULE="on" go install sigs.k8s.io/kind@${KIND_VERSION}
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
-ARG GOLANGCI_VERSION=1.42.0
+ARG GOLANGCI_VERSION=1.47.2
 RUN curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
 
 # Install Kustomize:


### PR DESCRIPTION
# Changes

golangci-lint v1.42.0 fails in all kinds of interesting ways with Go 1.18, so we need to bump it. The latest version, v1.48.0, requires Go 1.19 to compile, so we'll go with v1.47.2.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._