### PR TITLE
Fix PodSecurity for pr-commenter and pr-status-updater custom tasks

### DIFF
--- a/tekton/ci/custom-tasks/pr-commenter/config/500-controller.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/config/500-controller.yaml
@@ -57,8 +57,15 @@ spec:
           image: ko://github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-commenter/cmd/pr-commenter
           securityContext:
             allowPrivilegeEscalation: false
-            # User 65532 is the distroless nonroot user ID
+            capabilities:
+              drop:
+                - "ALL"
+            # User 65532 is the nonroot user ID
             runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/tekton/ci/custom-tasks/pr-status-updater/config/500-controller.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/config/500-controller.yaml
@@ -57,8 +57,15 @@ spec:
           image: ko://github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-status-updater/cmd/pr-status-updater
           securityContext:
             allowPrivilegeEscalation: false
-            # User 65532 is the distroless nonroot user ID
+            capabilities:
+              drop:
+                - "ALL"
+            # User 65532 is the nonroot user ID
             runAsUser: 65532
+            runAsGroup: 65532
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:


### PR DESCRIPTION
# Changes

Just noticed these weren't working since we upgraded k8s on dogfooding - well, specifically pr-commenter wasn't, because it must have had to recreate its pod since the upgrade, while pr-status-updater was still up. Anyway, here's a fix.

(I manually updated the deployments, but they'll obviously break again until this is merged)

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._