### PR TITLE
Upgraded golangci-lint to 1.50.1 (latest).

### DIFF
--- a/tekton/ci/custom-tasks/pr-commenter/Makefile
+++ b/tekton/ci/custom-tasks/pr-commenter/Makefile
@@ -2,7 +2,7 @@ MODULE   = $(shell env GO111MODULE=on $(GO) list -m)
 DATE    ?= $(shell date +%FT%T%z)
 BIN      = $(CURDIR)/.bin
 
-GOLANGCI_VERSION = v1.47.2
+GOLANGCI_VERSION = v1.50.1
 
 GO           = go
 TIMEOUT_UNIT = 5m

--- a/tekton/ci/custom-tasks/pr-commenter/tools/go.mod
+++ b/tekton/ci/custom-tasks/pr-commenter/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-commenter/tools
 
 go 1.18
 
-require github.com/golangci/golangci-lint v1.47.2
+require github.com/golangci/golangci-lint v1.50.1
 
 require (
 	4d63.com/gochecknoglobals v0.1.0 // indirect

--- a/tekton/ci/custom-tasks/pr-status-updater/Makefile
+++ b/tekton/ci/custom-tasks/pr-status-updater/Makefile
@@ -2,7 +2,7 @@ MODULE   = $(shell env GO111MODULE=on $(GO) list -m)
 DATE    ?= $(shell date +%FT%T%z)
 BIN      = $(CURDIR)/.bin
 
-GOLANGCI_VERSION = v1.47.2
+GOLANGCI_VERSION = v1.50.1
 
 GO           = go
 TIMEOUT_UNIT = 5m

--- a/tekton/ci/custom-tasks/pr-status-updater/tools/go.mod
+++ b/tekton/ci/custom-tasks/pr-status-updater/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-commenter/tools
 
 go 1.18
 
-require github.com/golangci/golangci-lint v1.47.2
+require github.com/golangci/golangci-lint v1.50.1
 
 require (
 	4d63.com/gochecknoglobals v0.1.0 // indirect

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -173,7 +173,7 @@ RUN GO111MODULE="on" go install github.com/google/go-licenses@latest && \
     GO111MODULE="on" go install sigs.k8s.io/kind@${KIND_VERSION}
 
 # Install GolangCI linter: https://github.com/golangci/golangci-lint/
-ARG GOLANGCI_VERSION=1.47.2
+ARG GOLANGCI_VERSION=1.50.1
 RUN curl -sL https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xvzf - --strip-components=1 --wildcards "*/golangci-lint"
 
 # Install Kustomize:


### PR DESCRIPTION
# Changes

Upgraded golangci-lint to 1.50.1 (latest).

This will make some new linters (like `dupword`) available; see https://github.com/tektoncd/pipeline/pull/5918.

Context: https://github.com/tektoncd/pipeline/issues/5899

/kind cleanup

# Submitter Checklist

- [N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)