### PR TITLE
Add an explicit 90m timeout to Pipeline nightly release

### DIFF
--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -23,6 +23,8 @@
           value: $(tt.params.versionTag)
         - name: serviceAccountPath
           value: release.json
+        timeouts:
+          pipeline: 1h30m0s
         workspaces:
           - name: workarea
             volumeClaimTemplate:


### PR DESCRIPTION
# Changes

The Pipeline nightly release `PipelineRun` timed out last night, with the default 60m timeout. A subsequent manually-triggered run succeeded in 51m. This suggests to me that it's not unreasonable to expect that the `PipelineRun` could take over 60m in some cases, so let's set an explicit 90m timeout for it.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._