### PR TITLE
Add "images" param to pipeline-in-pod release

### DIFF
--- a/tekton/resources/nightly-release/overlays/pipeline-in-pod/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-in-pod/template.yaml
@@ -15,6 +15,8 @@
           value: $(tt.params.gitrepository)
         - name: gitRevision
           value: $(tt.params.gitrevision)
+        - name: images
+          value: controller
         - name: imageRegistry
           value: $(tt.params.imageRegistry)
         - name: imageRegistryPath


### PR DESCRIPTION
# Changes
This commit adds an "images" parameter to the pipeline-in-pod nightly release pipeline template. Since this custom task has only a controller (no webhook) it can't use the default values for this param (which includes building a webhook).

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._