### PR TITLE
Add missing feature-flags overlay for Pipelines robocat deploy

### DIFF
--- a/tekton/cd/pipeline/overlays/robocat/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/robocat/feature-flags.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  enable-api-fields: "alpha"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Related to https://github.com/tektoncd/plumbing/pull/1171

Robocat is stuck on Pipelines `v20220727-55665765e4` due to an error in the nightly deploy TaskRun, see for example https://dashboard.dogfooding.tekton.dev/#/namespaces/default/taskruns/deploy-pipeline-release-robocat-chpl9-install-tekton-release?step=deploy-tekton-project

```
2022-08-30T03:01:38.142511933Z error: trouble configuring builtin PatchStrategicMergeTransformer with config: `
2022-08-30T03:01:38.142587504Z paths:
2022-08-30T03:01:38.142595931Z - config-artifact-bucket.yaml
2022-08-30T03:01:38.142602021Z - feature-flags.yaml
2022-08-30T03:01:38.142607828Z `: evalsymlink failure on '/workspace/resources/plumbing/tekton/cd/pipeline/overlays/robocat/feature-flags.yaml' : lstat /workspace/resources/plumbing/tekton/cd/pipeline/overlays/robocat/feature-flags.yaml: no such file or directory
```

Add the missing overlay based on the one currently used for dogfooding.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._