### PR TITLE
Make resources path writeable earlier

### DIFF
--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -51,6 +51,9 @@ spec:
       #!/bin/sh
       set -ex
 
+      # This directory needs to be writeable, and we need to make it writeable before we could exit early due to no changes.
+      chmod a+rwx ${RESOURCES_PATH}
+
       # Determine whether to enforce namespace across resources
       NAMESPACE_PARAM="-n ${NAMESPACE}"
       [[ "${NAMESPACE}" == "" ]] && NAMESPACE_PARAM=""
@@ -86,7 +89,6 @@ spec:
       fi
 
       # Produce the temporary deployment file
-      chmod a+rwx ${RESOURCES_PATH}
       kubectl create ${NAMESPACE_PARAM} -f $TARGET --dry-run=client \
         -o yaml > ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml
       chmod a+r ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml


### PR DESCRIPTION
# Changes

Otherwise the `PipelineRun` fails when there are no changes, because it tries to write to the resource path but exited the first step before getting to the `chmod`.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._