### PR TITLE
Explicitly specify `kind: ClusterInterceptor` on interceptor references

### DIFF
--- a/tekton/ci/bases/trigger.yaml
+++ b/tekton/ci/bases/trigger.yaml
@@ -10,6 +10,7 @@ spec:
     - name: "Filter by repo"
       ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: filter
           value: >-
@@ -33,6 +34,7 @@ spec:
     - name: "Filter by repo"
       ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: filter
           value: >-
@@ -50,6 +52,7 @@ spec:
     - name: "Add git clone depth"
       ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: overlays
           value:

--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -11,6 +11,7 @@ spec:
         - name: "Validate GitHub payload and filter on eventType"
           ref:
             name: "github"
+            kind: ClusterInterceptor
           params:
             - name: "secretRef"
               value:
@@ -22,6 +23,7 @@ spec:
         - name: "Filter the GitHub org and actions and add git_clone_depth"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -34,6 +36,7 @@ spec:
         - name: "Add a build ID into the payload"
           ref:
             name: "build-id"
+            kind: ClusterInterceptor
       triggerSelector:
         namespaceSelector:
           matchNames:
@@ -46,6 +49,7 @@ spec:
         - name: "Validate GitHub payload and filter on eventType"
           ref:
             name: "github"
+            kind: ClusterInterceptor
           params:
             - name: "secretRef"
               value:
@@ -57,6 +61,7 @@ spec:
         - name: "Filter the GitHub org and actions state text"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -68,6 +73,7 @@ spec:
         - name: "Add a build ID into the payload"
           ref:
             name: "build-id"
+            kind: ClusterInterceptor
       triggerSelector:
         namespaceSelector:
           matchNames:
@@ -80,6 +86,7 @@ spec:
         - name: "Validate GitHub payload and filter on eventType"
           ref:
             name: "github"
+            kind: ClusterInterceptor
           params:
             - name: "secretRef"
               value:
@@ -91,6 +98,7 @@ spec:
         - name: "Filter the GitHub org and actions and add git_clone_depth"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -103,6 +111,7 @@ spec:
         - name: "Add a build ID into the payload"
           ref:
             name: "build-id"
+            kind: ClusterInterceptor
       triggerSelector:
         namespaceSelector:
           matchNames:

--- a/tekton/ci/shared/labels.yaml
+++ b/tekton/ci/shared/labels.yaml
@@ -10,6 +10,7 @@ spec:
     - name: "Filter by repo"
       ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: filter
           value: >-

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -105,6 +105,7 @@ spec:
       interceptors:
         - ref:
             name: github
+            kind: ClusterInterceptor
           params:
             - name: secretRef
               value:

--- a/tekton/resources/cd/ci-triggers.yaml
+++ b/tekton/resources/cd/ci-triggers.yaml
@@ -8,6 +8,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -30,6 +31,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -52,6 +54,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -74,6 +77,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -96,6 +100,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -118,6 +123,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-

--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -22,6 +22,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -37,6 +38,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -52,6 +54,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -66,6 +69,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -81,6 +85,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -95,6 +100,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -114,6 +120,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -139,6 +146,7 @@ spec:
         - name: "Failed TaskRuns"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -161,6 +169,7 @@ spec:
         - name: "Tekton CI Jobs"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -191,6 +200,7 @@ spec:
         - name: "Release Job Triggers"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-

--- a/tekton/resources/cd/notification-triggers.yaml
+++ b/tekton/resources/cd/notification-triggers.yaml
@@ -8,6 +8,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -30,6 +31,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-

--- a/tekton/resources/images/eventlistener.yaml
+++ b/tekton/resources/images/eventlistener.yaml
@@ -10,6 +10,7 @@ spec:
         - name: "Filter if there's no platform"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -24,6 +25,7 @@ spec:
         - name: "Filter if platform and docker build"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-
@@ -41,6 +43,7 @@ spec:
         - name: "Filter if platform and ko build"
           ref:
             name: "cel"
+            kind: ClusterInterceptor
           params:
             - name: "filter"
               value: >-

--- a/tekton/resources/nightly-tests/eventlistener.yaml
+++ b/tekton/resources/nightly-tests/eventlistener.yaml
@@ -9,6 +9,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -24,6 +25,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -39,6 +41,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -54,6 +57,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -69,6 +73,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -84,6 +89,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -99,6 +105,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -114,6 +121,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -129,6 +137,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -144,6 +153,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -159,6 +169,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -174,6 +185,7 @@ spec:
     interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-

--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -60,6 +60,7 @@ spec:
       interceptors:
         - ref:
             name: cel
+            kind: ClusterInterceptor
           params:
             - name: filter
               value: >-

--- a/tekton/resources/release/release-logs/release-logs-triggers.yaml
+++ b/tekton/resources/release/release-logs/release-logs-triggers.yaml
@@ -43,6 +43,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-
@@ -63,6 +64,7 @@ spec:
   interceptors:
     - ref:
         name: cel
+        kind: ClusterInterceptor
       params:
         - name: "filter"
           value: >-


### PR DESCRIPTION
# Changes

Due to https://github.com/tektoncd/triggers/issues/1499, all our event listeners were failing. I've pushed an image of `eventlistenersink` built from https://github.com/abayer/triggers/tree/default-to-clusterinterceptor (just one commit on top of Triggers v0.22.0) that fixes this and configured the `tekton-triggers-controller` deployment to use that image (gcr.io/abayer-jclouds-test1/eventlistenersink-7ad1faa98cddbcb0c24990303b220bb8@sha256:6d7769173bec31635bc9994fa5ffa3ae40c493315bf4ae7cca5aff24d824a889) as its `-el-image` argument, which has gotten everything working again, but if we'd prefer to run vanilla v0.22.0, this PR adds an explicit `kind: ClusterInterceptor` to every interceptor reference I could find, which should have the same effect.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._