### PR TITLE
Enables cherry-pick plugin in prow for tektoncd/operator

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -63,3 +63,8 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  tektoncd/operator:
+  - name: cherrypicker
+    events:
+      - issue_comment
+      - pull_request


### PR DESCRIPTION
we would like to enable the cherrypicker plugin in prow for operator repository
https://github.com/kubernetes/test-infra/tree/master/prow/external-plugins/cherrypicker

eg.
```
/cherrypick release-1.10
```

following the docs at https://github.com/kubernetes/test-infra/blob/master/prow/plugins/README.md#external-plugins
enabling the cherrypicker external plugin for operator repository

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._