### PR TITLE
Don't delete/create identical PR comments

### DIFF
--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/reconciler.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"go.uber.org/zap"
@@ -133,6 +134,12 @@ func parseIssueComments(report *ReportInfo, botUser string, ics []*scm.Comment) 
 		createNewComment = true
 		newEntries = append(newEntries, jobEntry)
 	}
+
+	// Don't do anything if the existing entries are identical to the "new" entries.
+	if d := cmp.Diff(entries, newEntries); d == "" {
+		return nil, nil, 0
+	}
+
 	deleteComments = append(deleteComments, previousComments...)
 	if (createNewComment || len(newEntries) == 0) && latestComment != 0 {
 		deleteComments = append(deleteComments, latestComment)


### PR DESCRIPTION
# Changes

This doesn't fix whatever the underlying problem (i.e., events being processed more than once, causing the triggers for a specific `TaskRun` failure to fire periodically) is, and can still result in a single outdated comment being added for a stale event, but it should at least prevent that same single outdated comment from being deleted and recreated over and over again.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._