### PR TITLE
Turn pr-commenter back on, using existing params

### DIFF
--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -105,7 +105,7 @@ spec:
     default: ""
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+    kind: PipelineRun
     metadata:
       name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
@@ -115,28 +115,50 @@ spec:
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
-      serviceAccountName: tekton-ci-jobs
-      podTemplate:
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 1001
-      taskRef:
-        name: github-set-status
-        bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
-      params:
-        - name: REPO_FULL_NAME
-          value: $(tt.params.gitHubRepo)
-        - name: SHA
-          value: $(tt.params.gitRevision)
-        - name: TARGET_URL
-          value: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/$(tt.params.gitHubRepoUnderscore)/$(tt.params.pullRequestNumber)/$(tt.params.checkName)/$(tt.params.buildUUID)
-        - name: DESCRIPTION
-          value: $(tt.params.gitHubCheckDescription)
-        - name: CONTEXT
-          value: $(tt.params.checkName)
-        - name: STATE
-          value: $(tt.params.gitHubCheckStatus)
-        - name: GITHUB_TOKEN_SECRET_NAME
-          value: bot-token-github
-        - name: GITHUB_TOKEN_SECRET_KEY
-          value: bot-token
+      pipelineSpec:
+        tasks:
+        - name: set-status
+          serviceAccountName: tekton-ci-jobs
+          podTemplate:
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+          taskRef:
+            name: github-set-status
+            bundle: gcr.io/tekton-releases/catalog/upstream/github-set-status:0.2
+          params:
+          - name: REPO_FULL_NAME
+            value: $(tt.params.gitHubRepo)
+          - name: SHA
+            value: $(tt.params.gitRevision)
+          - name: TARGET_URL
+            value: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/$(tt.params.gitHubRepoUnderscore)/$(tt.params.pullRequestNumber)/$(tt.params.checkName)/$(tt.params.buildUUID)
+          - name: DESCRIPTION
+            value: $(tt.params.gitHubCheckDescription)
+          - name: CONTEXT
+            value: $(tt.params.checkName)
+          - name: STATE
+            value: $(tt.params.gitHubCheckStatus)
+          - name: GITHUB_TOKEN_SECRET_NAME
+            value: bot-token-github
+          - name: GITHUB_TOKEN_SECRET_KEY
+            value: bot-token
+        - name: comment-on-pr
+          taskRef:
+            apiVersion: custom.tekton.dev/v0
+            kind: PRCommenter
+          params:
+          - name: repo
+            value: $(tt.params.gitHubRepo)
+          - name: prNumber
+            value: $(tt.params.pullRequestNumber)
+          - name: sha
+            value: $(tt.params.gitRevision)
+          - name: jobName
+            value: $(tt.params.checkName)
+          - name: result
+            value: $(tt.params.gitHubCheckStatus)
+          - name: isOptional
+            value: "false"
+          - name: logURL
+            value: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/$(tt.params.gitHubRepoUnderscore)/$(tt.params.pullRequestNumber)/$(tt.params.checkName)/$(tt.params.buildUUID)


### PR DESCRIPTION
# Changes

As it turns out, the problem wasn't the params stuff but that I misformatted the `PipelineRun` in the trigger template. But hey, I still think this is better than needing new param values, so tada.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._