### PR TITLE
Remove usage of TaskLoop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .venv
 
 **/.bin
+**/.DS_Store

--- a/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: tekton-pipelines
 data:
   enable-api-fields: "alpha"
+  embedded-status: "minimal"

--- a/tekton/ci/jobs/tekton-golang-tests.yaml
+++ b/tekton/ci/jobs/tekton-golang-tests.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: custom.tekton.dev/v1alpha1
-kind: TaskLoop
-metadata:
-  name: golang-tests
-spec:
-  iterateParam: context
-  taskRef:
-    name: golang-test
-    bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
----
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
@@ -89,16 +79,17 @@ spec:
         operator: in
         values: ["passed"]
       taskRef:
-        apiVersion: custom.tekton.dev/v1alpha1
-        kind: TaskLoop
-        name: golang-tests
+        name: golang-test
+        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+      matrix:
+        params:
+        - name: context
+          value: [$(params.folders)]
       params:
       - name: package
         value: "$(params.package)"
-      - name: context
-        value: [$(params.folders)]
       - name: version
-        value: "1.15"
+        value: "1.18"
       workspaces:
         - name: source
           workspace: sources

--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -60,15 +60,6 @@ spec:
         --digest-file=${DIGEST_FILE} \
         --no-push
 ---
-apiVersion: custom.tekton.dev/v1alpha1
-kind: TaskLoop
-metadata:
-  name: image-build
-spec:
-  iterateParam: CONTEXT
-  taskRef:
-    name: kaniko4ci
----
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
@@ -148,14 +139,14 @@ spec:
         operator: in
         values: ["passed"]
       taskRef:
-        apiVersion: custom.tekton.dev/v1alpha1
-        kind: TaskLoop
-        name: image-build
+        name: kaniko4ci
+      matrix:
+        params:
+        - name: CONTEXT
+          value: [$(tasks.check-git-files-changed.results.files)]
       params:
       - name: pullRequestNumber
         value: "$(params.pullRequestNumber)"
-      - name: CONTEXT
-        value: $(tasks.check-git-files-changed.results.files)
       workspaces:
         - name: source
           workspace: sources


### PR DESCRIPTION
# Changes

TaskLoop has been superseded by matrix and the taskloop custom controller is not maintained anymore, so remote TaskLoops and replace them with matrix.

Matrix requires minimal embedded status, so enable that too.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._