### PR TITLE
renaming token to bot-token

### DIFF
--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -35,6 +35,8 @@ spec:
     - name: covThresholdPercentage
       description: coverage percentage below which to mark the coverage test as failed.
       default: 0
+    - name: githubTokenFile
+      descrtiption: The file within workspace that contains the GitHub token.
   workspaces:
   - name: source
     description: Location where the git repo will be installed.
@@ -71,7 +73,7 @@ spec:
         - "--profile-name=$(params.profileName)"
         - "--cov-target=$(params.covTarget)"
         - "--cov-threshold-percentage=$(params.covThresholdPercentage)"
-        - "--github-token=$(workspaces.github-token.path)/token"
+        - "--github-token=$(workspaces.github-token.path)/$(params.githubTokenFile)"
       workingDir: "$(workspaces.source.path)"
 ---
 apiVersion: tekton.dev/v1beta1
@@ -116,6 +118,8 @@ spec:
       default: 0
     - name: uploadGcsBucket
       description: GCS bucket to upload artifacts to.
+    - name: githubTokenFile
+      descrtiption: The file within workspace that contains the GitHub token.
   workspaces:
     - name: source
       description: Location where the git repo will be installed.
@@ -205,6 +209,8 @@ spec:
           value: $(params.profileName)
         - name: covThresholdPercentage
           value: $(params.covThresholdPercentage)
+        - name: githubTokenFile
+          value: $(params.githubTokenFile)
       workspaces:
         - name: source
           workspace: source

--- a/tekton/ci/repos/pipeline/template.yaml
+++ b/tekton/ci/repos/pipeline/template.yaml
@@ -53,3 +53,5 @@
           value: post-tekton-pipeline-go-coverage
         - name: uploadGcsBucket
           value: tekton-prow
+        - name: githubTokenFile
+          value: bot-token


### PR DESCRIPTION
This PR tries to address issue https://github.com/tektoncd/plumbing/issues/1297.
After looking at some other tasks, it seems like the GitHub token file is named `bot-token`, not `token`. 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._