### PR TITLE
Turn on PRCommenter on completion of PR builds

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -179,6 +179,8 @@ spec:
                   expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1).split('/').join('_')
                 - key: shortSourceEventID
                   expression: body.taskRun.metadata.labels['tekton.dev/source-event-id'].truncate(13)
+                - key: repoName
+                  expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1).split('/')[1]
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -38,6 +38,8 @@ spec:
     value: success
   - name: gitHubCheckDescription
     value: "Job Successful."
+  - name: gitHubCheckIsSuccess
+    value: "true"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -49,6 +51,8 @@ spec:
     value: failure
   - name: gitHubCheckDescription
     value: "Job Failed."
+  - name: gitHubCheckIsSuccess
+    value: "false"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -73,3 +77,5 @@ spec:
     value: $(extensions.shortSourceEventID)
   - name: gitHubRepoUnderscore
     value: $(extensions.repoUnderscore)
+  - name: gitHubRepoName
+    value: $(extensions.repoName)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -83,6 +83,8 @@ spec:
     description: A truncated version of the sourceEventId
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
+  - name: gitHubRepoName
+    description: The gitHubRepo's name (repo)
   - name: gitHubRepoUnderscore
     description: The gitHubRepoUnderscore (org_repo)
   - name: gitRevision
@@ -105,7 +107,7 @@ spec:
     default: ""
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
       name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
@@ -115,15 +117,17 @@ spec:
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
-      serviceAccountName: tekton-ci-jobs
-      podTemplate:
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 1001
-      taskRef:
-        name: github-set-status
-        bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
-      params:
+      tasks:
+      - name: set-status
+        serviceAccountName: tekton-ci-jobs
+        podTemplate:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+        taskRef:
+          name: github-set-status
+          bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
+        params:
         - name: REPO_FULL_NAME
           value: $(tt.params.gitHubRepo)
         - name: SHA
@@ -140,3 +144,22 @@ spec:
           value: bot-token-github
         - name: GITHUB_TOKEN_SECRET_KEY
           value: bot-token
+      - name: comment-on-pr
+        taskRef:
+          apiVersion: custom.tekton.dev/v0
+          kind: PRCommenter
+        params:
+        - name: repo
+          value: $(tt.params.gitHubRepoName)
+        - name: prNumber
+          value: $(tt.params.pullRequestNumber)
+        - name: sha
+          value: $(tt.params.gitRevision)
+        - name: jobName
+          value: $(tt.params.checkName)
+        - name: isSuccess
+          value: $(tt.params.gitHubCheckIsSuccess)
+        - name: isOptional
+          value: "false"
+        - name: logURL
+          value: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/$(tt.params.gitHubRepoUnderscore)/$(tt.params.pullRequestNumber)/$(tt.params.checkName)/$(tt.params.buildUUID)


### PR DESCRIPTION
# Changes

Closes #483

I could have added a new `TriggerTemplate`, but it made more sense to just turn the existing `tekton-ci-github-check-end` into a `PipelineRun`.

I did have to add a couple new parameters - the bare repo name (since I wrote up the PR commenter to have the org as a global configuration), and a boolean for pass/fail. It may make sense to tweak the PR commenter to handle `org/repo` instead of just `repo`, and `"success"` or `"failure"` instead of `true` or `false`, but I thought I'd wait to see what people think. =)

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._