### PR TITLE
Add interceptor to trigger roles

### DIFF
--- a/tekton/ci/infra/0001_rbac.yaml
+++ b/tekton/ci/infra/0001_rbac.yaml
@@ -7,7 +7,7 @@ rules:
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "interceptors"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns"]

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -7,7 +7,7 @@ rules:
   resources: ["configmaps", "secrets"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "interceptors"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns"]
@@ -23,7 +23,7 @@ metadata:
 rules:
 # EventListeners need to be able to fetch any clustertriggerbindings
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings", "clusterinterceptors"]
+  resources: ["clustertriggerbindings", "clusterinterceptors", "interceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1

--- a/tekton/resources/cd/serviceaccount.yaml
+++ b/tekton/resources/cd/serviceaccount.yaml
@@ -25,7 +25,7 @@ rules:
   resources: ["configmaps"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "interceptors"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["tekton.dev"]
   resources: ["pipelineruns", "pipelineresources", "taskruns", "runs"]

--- a/tekton/resources/nightly-tests/serviceaccount.yaml
+++ b/tekton/resources/nightly-tests/serviceaccount.yaml
@@ -51,7 +51,7 @@ metadata:
   name: tekton-test-triggers-nightly-clusterrole
 rules:
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings", "clusterinterceptors"]
+  resources: ["clustertriggerbindings", "clusterinterceptors", "interceptors"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -73,7 +73,7 @@ metadata:
   name: tekton-test-triggers-nightly
 rules:
 - apiGroups: ["triggers.tekton.dev"]
-  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "interceptors"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["configmaps", "secrets"]


### PR DESCRIPTION
# Changes

After upgrading to triggers v0.22.0, event listeners stopped running, because of interceptors missing in roles

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._