### PR TITLE
Add `-f` to cleanup's `tkn ... delete` calls

### DIFF
--- a/tekton/resources/cd/cleanup-template.yaml
+++ b/tekton/resources/cd/cleanup-template.yaml
@@ -47,9 +47,9 @@ spec:
       fi
 
       # Cleanup pipelineruns first, as this will delete tasksruns too
-      tkn pr delete -n ${NAMESPACE} --keep ${KEEP}
+      tkn pr delete -f -n ${NAMESPACE} --keep ${KEEP}
       # Keep double the amount of tr, for standalone trs
-      tkn tr delete -n ${NAMESPACE} --keep $(( ${KEEP} * 2 ))
+      tkn tr delete -f -n ${NAMESPACE} --keep $(( ${KEEP} * 2 ))
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate


### PR DESCRIPTION
# Changes

Because the `TaskRun`s are currently failing like:

```
Defaulted container "step-cleanup-pr-tr" out of: step-cleanup-pr-tr, prepare (init), place-scripts (init)
+ '[[' 200 -eq 0 -o 200 '=='  ]]
+ tkn pr delete -n default --keep 200
Error: json: cannot unmarshal object into Go value of type []string
Are you sure you want to delete all PipelineRuns in namespace "default" keeping 200 PipelineRuns (y/n): %
```

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._