### PR TITLE
Fix tekton-ci-github-check-start TriggerTemplate for custom task

### DIFF
--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -28,7 +28,7 @@ rules:
   resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["tekton.dev"]
-  resources: ["pipelineruns", "pipelineresources", "taskruns"]
+  resources: ["pipelineruns", "pipelineresources", "taskruns", "runs"]
   verbs: ["create"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]

--- a/tekton/resources/ci/github-template.yaml
+++ b/tekton/resources/ci/github-template.yaml
@@ -32,8 +32,8 @@ spec:
     description: The name of the task in the parent pipeline run - if any
     default: ""
   resourcetemplates:
-  - apiVersion: tekton.dev/v1beta1
-    kind: TaskRun
+  - apiVersion: tekton.dev/v1alpha1
+    kind: Run
     metadata:
       name: $(tt.params.shortSourceEventID)-$(tt.params.checkName)-$(tt.params.gitHubCheckStatus)
       namespace: tekton-ci
@@ -43,7 +43,7 @@ spec:
         ci.tekton.dev/source-taskrun-name: $(tt.params.taskRunName)
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
     spec:
-      taskRef:
+      ref:
         apiVersion: custom.tekton.dev/v0
         kind: PRStatusUpdater
       params:


### PR DESCRIPTION
# Changes

I kinda borked the trigger template in #1234 - it's not a `TaskRun` now, it's a `Run`, and the `triggers` `ClusterRole` needs create permissions for `tekton.dev` `runs`.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._