### PR TITLE
Enable pipeline tekton-ci trigger

### DIFF
--- a/tekton/ci/repos/pipeline/template.yaml
+++ b/tekton/ci/repos/pipeline/template.yaml
@@ -4,56 +4,6 @@
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      generateName: pull-pipeline-kind-k8s-v1-21-e2e-
-      labels:
-        prow.k8s.io/build-id: $(tt.params.buildUUID)
-        tekton.dev/source-event-id: $(tt.params.sourceEventId)
-        tekton.dev/kind: ci
-        tekton.dev/check-name: pull-pipeline-kind-k8s-v1-21-e2e
-        tekton.dev/pr-number: $(tt.params.pullRequestNumber)
-      annotations:
-        tekton.dev/gitRevision: "$(tt.params.gitRevision)"
-        tekton.dev/gitURL: "$(tt.params.gitRepository)"
-    spec:
-      serviceAccountName: tekton-ci-jobs
-      workspaces:
-        - name: sources
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-                - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 1Gi
-        - name: credentials
-          secret:
-            secretName: "release-secret"
-      pipelineRef:
-        name: kind-e2e
-      params:
-        - name: pullRequestNumber
-          value: $(tt.params.pullRequestNumber)
-        - name: pullRequestBaseRef
-          value: $(tt.params.pullRequestBaseRef)
-        - name: gitRepository
-          value: "$(tt.params.gitRepository)"
-        - name: gitCloneDepth
-          value: $(tt.params.gitCloneDepth)
-        - name: fileFilterRegex
-          value: '^(cmd/|examples/|images/|pkg/|test/|go\.)'
-        - name: checkName
-          value: pull-pipeline-kind-k8s-v1-21-e2e
-        - name: gitHubCommand
-          value: $(tt.params.gitHubCommand)
-        - name: k8s-version
-          value: v1.21.x
-        - name: e2e-script
-          value: test/e2e-tests.sh
-        - name: e2e-env
-          value: test/e2e-tests-kind.env
-  - apiVersion: tekton.dev/v1beta1
-    kind: PipelineRun
-    metadata:
       generateName: run-go-coverage-
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)

--- a/tekton/ci/repos/pipeline/trigger.yaml
+++ b/tekton/ci/repos/pipeline/trigger.yaml
@@ -1,5 +1,4 @@
 - op: replace
   path: /spec/interceptors/0/params/0/value
   value: >-
-    body.repository.name == 'pipeline' &&
-    body.repository.name == 'wont-match'
+    body.repository.name == 'pipeline'


### PR DESCRIPTION
# Changes

The trigger for pipeline was disable as the only job in the template was not to be executed - kind e2e tests are implemented in prow right now.

Remove the redundant job and re-enable the trigger.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._