### PR TITLE
Fix perms for custom tasks, revert those custom tasks back to v1alpha1.Runs for now

### DIFF
--- a/tekton/ci/custom-tasks/pr-commenter/README.md
+++ b/tekton/ci/custom-tasks/pr-commenter/README.md
@@ -18,8 +18,8 @@ deployment for that to be reflected in the comment.
 ## Example `Run`
 
 ```yaml
-apiVersion: tekton.dev/v1beta1
-kind: CustomRun
+apiVersion: tekton.dev/v1alpha1
+kind: Run
 metadata:
   name: example-pr-comment
   namespace: tekton-ci

--- a/tekton/ci/custom-tasks/pr-commenter/config/201-clusterrole.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/config/201-clusterrole.yaml
@@ -23,13 +23,13 @@ metadata:
 rules:
   # Controller needs cluster access to all of the CRDs that it is responsible for managing.
   - apiGroups: ["tekton.dev"]
-    resources: ["runs"]
+    resources: ["runs", "customruns"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["runs/finalizers"]
+    resources: ["runs/finalizers", "customruns/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["runs/status"]
+    resources: ["runs/status", "customruns/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
 kind: ClusterRole

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/controller.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/controller.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/jenkins-x/go-scm/scm"
-	runinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/customrun"
-	runreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/customrun"
+	runinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/run"
+	runreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1alpha1/run"
 	tkncontroller "github.com/tektoncd/pipeline/pkg/controller"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/params.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/params.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"knative.dev/pkg/apis"
 )
@@ -63,7 +64,7 @@ type ReportInfo struct {
 }
 
 // ReportInfoFromRun reads params from the given Run and returns either a populated info or errors.
-func ReportInfoFromRun(r *v1beta1.CustomRun) (*ReportInfo, *apis.FieldError) {
+func ReportInfoFromRun(r *v1alpha1.Run) (*ReportInfo, *apis.FieldError) {
 	report := &ReportInfo{}
 	var errs *apis.FieldError
 

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/params_test.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/params_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -11,14 +12,14 @@ import (
 func TestReportInfoFromRun(t *testing.T) {
 	testCases := []struct {
 		name string
-		run  *v1beta1.CustomRun
+		run  *v1alpha1.Run
 		info *ReportInfo
 		err  string
 	}{
 		{
 			name: "valid run",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -56,8 +57,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			},
 		}, {
 			name: "missing repo",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  prNumberKey,
@@ -84,8 +85,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "missing field(s): repo",
 		}, {
 			name: "missing PR number",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -112,8 +113,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "missing field(s): prNumber",
 		}, {
 			name: "missing SHA",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -140,8 +141,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "missing field(s): sha",
 		}, {
 			name: "missing job name",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -168,8 +169,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "missing field(s): jobName",
 		}, {
 			name: "missing result",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -196,8 +197,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "missing field(s): result",
 		}, {
 			name: "non-string value",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
 						Value: *v1beta1.NewStructuredValues("bob", "steve"),
@@ -225,8 +226,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "invalid value: should be a string, is array: repo",
 		}, {
 			name: "non-int value",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
 						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
@@ -254,8 +255,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "invalid value: five should be a number: prNumber",
 		}, {
 			name: "non-bool value",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
 						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),
@@ -283,8 +284,8 @@ func TestReportInfoFromRun(t *testing.T) {
 			err: "invalid value: banana should be a bool: isOptional",
 		}, {
 			name: "invalid result value",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
 						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/reconciler.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/reconciler.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 	kreconciler "knative.dev/pkg/reconciler"
@@ -26,7 +26,7 @@ type Reconciler struct {
 }
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1beta1.CustomRun) kreconciler.Event {
+func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1alpha1.Run) kreconciler.Event {
 	logger := logging.FromContext(ctx)
 	logger.Infof("Reconciling %s/%s", r.Namespace, r.Name)
 
@@ -36,19 +36,19 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1beta1.CustomRun) kr
 		return nil
 	}
 
-	if r.Spec.CustomRef == nil ||
-		r.Spec.CustomRef.APIVersion != "custom.tekton.dev/v0" || r.Spec.CustomRef.Kind != "PRCommenter" {
+	if r.Spec.Ref == nil ||
+		r.Spec.Ref.APIVersion != "custom.tekton.dev/v0" || r.Spec.Ref.Kind != "PRCommenter" {
 		// This is not a Run we should have been notified about; do nothing.
 		return nil
 	}
-	if r.Spec.CustomRef.Name != "" {
-		r.Status.MarkCustomRunFailed("UnexpectedName", "Found unexpected ref name: %s", r.Spec.CustomRef.Name)
-		return fmt.Errorf("unexpected ref name: %s", r.Spec.CustomRef.Name)
+	if r.Spec.Ref.Name != "" {
+		r.Status.MarkRunFailed("UnexpectedName", "Found unexpected ref name: %s", r.Spec.Ref.Name)
+		return fmt.Errorf("unexpected ref name: %s", r.Spec.Ref.Name)
 	}
 
 	spec, err := ReportInfoFromRun(r)
 	if err != nil {
-		r.Status.MarkCustomRunFailed("InvalidParams", "Invalid parameters: %s", err.Error())
+		r.Status.MarkRunFailed("InvalidParams", "Invalid parameters: %s", err.Error())
 		return err
 	}
 
@@ -56,12 +56,12 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1beta1.CustomRun) kr
 	if spec.Result != "pending" {
 		fieldErr := c.reportComment(ctx, spec, logger)
 		if fieldErr != nil {
-			r.Status.MarkCustomRunFailed("SCMError", "Error interacting with SCM: %s", fieldErr.Error())
+			r.Status.MarkRunFailed("SCMError", "Error interacting with SCM: %s", fieldErr.Error())
 			return fieldErr
 		}
 	}
 
-	r.Status.MarkCustomRunSucceeded("Commented", "PR comment successfully added/updated/deleted")
+	r.Status.MarkRunSucceeded("Commented", "PR comment successfully added/updated/deleted")
 
 	// Don't emit events on nop-reconciliations, it causes scale problems.
 	return nil

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/reconciler_test.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -280,14 +281,14 @@ some-job | abcd1234 | [link](http://some/where) | true | ` + "`/test some-job`" 
 	}
 }
 
-func reportInfoToRun(info *ReportInfo) *v1beta1.CustomRun {
-	return &v1beta1.CustomRun{
+func reportInfoToRun(info *ReportInfo) *v1alpha1.Run {
+	return &v1alpha1.Run{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "some-run",
 			Namespace: "foo",
 		},
-		Spec: v1beta1.CustomRunSpec{
-			CustomRef: &v1beta1.TaskRef{
+		Spec: v1alpha1.RunSpec{
+			Ref: &v1beta1.TaskRef{
 				Kind:       "PRCommenter",
 				APIVersion: "custom.tekton.dev/v0",
 			},

--- a/tekton/ci/custom-tasks/pr-status-updater/README.md
+++ b/tekton/ci/custom-tasks/pr-status-updater/README.md
@@ -11,8 +11,8 @@ The `GITHUB_TOKEN` secret is the same GitHub OAuth token used in a number of oth
 ## Example `Run`
 
 ```yaml
-apiVersion: tekton.dev/v1beta1
-kind: CustomRun
+apiVersion: tekton.dev/v1alpha1
+kind: Run
 metadata:
   name: example-pr-status-update
   namespace: tekton-ci

--- a/tekton/ci/custom-tasks/pr-status-updater/config/201-clusterrole.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/config/201-clusterrole.yaml
@@ -23,13 +23,13 @@ metadata:
 rules:
   # Controller needs cluster access to all of the CRDs that it is responsible for managing.
   - apiGroups: ["tekton.dev"]
-    resources: ["runs"]
+    resources: ["runs", "customruns"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["runs/finalizers"]
+    resources: ["runs/finalizers", "customruns/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["runs/status"]
+    resources: ["runs/status", "customruns/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
 kind: ClusterRole

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/controller.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/controller.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/jenkins-x/go-scm/scm"
-	runinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/customrun"
-	runreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/customrun"
+	runinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/run"
+	runreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1alpha1/run"
 	tkncontroller "github.com/tektoncd/pipeline/pkg/controller"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/params.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/params.go
@@ -19,6 +19,7 @@ package reconciler
 import (
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"knative.dev/pkg/apis"
 )
@@ -56,7 +57,7 @@ type StatusInfo struct {
 }
 
 // StatusInfoFromRun reads params from the given Run and returns either a populated info or errors.
-func StatusInfoFromRun(r *v1beta1.CustomRun) (*StatusInfo, *apis.FieldError) {
+func StatusInfoFromRun(r *v1alpha1.Run) (*StatusInfo, *apis.FieldError) {
 	statusInfo := &StatusInfo{}
 	var errs *apis.FieldError
 

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/params_test.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/params_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -11,14 +12,14 @@ import (
 func TestStatusInfoFromRun(t *testing.T) {
 	testCases := []struct {
 		name string
-		run  *v1beta1.CustomRun
+		run  *v1alpha1.Run
 		info *StatusInfo
 		err  string
 	}{
 		{
 			name: "valid run",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -52,8 +53,8 @@ func TestStatusInfoFromRun(t *testing.T) {
 			},
 		}, {
 			name: "missing repo",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  shaKey,
@@ -77,8 +78,8 @@ func TestStatusInfoFromRun(t *testing.T) {
 			err: "missing field(s): repo",
 		}, {
 			name: "missing SHA",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -102,8 +103,8 @@ func TestStatusInfoFromRun(t *testing.T) {
 			err: "missing field(s): sha",
 		}, {
 			name: "missing job name",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -127,8 +128,8 @@ func TestStatusInfoFromRun(t *testing.T) {
 			err: "missing field(s): jobName",
 		}, {
 			name: "missing state",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{
 						{
 							Name:  repoKey,
@@ -152,8 +153,8 @@ func TestStatusInfoFromRun(t *testing.T) {
 			err: "missing field(s): state",
 		}, {
 			name: "non-string value",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
 						Value: *v1beta1.NewStructuredValues("bob", "steve"),
@@ -178,8 +179,8 @@ func TestStatusInfoFromRun(t *testing.T) {
 			err: "invalid value: should be a string, is array: repo",
 		}, {
 			name: "invalid state value",
-			run: &v1beta1.CustomRun{
-				Spec: v1beta1.CustomRunSpec{
+			run: &v1alpha1.Run{
+				Spec: v1alpha1.RunSpec{
 					Params: []v1beta1.Param{{
 						Name:  repoKey,
 						Value: *v1beta1.NewStructuredValues("some-org/some-repo"),

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"knative.dev/pkg/logging"
 	kreconciler "knative.dev/pkg/reconciler"
 )
@@ -17,7 +17,7 @@ type Reconciler struct {
 }
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1beta1.CustomRun) kreconciler.Event {
+func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1alpha1.Run) kreconciler.Event {
 	logger := logging.FromContext(ctx)
 	logger.Infof("Reconciling %s/%s", r.Namespace, r.Name)
 
@@ -27,19 +27,19 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1beta1.CustomRun) kr
 		return nil
 	}
 
-	if r.Spec.CustomRef == nil ||
-		r.Spec.CustomRef.APIVersion != "custom.tekton.dev/v0" || r.Spec.CustomRef.Kind != "PRStatusUpdater" {
+	if r.Spec.Ref == nil ||
+		r.Spec.Ref.APIVersion != "custom.tekton.dev/v0" || r.Spec.Ref.Kind != "PRStatusUpdater" {
 		// This is not a Run we should have been notified about; do nothing.
 		return nil
 	}
-	if r.Spec.CustomRef.Name != "" {
-		r.Status.MarkCustomRunFailed("UnexpectedName", "Found unexpected ref name: %s", r.Spec.CustomRef.Name)
-		return fmt.Errorf("unexpected ref name: %s", r.Spec.CustomRef.Name)
+	if r.Spec.Ref.Name != "" {
+		r.Status.MarkRunFailed("UnexpectedName", "Found unexpected ref name: %s", r.Spec.Ref.Name)
+		return fmt.Errorf("unexpected ref name: %s", r.Spec.Ref.Name)
 	}
 
 	spec, fieldErr := StatusInfoFromRun(r)
 	if fieldErr != nil {
-		r.Status.MarkCustomRunFailed("InvalidParams", "Invalid parameters: %s", fieldErr.Error())
+		r.Status.MarkRunFailed("InvalidParams", "Invalid parameters: %s", fieldErr.Error())
 		return fieldErr
 	}
 
@@ -54,11 +54,11 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1beta1.CustomRun) kr
 	_, resp, err := c.SCMClient.Repositories.CreateStatus(ctx, spec.Repo, spec.SHA, gitRepoStatus)
 	if err != nil {
 		logger.Errorf("failure in SCM client: error: %v, headers: %+v", err, resp.Header)
-		r.Status.MarkCustomRunFailed("SCMError", "Error interacting with SCM: %s", err.Error())
+		r.Status.MarkRunFailed("SCMError", "Error interacting with SCM: %s", err.Error())
 		return err
 	}
 
-	r.Status.MarkCustomRunSucceeded("Commented", "PR status successfully set")
+	r.Status.MarkRunSucceeded("Commented", "PR status successfully set")
 
 	// Don't emit events on nop-reconciliations, it causes scale problems.
 	return nil

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler_test.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,14 +108,14 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func statusInfoToRun(info *StatusInfo) *v1beta1.CustomRun {
-	return &v1beta1.CustomRun{
+func statusInfoToRun(info *StatusInfo) *v1alpha1.Run {
+	return &v1alpha1.Run{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "some-run",
 			Namespace: "foo",
 		},
-		Spec: v1beta1.CustomRunSpec{
-			CustomRef: &v1beta1.TaskRef{
+		Spec: v1alpha1.RunSpec{
+			Ref: &v1beta1.TaskRef{
 				Kind:       "PRStatusUpdater",
 				APIVersion: "custom.tekton.dev/v0",
 			},


### PR DESCRIPTION
# Changes

This is two commits on purpose to make it easier to revert the `CustomRun`->`Run` change later.

First, I added `customruns` to the permissions for the `pr-commenter` and `pr-status-updater` service accounts, which was kinda needed if they're trying to watch `CustomRun`s. =)

But once I fixed that in-cluster manually, I realized that the custom tasks invoked by various triggered `PipelineRun`s for these particular custom tasks...were being generated as `Run`s. That's because the `PipelineRun` reconciler only recently added a feature flag to enable creating `CustomRun`s instead, and that's not switching to the default until v0.44, if I remember correctly. So for now, we need to go back to `Run`s here.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._