### PR TITLE
Log errors with SCM client in pr-status-updater

### DIFF
--- a/tekton/ci/custom-tasks/pr-status-updater/config/500-controller.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/config/500-controller.yaml
@@ -76,6 +76,8 @@ spec:
               value: github
             - name: GIT_SERVER
               value: https://github.com
+            - name: GIT_USER
+              value: tekton-robot
             - name: "GIT_TOKEN"
               valueFrom:
                 secretKeyRef:

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler.go
@@ -50,8 +50,10 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1alpha1.Run) kreconc
 		Target: spec.TargetURL,
 	}
 
-	_, _, err := c.SCMClient.Repositories.CreateStatus(ctx, spec.Repo, spec.SHA, gitRepoStatus)
+	logger.Infof("creating status on repo %s for sha %s: %+v", spec.Repo, spec.SHA, gitRepoStatus)
+	_, resp, err := c.SCMClient.Repositories.CreateStatus(ctx, spec.Repo, spec.SHA, gitRepoStatus)
 	if err != nil {
+		logger.Errorf("failure in SCM client: error: %v, headers: %+v", err, resp.Header)
 		r.Status.MarkRunFailed("SCMError", "Error interacting with SCM: %s", err.Error())
 		return err
 	}


### PR DESCRIPTION
# Changes

In dogfooding, it's failing with a "not found" error (which can mean any number of things), but it's working for me locally. I've made a small tweak to the deployment, in case not having `GIT_USER` is causing problems (I don't think it is, but this change matches what's in the configuration for `pr-commenter`), and added some debug logging to better determine what it's actually doing/failing on.

EDIT: Turns out the failure was due to an old version of `pr-status-updater` being installed. Oops. Well, I still think this is worth adding for logging purposes.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._