### PR TITLE
Revert turning on PRCommenter in triggers

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -179,8 +179,6 @@ spec:
                   expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1).split('/').join('_')
                 - key: shortSourceEventID
                   expression: body.taskRun.metadata.labels['tekton.dev/source-event-id'].truncate(13)
-                - key: repoName
-                  expression: body.taskRun.metadata.annotations['tekton.dev/gitURL'].parseURL().path.substring(1).split('/')[1]
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -38,8 +38,6 @@ spec:
     value: success
   - name: gitHubCheckDescription
     value: "Job Successful."
-  - name: gitHubCheckIsSuccess
-    value: "true"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -51,8 +49,6 @@ spec:
     value: failure
   - name: gitHubCheckDescription
     value: "Job Failed."
-  - name: gitHubCheckIsSuccess
-    value: "false"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
@@ -77,5 +73,3 @@ spec:
     value: $(extensions.shortSourceEventID)
   - name: gitHubRepoUnderscore
     value: $(extensions.repoUnderscore)
-  - name: gitHubRepoName
-    value: $(extensions.repoName)

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -83,8 +83,6 @@ spec:
     description: A truncated version of the sourceEventId
   - name: gitHubRepo
     description: The gitHubRepo (org/repo)
-  - name: gitHubRepoName
-    description: The gitHubRepo's name (repo)
   - name: gitHubRepoUnderscore
     description: The gitHubRepoUnderscore (org_repo)
   - name: gitRevision
@@ -93,8 +91,6 @@ spec:
     description: Name of the CI Job (GitHub Check)
   - name: gitHubCheckStatus
     description: Can be 'pending', 'success' or 'failure'
-  - name: gitHubCheckIsSuccess
-    description: Can be 'true' or 'false'
   - name: gitHubCheckDescription
     description: A description to be displayed for the status of the check
   - name: taskRunName
@@ -109,7 +105,7 @@ spec:
     default: ""
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
+    kind: TaskRun
     metadata:
       name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
@@ -119,17 +115,15 @@ spec:
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
-      tasks:
-      - name: set-status
-        serviceAccountName: tekton-ci-jobs
-        podTemplate:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-        taskRef:
-          name: github-set-status
-          bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
-        params:
+      serviceAccountName: tekton-ci-jobs
+      podTemplate:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+      taskRef:
+        name: github-set-status
+        bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
+      params:
         - name: REPO_FULL_NAME
           value: $(tt.params.gitHubRepo)
         - name: SHA
@@ -146,22 +140,3 @@ spec:
           value: bot-token-github
         - name: GITHUB_TOKEN_SECRET_KEY
           value: bot-token
-      - name: comment-on-pr
-        taskRef:
-          apiVersion: custom.tekton.dev/v0
-          kind: PRCommenter
-        params:
-        - name: repo
-          value: $(tt.params.gitHubRepoName)
-        - name: prNumber
-          value: $(tt.params.pullRequestNumber)
-        - name: sha
-          value: $(tt.params.gitRevision)
-        - name: jobName
-          value: $(tt.params.checkName)
-        - name: isSuccess
-          value: $(tt.params.gitHubCheckIsSuccess)
-        - name: isOptional
-          value: "false"
-        - name: logURL
-          value: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/$(tt.params.gitHubRepoUnderscore)/$(tt.params.pullRequestNumber)/$(tt.params.checkName)/$(tt.params.buildUUID)


### PR DESCRIPTION
# Changes

Specifically reverting #1220 and #1225

Something's wrong with how this is actually working in practice - I'm not seeing the `PipelineRun` get created, so I'm _guessing_ something's awry in the eventlistener. But I don't know enough to figure out what's wrong. So let's revert this for the moment.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._