### PR TITLE
make the name shorter to avoid webhook failure

### DIFF
--- a/tekton/ci/repos/pipeline/template.yaml
+++ b/tekton/ci/repos/pipeline/template.yaml
@@ -8,7 +8,7 @@
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         tekton.dev/source-event-id: $(tt.params.sourceEventId)
-        tekton.dev/check-name: pull-tekton-pipeline-go-coverage-using-tekton
+        tekton.dev/check-name: pull-tekton-pipeline-go-coverage-df
         tekton.dev/kind: ci
         tekton.dev/pr-number: $(tt.params.pullRequestNumber)
       annotations:
@@ -36,7 +36,7 @@
         - name: buildUUID
           value: $(tt.params.buildUUID)
         - name: jobName
-          value: pull-tekton-pipeline-go-coverage-using-tekton
+          value: pull-tekton-pipeline-go-coverage-df
         - name: gitHubCommand
           value: $(tt.params.gitHubCommand)
         - name: package


### PR DESCRIPTION
When the prefix and suffix were being added to the name `pull-tekton-pipeline-go-coverage-using-tekton`, the admission web hook was throwing an error that the name was too long (> 63 characters). Renaming this to `pull-tekton-pipeline-go-coverage-df` to ensure that it obeys the character limit.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug