### PR TITLE
Fix Typo in tekton-golang-coverage.yaml

### DIFF
--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -219,7 +219,7 @@ spec:
         - name: path
           value: artifacts
         - name: location
-          value: gs://$(params.uploadGcsBucket)/pr-logs/pull/$(tasks.split-full-repo-name.results.repoOwner)_$(tasks.split-full-repo-name.results.repoName)/$(params.pullRequestNumber)/$(params.jobName)/$(params.buildUUID)/artifacts"
+          value: gs://$(params.uploadGcsBucket)/pr-logs/pull/$(tasks.split-full-repo-name.results.repoOwner)_$(tasks.split-full-repo-name.results.repoName)/$(params.pullRequestNumber)/$(params.jobName)/$(params.buildUUID)/artifacts
       workspaces:
         - name: credentials
           workspace: credentials


### PR DESCRIPTION
There was a typo in tekton-golang-coverage.yaml that was creating wrong artifacts directory named `artifacts"` instead of `artifacts`. This PR fixes that typo.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind bug
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._