### PR TITLE
Update gubernator and release PipelineRun logs ingest from tkn to use newer dogfooding/tkn image

### DIFF
--- a/tekton/ci/shared/gubernator-metadata.yaml
+++ b/tekton/ci/shared/gubernator-metadata.yaml
@@ -79,7 +79,7 @@ spec:
         value: $(params.pullRequestNumber)
   steps:
     - name: write-data
-      image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
+      image: gcr.io/tekton-releases/dogfooding/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
       workingDir: $(workspaces.shared.path)
       script: |
         #!/usr/bin/env sh
@@ -172,7 +172,7 @@ spec:
         value: $(params.jobStatus)
   steps:
     - name: write-data
-      image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
+      image: gcr.io/tekton-releases/dogfooding/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
       workingDir: $(workspaces.shared.path)
       script: |
         #!/usr/bin/env sh

--- a/tekton/resources/release/release-logs/save-release-logs.yaml
+++ b/tekton/resources/release/release-logs/save-release-logs.yaml
@@ -34,7 +34,7 @@ spec:
         value: $(params.namespace)
   steps:
   - name: write-data
-    image: gcr.io/tekton-releases/dogfooding/tkn:v20220331-17fc70470d@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
+    image: gcr.io/tekton-releases/dogfooding/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
     workingDir: $(workspaces.shared.path)
     script: |
       #!/usr/bin/env sh


### PR DESCRIPTION
# Changes

The previous version of the image, with tkn v0.23.1, generated no output (and may have had a non-zero exit status, I forgot to check) when trying to read `PipelineRun` logs, breaking capturing the logs for Tekton jobs on Dogfooding in Gubernator (or in S3, in the case of the release tooling). So let's switch to the latest nightly image, which uses tkn v0.28.0, since I'm pretty sure this is some compatibility issue with some combination of the Pipelines version we have on Dogfooding (v0.41.0 at the moment) and/or Dogfooding's k8s version (v1.23).

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._