### PR TITLE
Fix operator integration test configuration, cleanup unneeded affinity rules

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1080,7 +1080,7 @@ presubmits:
   - name: pull-tekton-operator-integration-tests
     labels:
       preset-presubmit-sh: "true"
-      preset-dind-enable: "true"
+      preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     agent: kubernetes
     always_run: true
@@ -1088,14 +1088,6 @@ presubmits:
     rerun_command: "/test pull-tekton-operator-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-operator-integration-tests),?(\\s+|$)"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: operator-kind-e2e
-                    operator: Exists
-              topologyKey: kubernetes.io/hostname
       nodeSelector:
         cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
         cloud.google.com/gke-nodepool: n2-standard-4-kind
@@ -1265,21 +1257,12 @@ presubmits:
       preset-presubmit-sh: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      pipeline-kind-e2e: "true"
     agent: kubernetes
     always_run: true
     decorate: true
     rerun_command: "/test pull-tekton-pipeline-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-pipeline-integration-tests),?(\\s+|$)"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: pipeline-kind-e2e
-                    operator: Exists
-              topologyKey: kubernetes.io/hostname
       nodeSelector:
         cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
         cloud.google.com/gke-nodepool: n2-standard-4-kind
@@ -1320,21 +1303,12 @@ presubmits:
       preset-presubmit-sh: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      pipeline-kind-e2e: "true"
     agent: kubernetes
     always_run: true
     decorate: true
     rerun_command: "/test pull-tekton-pipeline-alpha-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-pipeline-alpha-integration-tests),?(\\s+|$)"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: pipeline-kind-e2e
-                    operator: Exists
-              topologyKey: kubernetes.io/hostname
       nodeSelector:
         cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
         cloud.google.com/gke-nodepool: n2-standard-4-kind
@@ -1869,7 +1843,6 @@ periodics:
     preset-presubmit-sh: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    pipeline-kind-e2e: "true"
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -1878,14 +1851,6 @@ periodics:
     base_ref: main
     path_alias: github.com/tektoncd/pipeline
   spec:
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: pipeline-kind-e2e
-                  operator: Exists
-            topologyKey: kubernetes.io/hostname
     nodeSelector:
       cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
       cloud.google.com/gke-nodepool: n2-standard-4-kind


### PR DESCRIPTION
# Changes

Should have been `preset-dind-enabled`, not `preset-dind-enable`. And while I'm here, I'm removing the unneeded anti-affinity rules to make things a bit clearer. Those were from the very early days of the `kind` work to ensure that multiple jobs couldn't end up on the same node before we switched to dedicated nodes of an appropriate size to not be able to have multiple running on them at once.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._