### PR TITLE
Remove version tag labels from pr-commenter controller

### DIFF
--- a/tekton/ci/custom-tasks/pr-commenter/config/500-controller.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/config/500-controller.yaml
@@ -18,20 +18,15 @@ metadata:
   name: pr-commenter-controller
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: pr-commenter-controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "devel"
     app.kubernetes.io/part-of: pr-commenter
-    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "devel"
-    # labels below are related to istio and should not be used for resource lookup
-    version: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: controller
+      app.kubernetes.io/name: pr-commenter-controller
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: default
       app.kubernetes.io/part-of: pr-commenter
@@ -40,16 +35,11 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app.kubernetes.io/name: controller
+        app.kubernetes.io/name: pr-commenter-controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "devel"
         app.kubernetes.io/part-of: pr-commenter
-        # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "devel"
-        # labels below are related to istio and should not be used for resource lookup
         app: pr-commenter-controller
-        version: "devel"
     spec:
       serviceAccountName: pr-commenter-controller
       containers:


### PR DESCRIPTION
# Changes

`VERSION_TAG` isn't set in the right task, and I'm being lazy.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._