### PR TITLE
Fix the resource deployment

### DIFF
--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -85,9 +85,11 @@ spec:
         fi
       fi
 
-      # Run the actual deployment. If it fails, it will fail the step.
+      # Produce the temporary deployment file
+      chmod a+rwx ${RESOURCES_PATH}
       kubectl create ${NAMESPACE_PARAM} -f $TARGET --dry-run=client \
         -o yaml > ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml
+      chmod a+r ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml
 
   - name: split-yaml-file
     image: mikefarah/yq
@@ -111,8 +113,9 @@ spec:
       [[ "${NAMESPACE}" == "" ]] && NAMESPACE_PARAM=""
 
       # ServiceAccounts are always applied to avoid the creation of a new token
-      kubectl apply ${NAMESPACE_PARAM} -f ${RESOURCES_PATH}/DEPLOYABLE_sa.yaml
-      kubectl "${DEPLOY_METHOD}" ${NAMESPACE_PARAM} -f ${RESOURCES_PATH}/DEPLOYABLE_not_sa.yaml
+      # Only apply non-empty files
+      [ -s ${RESOURCES_PATH}/DEPLOYABLE_sa.yaml ] && kubectl apply ${NAMESPACE_PARAM} -f ${RESOURCES_PATH}/DEPLOYABLE_sa.yaml
+      [ -s ${RESOURCES_PATH}/DEPLOYABLE_not_sa.yaml ] && kubectl "${DEPLOY_METHOD}" ${NAMESPACE_PARAM} -f ${RESOURCES_PATH}/DEPLOYABLE_not_sa.yaml
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The resource deployment task was failing on permission issues. Ensure the 2nd step can write extra files in the workspace. Only apply files that are non-empty. For instance the cronjob deployment job does not have any service account.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._