### PR TITLE
Apply label_sync to tektoncd-catalog org

### DIFF
--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -18,7 +18,7 @@ spec:
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true
-              - --orgs=tektoncd
+              - --orgs=tektoncd,tektoncd-catalog
               - --token=/etc/github/bot-token
               volumeMounts:
               - name: oauth

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -13,7 +13,7 @@ spec:
           args:
           - --config=/etc/config/labels.yaml
           - --confirm=true
-          - --orgs=tektoncd
+          - --orgs=tektoncd,tektoncd-catalog
           - --token=/etc/github/bot-token
           - --debug=true
           volumeMounts:


### PR DESCRIPTION
Part of [tektoncd-catalog#3][#3]. This commit adds the `tektoncd-catalog` org to the `orgs` parameter of label syncer so that the `tektoncd-catalog` org can automatically maintain the labels as `tektoncd`. There is no change to the `labels.yaml` file itself.

Comma separated orgs based on: https://github.com/kubernetes/test-infra/blob/master/label_sync/main.go#L144

[#3]: https://github.com/tektoncd-catalog/.github/issues/3

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._