### PR TITLE
Switch ci-job-failure-github-notification trigger and binding to PipelineRun

### DIFF
--- a/tekton/resources/cd/ci-triggers.yaml
+++ b/tekton/resources/cd/ci-triggers.yaml
@@ -57,9 +57,8 @@ spec:
           value: >-
             header.match('ce-type', 'dev.tekton.event.taskrun.failed.v1')
   bindings:
-    - ref: tekton-ci-taskrun-cloudevent
+    - ref: tekton-ci-pipelinerun-cloudevent
     - ref: tekton-ci-check-failure
-    - ref: tekton-ci-taskrun-from-pipelinerun-cloudevent
     - ref: tekton-ci-overlays
   template:
     ref: tekton-ci-github-check-end

--- a/tekton/resources/ci/bindings.yaml
+++ b/tekton/resources/ci/bindings.yaml
@@ -20,6 +20,25 @@ spec:
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerBinding
 metadata:
+  name: tekton-ci-pipelinerun-cloudevent
+spec:
+  params:
+    - name: pullRequestNumber
+      value: $(body.pipelineRun.metadata.labels.tekton\.dev/pr-number)
+    - name: gitRevision
+      value: $(body.pipelineRun.metadata.annotations.tekton\.dev/gitRevision)
+    - name: buildUUID
+      value: $(body.pipelineRun.metadata.labels.prow\.k8s\.io/build-id)
+    - name: checkName
+      value: $(body.pipelineRun.metadata.labels.tekton\.dev/check-name)
+    - name: pipelineRunName
+      value: $(body.pipelineRun.metadata.name)
+    - name: pipelineRunNamespace
+      value: $(body.pipelineRun.metadata.namespace)
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
   name: tekton-ci-check-pending
 spec:
   params:

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -93,16 +93,10 @@ spec:
     description: Can be 'pending', 'success' or 'failure'
   - name: gitHubCheckDescription
     description: A description to be displayed for the status of the check
-  - name: taskRunName
-    description: The name of the task run that triggered this
-  - name: taskRunNamespace
+  - name: pipelineRunName
+    description: The name of the pipeline run that triggered this
+  - name: pipelineRunNamespace
     description: The namespace where the CI job was executed
-  - name: parentPipelineRunName
-    description: The name of the parent pipeline run - if any
-    default: ""
-  - name: parentPipelineRunTaskName
-    description: The name of the task in the parent pipeline run - if any
-    default: ""
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
@@ -111,8 +105,8 @@ spec:
       namespace: tekton-ci
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
-        ci.tekton.dev/source-taskrun-namespace: $(tt.params.taskRunNamespace)
-        ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
+        ci.tekton.dev/source-pipelinerun-namespace: $(tt.params.pipelineRunNamespace)
+        ci.tekton.dev/source-pipelinerun-name: $(tt.params.pipelineRunName)
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
       pipelineSpec:


### PR DESCRIPTION
# Changes

This creates a `PipelineRun` now, not a `TaskRun`, so its expectations in terms of bindings and params are different than for other triggered events.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._