### PR TITLE
Apply ServiceAccount to the cluster

### DIFF
--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -86,7 +86,33 @@ spec:
       fi
 
       # Run the actual deployment. If it fails, it will fail the step.
-      kubectl "${DEPLOY_METHOD}" $NAMESPACE_PARAM -f $TARGET
+      kubectl create ${NAMESPACE_PARAM} -f $TARGET --dry-run=client \
+        -o yaml > ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml
+
+  - name: split-yaml-file
+    image: mikefarah/yq
+    script: |
+      #!/bin/sh
+      set -ex
+
+      yq 'select(.kind == "ServiceAccount")' \
+        ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml > ${RESOURCES_PATH}/DEPLOYABLE_sa.yaml
+      yq 'select(.kind != "ServiceAccount")' \
+        ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml > ${RESOURCES_PATH}/DEPLOYABLE_not_sa.yaml
+
+  - name: deploy-resources
+    image: gcr.io/tekton-releases/dogfooding/kubectl
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Determine whether to enforce namespace across resources
+      NAMESPACE_PARAM="-n ${NAMESPACE}"
+      [[ "${NAMESPACE}" == "" ]] && NAMESPACE_PARAM=""
+
+      # ServiceAccounts are always applied to avoid the creation of a new token
+      kubectl apply ${NAMESPACE_PARAM} -f ${RESOURCES_PATH}/DEPLOYABLE_sa.yaml
+      kubectl "${DEPLOY_METHOD}" ${NAMESPACE_PARAM} -f ${RESOURCES_PATH}/DEPLOYABLE_not_sa.yaml
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline


### PR DESCRIPTION
# Changes

Replacing a service account on the cluster causes k8s to create a
service account token every time.

Using kubectl apply avoids that behaviour, but we still want to
use create/replace for other resources. To solve this, use
dry-run first on kubectl create to place all resources in a file,
then use yq to separate service accounts in a dedicated file, and
finally apply the service accounts file.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._