### PR TITLE
Add nightly release for concurrency project

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/concurrency/README.md
+++ b/tekton/cronjobs/dogfooding/releases/concurrency/README.md
@@ -1,0 +1,2 @@
+Cron Job to trigger the [Concurrency](https://github.com/tektoncd/experimental/tree/main/concurrency) nightly build.
+Results are published to https://storage.cloud.google.com/tekton-releases-nightly/concurrency/latest/release.yaml

--- a/tekton/cronjobs/dogfooding/releases/concurrency/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/concurrency/cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nightly-cron-trigger
+spec:
+  schedule: "30 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            env:
+              - name: PROJECT_NAME
+                value: concurrency
+          initContainers:
+          - name: git
+            env:
+              - name: GIT_REPO
+                value: github.com/tektoncd/experimental

--- a/tekton/cronjobs/dogfooding/releases/concurrency/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/concurrency/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../../bases/release
+patchesStrategicMerge:
+- cronjob.yaml
+nameSuffix: "-concurrency-nightly-release"

--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
 - pipeline-in-pod-nightly
 - pr-commenter-nightly
 - pr-status-updater-nightly
+- concurrency-nightly

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
 - overlays/pipeline-in-pod
 - overlays/pr-commenter
 - overlays/pr-status-updater
+- overlays/concurrency

--- a/tekton/resources/nightly-release/overlays/concurrency/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/concurrency/kustomization.yaml
@@ -1,0 +1,18 @@
+namePrefix: concurrency-
+bases:
+  - ../../base
+patchesJson6902:
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: TriggerTemplate
+      name: template
+    path: template.yaml
+  - target:
+      group: triggers.tekton.dev
+      version: v1alpha1
+      kind: Trigger
+      name: nightly
+    path: trigger.yaml
+resources:
+  - github.com/tektoncd/experimental/tekton/?ref=main

--- a/tekton/resources/nightly-release/overlays/concurrency/template.yaml
+++ b/tekton/resources/nightly-release/overlays/concurrency/template.yaml
@@ -1,0 +1,41 @@
+- op: add
+  path: /spec/resourcetemplates
+  value:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: concurrency-release-nightly-
+        labels:
+          tekton.dev/kind: release
+      spec:
+        pipelineRef:
+          name: release
+        params:
+        - name: package
+          value: $(tt.params.gitrepository)
+        - name: gitRevision
+          value: $(tt.params.gitrevision)
+        - name: imageRegistry
+          value: $(tt.params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(tt.params.imageRegistryPath)
+        - name: versionTag
+          value: $(tt.params.versionTag)
+        - name: serviceAccountPath
+          value: release.json
+        - name: subfolder
+          value: concurrency
+        - name: releaseBucket
+          value: gs://tekton-releases-nightly/concurrency
+        workspaces:
+          - name: workarea
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+          - name: release-secret
+            secret:
+              secretName: release-secret

--- a/tekton/resources/nightly-release/overlays/concurrency/trigger.yaml
+++ b/tekton/resources/nightly-release/overlays/concurrency/trigger.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/interceptors
+  value:
+    - cel:
+        filter: >-
+          'trigger-template' in body &&
+          body.params.release.projectName == 'concurrency'


### PR DESCRIPTION
# Changes
This commit adds a nightly cronjob and triggers for the experimental concurrency reconciler located in tektoncd/experimental/concurrency. It uses the custom task release pipeline defined at the top level of the experimental repo. The cronjob and triggers are copied from other custom task examples in plumbing.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._