### PR TITLE
combine: Support multiple base images

### DIFF
--- a/cmd/combine/README.md
+++ b/cmd/combine/README.md
@@ -8,13 +8,13 @@ It fails if any images provide the same platforms, or if any isn't a manifest li
 
 ```
 $ go run ./ \
-    gcr.io/distroless/static:nonroot \
+    ghcr.io/distroless/static \
     mcr.microsoft.com/windows/nanoserver:ltsc2022 \
     mcr.microsoft.com/windows/nanoserver:ltsc2019 \
-    gcr.io/imjasonh/combined
+    gcr.io/MY_PROJECT/combined
 ```
 
-This combines the [distroless](https://github.com/googlecontainertools/distroless) image providing linux platform support with two image providing different versions of a Windows base image.
+This combines a [distroless](https://github.com/distroless/static) base image providing Linux platform support, with two image providing different versions of a Windows base image.
 
 The general form of the command args is:
 
@@ -27,14 +27,24 @@ combine src1 src2 [src...] dst
 After running the script, you can check the image's platforms using [`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md):
 
 ```
-$ crane manifest gcr.io/imjasonh/combined | jq '.manifests[].platform'
+$ crane manifest gcr.io/MY_PROJECT/combined | jq '.manifests[].platform'
+{
+  "architecture": "386",
+  "os": "linux"
+}
 {
   "architecture": "amd64",
   "os": "linux"
 }
 {
   "architecture": "arm",
-  "os": "linux"
+  "os": "linux",
+  "variant": "v6"
+}
+{
+  "architecture": "arm",
+  "os": "linux",
+  "variant": "v7"
 }
 {
   "architecture": "arm64",
@@ -45,18 +55,22 @@ $ crane manifest gcr.io/imjasonh/combined | jq '.manifests[].platform'
   "os": "linux"
 }
 {
+  "architecture": "riscv64",
+  "os": "linux"
+}
+{
   "architecture": "s390x",
   "os": "linux"
 }
 {
   "architecture": "amd64",
   "os": "windows",
-  "os.version": "10.0.17763.1935"
+  "os.version": "10.0.20348.887"
 }
 {
-  "architecture": "arm",
+  "architecture": "amd64",
   "os": "windows",
-  "os.version": "10.0.17763.1935"
+  "os.version": "10.0.17763.3287"
 }
 ```
 

--- a/cmd/combine/README.md
+++ b/cmd/combine/README.md
@@ -1,27 +1,28 @@
 # combine manifest lists
 
-This tool combines two Docker manifest lists ("multi-arch images") into one that provides all the platforms supported by both manifest lists.
+This tool combines two or more Docker manifest lists ("multi-arch images") into one that provides all the platforms supported by all the specified base image manifest lists.
 
-It fails if both images provide the same platforms, or if either isn't a manifest list.
+It fails if any images provide the same platforms, or if any isn't a manifest list.
 
 # demo
 
 ```
 $ go run ./ \
     gcr.io/distroless/static:nonroot \
-    mcr.microsoft.com/windows/nanoserver:1809 \
+    mcr.microsoft.com/windows/nanoserver:ltsc2022 \
+    mcr.microsoft.com/windows/nanoserver:ltsc2019 \
     gcr.io/imjasonh/combined
 ```
 
-This combines the [distroless](https://github.com/googlecontainertools/distroless) image providing linux platform support with an image providing Windows support.
+This combines the [distroless](https://github.com/googlecontainertools/distroless) image providing linux platform support with two image providing different versions of a Windows base image.
 
 The general form of the command args is:
 
 ```
-combine src1 src2 dst
+combine src1 src2 [src...] dst
 ```
 
-(combine two source manifest lists and push to the `dst` reference).
+(combine two or more source manifest lists and push to the `dst` reference).
 
 After running the script, you can check the image's platforms using [`crane`](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md):
 
@@ -59,7 +60,7 @@ $ crane manifest gcr.io/imjasonh/combined | jq '.manifests[].platform'
 }
 ```
 
-The result is an image that provides support for both.
-If both manifest lists provide support for the same platform, the script will fail.
+The result is an image that provides support for all the provided base image platforms.
+If any manifest lists provide duplicate support for the same platform, the script will fail.
 
 This image is intended to be suitable as a base image used with `ko` to provide multi-arch _and multi-OS_ support for a Go application.


### PR DESCRIPTION
This updates cmd/combine to optionally allow combining 3+ base images
together, in addition to the 2 base images previously supported.

Some users may need support for multiple versions of Windows, which this
enables.

https://github.com/tektoncd/pipeline/issues/5327

/kind feature 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._