### PR TITLE
Switch pr-commenter and pr-status-updater to use existing params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 # Virtualenv files
 .venv
 
-tekton/ci/custom-tasks/pr-commenter/.bin
+**/.bin

--- a/tekton/ci/custom-tasks/pr-commenter/cmd/pr-commenter/main.go
+++ b/tekton/ci/custom-tasks/pr-commenter/cmd/pr-commenter/main.go
@@ -14,14 +14,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	owner := os.Getenv("GIT_OWNER")
-	if owner == "" {
-		log.Fatal("GIT_OWNER env var required")
-	}
 	botUser := os.Getenv("GIT_USER")
 	if botUser == "" {
 		botUser = "tekton-robot"
 	}
 
-	sharedmain.Main(reconciler.ControllerName, reconciler.NewController(scmClient, botUser, owner))
+	sharedmain.Main(reconciler.ControllerName, reconciler.NewController(scmClient, botUser))
 }

--- a/tekton/ci/custom-tasks/pr-commenter/config/500-controller.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/config/500-controller.yaml
@@ -78,8 +78,6 @@ spec:
               value: github
             - name: GIT_SERVER
               value: https://github.com
-            - name: GIT_OWNER
-              value: tektoncd
             - name: GIT_USER
               value: tekton-robot
             - name: "GIT_TOKEN"

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/controller.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/controller.go
@@ -18,11 +18,10 @@ const (
 )
 
 // NewController instantiates a new controller
-func NewController(scmClient *scm.Client, botUser string, owner string) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(scmClient *scm.Client, botUser string) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		r := &Reconciler{
 			SCMClient: scmClient,
-			Owner:     owner,
 			BotUser:   botUser,
 		}
 

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/params_test.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/params_test.go
@@ -23,7 +23,7 @@ func TestReportInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  prNumberKey,
 							Value: *v1beta1.NewStructuredValues("5"),
@@ -34,8 +34,8 @@ func TestReportInfoFromRun(t *testing.T) {
 							Name:  jobNameKey,
 							Value: *v1beta1.NewStructuredValues("some-job"),
 						}, {
-							Name:  successKey,
-							Value: *v1beta1.NewStructuredValues("true"),
+							Name:  resultKey,
+							Value: *v1beta1.NewStructuredValues("success"),
 						}, {
 							Name:  optionalKey,
 							Value: *v1beta1.NewStructuredValues("false"),
@@ -47,11 +47,11 @@ func TestReportInfoFromRun(t *testing.T) {
 				},
 			},
 			info: &ReportInfo{
-				Repo:       "some-repo",
+				Repo:       "some-org/some-repo",
 				PRNumber:   5,
 				SHA:        "abcd1234",
 				JobName:    "some-job",
-				IsSuccess:  true,
+				Result:     "success",
 				LogURL:     "http://some/where",
 				IsOptional: false,
 			},
@@ -70,8 +70,8 @@ func TestReportInfoFromRun(t *testing.T) {
 							Name:  jobNameKey,
 							Value: *v1beta1.NewStructuredValues("some-job"),
 						}, {
-							Name:  successKey,
-							Value: *v1beta1.NewStructuredValues("true"),
+							Name:  resultKey,
+							Value: *v1beta1.NewStructuredValues("success"),
 						}, {
 							Name:  optionalKey,
 							Value: *v1beta1.NewStructuredValues("false"),
@@ -90,7 +90,7 @@ func TestReportInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  shaKey,
 							Value: *v1beta1.NewStructuredValues("abcd1234"),
@@ -98,8 +98,8 @@ func TestReportInfoFromRun(t *testing.T) {
 							Name:  jobNameKey,
 							Value: *v1beta1.NewStructuredValues("some-job"),
 						}, {
-							Name:  successKey,
-							Value: *v1beta1.NewStructuredValues("true"),
+							Name:  resultKey,
+							Value: *v1beta1.NewStructuredValues("success"),
 						}, {
 							Name:  optionalKey,
 							Value: *v1beta1.NewStructuredValues("false"),
@@ -118,7 +118,7 @@ func TestReportInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  prNumberKey,
 							Value: *v1beta1.NewStructuredValues("5"),
@@ -126,8 +126,8 @@ func TestReportInfoFromRun(t *testing.T) {
 							Name:  jobNameKey,
 							Value: *v1beta1.NewStructuredValues("some-job"),
 						}, {
-							Name:  successKey,
-							Value: *v1beta1.NewStructuredValues("true"),
+							Name:  resultKey,
+							Value: *v1beta1.NewStructuredValues("success"),
 						}, {
 							Name:  optionalKey,
 							Value: *v1beta1.NewStructuredValues("false"),
@@ -146,7 +146,7 @@ func TestReportInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  prNumberKey,
 							Value: *v1beta1.NewStructuredValues("5"),
@@ -154,8 +154,8 @@ func TestReportInfoFromRun(t *testing.T) {
 							Name:  shaKey,
 							Value: *v1beta1.NewStructuredValues("abcd1234"),
 						}, {
-							Name:  successKey,
-							Value: *v1beta1.NewStructuredValues("true"),
+							Name:  resultKey,
+							Value: *v1beta1.NewStructuredValues("success"),
 						}, {
 							Name:  optionalKey,
 							Value: *v1beta1.NewStructuredValues("false"),
@@ -168,13 +168,13 @@ func TestReportInfoFromRun(t *testing.T) {
 			},
 			err: "missing field(s): jobName",
 		}, {
-			name: "missing isSuccess",
+			name: "missing result",
 			run: &v1alpha1.Run{
 				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  prNumberKey,
 							Value: *v1beta1.NewStructuredValues("5"),
@@ -194,7 +194,7 @@ func TestReportInfoFromRun(t *testing.T) {
 					},
 				},
 			},
-			err: "missing field(s): isSuccess",
+			err: "missing field(s): result",
 		}, {
 			name: "non-string value",
 			run: &v1alpha1.Run{
@@ -212,8 +212,8 @@ func TestReportInfoFromRun(t *testing.T) {
 						Name:  jobNameKey,
 						Value: *v1beta1.NewStructuredValues("some-job"),
 					}, {
-						Name:  successKey,
-						Value: *v1beta1.NewStructuredValues("true"),
+						Name:  resultKey,
+						Value: *v1beta1.NewStructuredValues("success"),
 					}, {
 						Name:  optionalKey,
 						Value: *v1beta1.NewStructuredValues("false"),
@@ -230,7 +230,7 @@ func TestReportInfoFromRun(t *testing.T) {
 				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
-						Value: *v1beta1.NewStructuredValues("some-repo"),
+						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 					}, {
 						Name:  prNumberKey,
 						Value: *v1beta1.NewStructuredValues("five"),
@@ -241,8 +241,8 @@ func TestReportInfoFromRun(t *testing.T) {
 						Name:  jobNameKey,
 						Value: *v1beta1.NewStructuredValues("some-job"),
 					}, {
-						Name:  successKey,
-						Value: *v1beta1.NewStructuredValues("true"),
+						Name:  resultKey,
+						Value: *v1beta1.NewStructuredValues("success"),
 					}, {
 						Name:  optionalKey,
 						Value: *v1beta1.NewStructuredValues("false"),
@@ -259,7 +259,7 @@ func TestReportInfoFromRun(t *testing.T) {
 				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
-						Value: *v1beta1.NewStructuredValues("some-repo"),
+						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 					}, {
 						Name:  prNumberKey,
 						Value: *v1beta1.NewStructuredValues("5"),
@@ -270,7 +270,36 @@ func TestReportInfoFromRun(t *testing.T) {
 						Name:  jobNameKey,
 						Value: *v1beta1.NewStructuredValues("some-job"),
 					}, {
-						Name:  successKey,
+						Name:  resultKey,
+						Value: *v1beta1.NewStructuredValues("success"),
+					}, {
+						Name:  optionalKey,
+						Value: *v1beta1.NewStructuredValues("banana"),
+					}, {
+						Name:  logURLKey,
+						Value: *v1beta1.NewStructuredValues("http://some/where"),
+					}},
+				},
+			},
+			err: "invalid value: banana should be a bool: isOptional",
+		}, {
+			name: "invalid result value",
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
+					Params: []v1beta1.Param{{
+						Name:  repoKey,
+						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
+					}, {
+						Name:  prNumberKey,
+						Value: *v1beta1.NewStructuredValues("5"),
+					}, {
+						Name:  shaKey,
+						Value: *v1beta1.NewStructuredValues("abcd1234"),
+					}, {
+						Name:  jobNameKey,
+						Value: *v1beta1.NewStructuredValues("some-job"),
+					}, {
+						Name:  resultKey,
 						Value: *v1beta1.NewStructuredValues("banana"),
 					}, {
 						Name:  optionalKey,
@@ -281,7 +310,7 @@ func TestReportInfoFromRun(t *testing.T) {
 					}},
 				},
 			},
-			err: "invalid value: banana should be a bool: isSuccess",
+			err: "invalid value: should be one of 'pending', 'success', or 'failure', but is 'banana': result",
 		},
 	}
 

--- a/tekton/ci/custom-tasks/pr-status-updater/cmd/pr-status-updater/main.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/cmd/pr-status-updater/main.go
@@ -14,14 +14,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	owner := os.Getenv("GIT_OWNER")
-	if owner == "" {
-		log.Fatal("GIT_OWNER env var required")
-	}
 	botUser := os.Getenv("GIT_USER")
 	if botUser == "" {
 		botUser = "tekton-robot"
 	}
 
-	sharedmain.Main(reconciler.ControllerName, reconciler.NewController(scmClient, botUser, owner))
+	sharedmain.Main(reconciler.ControllerName, reconciler.NewController(scmClient, botUser))
 }

--- a/tekton/ci/custom-tasks/pr-status-updater/config/500-controller.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/config/500-controller.yaml
@@ -76,10 +76,6 @@ spec:
               value: github
             - name: GIT_SERVER
               value: https://github.com
-            - name: GIT_OWNER
-              value: tektoncd
-            - name: GIT_USER
-              value: tekton-robot
             - name: "GIT_TOKEN"
               valueFrom:
                 secretKeyRef:

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/controller.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/controller.go
@@ -18,11 +18,10 @@ const (
 )
 
 // NewController instantiates a new controller
-func NewController(scmClient *scm.Client, botUser string, owner string) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(scmClient *scm.Client, botUser string) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		r := &Reconciler{
 			SCMClient: scmClient,
-			Owner:     owner,
 			BotUser:   botUser,
 		}
 

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/params_test.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/params_test.go
@@ -23,7 +23,7 @@ func TestStatusInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  shaKey,
 							Value: *v1beta1.NewStructuredValues("abcd1234"),
@@ -44,7 +44,7 @@ func TestStatusInfoFromRun(t *testing.T) {
 				},
 			},
 			info: &StatusInfo{
-				Repo:        "some-repo",
+				Repo:        "some-org/some-repo",
 				SHA:         "abcd1234",
 				JobName:     "some-job",
 				State:       "success",
@@ -83,7 +83,7 @@ func TestStatusInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  jobNameKey,
 							Value: *v1beta1.NewStructuredValues("some-job"),
@@ -108,7 +108,7 @@ func TestStatusInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  shaKey,
 							Value: *v1beta1.NewStructuredValues("abcd1234"),
@@ -133,7 +133,7 @@ func TestStatusInfoFromRun(t *testing.T) {
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
-							Value: *v1beta1.NewStructuredValues("some-repo"),
+							Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 						}, {
 							Name:  shaKey,
 							Value: *v1beta1.NewStructuredValues("abcd1234"),
@@ -183,7 +183,7 @@ func TestStatusInfoFromRun(t *testing.T) {
 				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
-						Value: *v1beta1.NewStructuredValues("some-repo"),
+						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
 					}, {
 						Name:  shaKey,
 						Value: *v1beta1.NewStructuredValues("abcd1234"),

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler.go
@@ -10,14 +10,9 @@ import (
 	kreconciler "knative.dev/pkg/reconciler"
 )
 
-const (
-	commentTag = "<!-- Tekton test report -->"
-)
-
 // Reconciler is the core of the implementation of the PR commenter, adding, updating, or deleting comments as needed.
 type Reconciler struct {
 	SCMClient *scm.Client
-	Owner     string
 	BotUser   string
 }
 
@@ -55,7 +50,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1alpha1.Run) kreconc
 		Target: spec.TargetURL,
 	}
 
-	_, _, err := c.SCMClient.Repositories.CreateStatus(ctx, fmt.Sprintf("%s/%s", c.Owner, spec.Repo), spec.SHA, gitRepoStatus)
+	_, _, err := c.SCMClient.Repositories.CreateStatus(ctx, spec.Repo, spec.SHA, gitRepoStatus)
 	if err != nil {
 		r.Status.MarkRunFailed("SCMError", "Error interacting with SCM: %s", err.Error())
 		return err

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler_test.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestReconcile(t *testing.T) {
-	owner := "some-org"
 	sha := "abcd1234"
 	botUser := "k8s-ci-robot"
 
@@ -27,7 +26,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "first status update",
 			info: &StatusInfo{
-				Repo:        "some-repo",
+				Repo:        "some-org/some-repo",
 				SHA:         sha,
 				JobName:     "some-job",
 				State:       "success",
@@ -43,7 +42,7 @@ func TestReconcile(t *testing.T) {
 		}, {
 			name: "replace job",
 			info: &StatusInfo{
-				Repo:      "some-repo",
+				Repo:      "some-org/some-repo",
 				SHA:       sha,
 				JobName:   "some-job",
 				State:     "success",
@@ -62,7 +61,7 @@ func TestReconcile(t *testing.T) {
 		}, {
 			name: "replace job retaining existing other job",
 			info: &StatusInfo{
-				Repo:      "some-repo",
+				Repo:      "some-org/some-repo",
 				SHA:       sha,
 				JobName:   "some-job",
 				State:     "success",
@@ -93,7 +92,6 @@ func TestReconcile(t *testing.T) {
 
 			r := &Reconciler{
 				SCMClient: fakeScmClient,
-				Owner:     owner,
 				BotUser:   botUser,
 			}
 


### PR DESCRIPTION
# Changes

This should hopefully fix whatever was wrong that led to reverting in #1227, since my best guess is that it was something wrong with the new params (probably the new `repoName` specifically). Once this has merged/deployed, I'll do another follow-up PR that un-reverts #1227, tweaked to fit the new configuration.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._