### PR TITLE
prow/config: only set docker-in-docker with labels

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -907,6 +907,7 @@ presubmits:
   - name: pull-tekton-experimental-integration-tests
     labels:
       preset-presubmit-sh: "true"
+      preset-dind-enabled: "true"
     agent: kubernetes
     always_run: true
     decorate: true
@@ -930,9 +931,6 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "./test/presubmit-tests.sh"
         - "--integration-tests"
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
   tektoncd/hub:
   - name: pull-tekton-hub-build-tests
     labels:
@@ -1046,11 +1044,6 @@ presubmits:
           limits:
             cpu: 4000m
             memory: 8Gi
-        env:
-        - name: DOCKER_IN_DOCKER_ENABLED
-          value: "true"
-        securityContext:
-          privileged: true
   - name: pull-tekton-operator-unit-tests
     labels:
       preset-presubmit-sh: "true"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Removes dind for operator-build-test (not needed)
- Add dind label for experimental integration tests instead of the env

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
