### PR TITLE
prow: bump kind clusters to 1.23

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1278,7 +1278,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.22.x"
+            - "v1.23.x"
             - "--nodes"
             - "3"
             - "--e2e-script"
@@ -1333,7 +1333,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.22.x"
+            - "v1.23.x"
             - "--nodes"
             - "3"
             - "--e2e-script"


### PR DESCRIPTION

# Changes

This is required for https://github.com/tektoncd/pipeline/pull/5130.
By doing that though, we are not testing on 1.22 anymore which is our min version required, so I am not sure if that's fine or not. https://github.com/tektoncd/pipeline/pull/5130 *will* move the minimum version to 1.23.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._