### PR TITLE
tektoncd/operator: switch e2e to use kind…

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1080,35 +1080,56 @@ presubmits:
   - name: pull-tekton-operator-integration-tests
     labels:
       preset-presubmit-sh: "true"
+      preset-dind-enable: "true"
+      preset-kind-volume-mounts: "true"
     agent: kubernetes
     always_run: true
     decorate: true
     rerun_command: "/test pull-tekton-operator-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-operator-integration-tests),?(\\s+|$)"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: operator-kind-e2e
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+        cloud.google.com/gke-nodepool: n2-standard-4-kind
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:01bace96516d22d70c092ff9c01f9ffe7af806c7475157dcaa7cdb45d84bd68b # golang 1.18.7
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
         - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://tekton-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "/usr/local/bin/kind-e2e"
+        - "--k8s-version"
+        - "v1.23.x"
+        - "--nodes"
+        - "3"
+        - "--e2e-script"
+        - "./test/e2e-tests-prow.sh"
+        - "--e2e-env"
+        - "./test/e2e-tests-kind-prow.env"
+        securityContext:
+          privileged: true
         resources:
           requests:
-            cpu: 2000m
+            cpu: 3500m
             memory: 4Gi
           limits:
-            cpu: 4000m
+            cpu: 3500m
             memory: 8Gi
   - name: pull-tekton-operator-go-coverage
     labels:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

… similar to other repositories, we are switching e2e tests to be run on kind by default.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/cc @afrittoli @sm43 @abayer 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._