### PR TITLE
Use cos_containerd image for testing

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -20,7 +20,7 @@
 
 # Default GKE version to be used with Tekton Serving
 readonly SERVING_GKE_VERSION=gke-channel-regular
-readonly SERVING_GKE_IMAGE=cos
+readonly SERVING_GKE_IMAGE=cos_containerd
 
 # Conveniently set GOPATH if unset
 if [[ -z "${GOPATH:-}" ]]; then


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The previously used image, cos, is no longer supported on GKE version 1.24 and later:
https://cloud.google.com/kubernetes-engine/docs/concepts/node-images

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._