### PR TITLE
Use v1 CronJob for Workflows nightly release

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/workflows-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/workflows-nightly/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nightly-cron-trigger


### PR DESCRIPTION
All of our other nightly releases use v1 CronJobs, and it looks like that change was made concurrently with adding a workflows release cronjob, so the workflows cronjob was left out.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._