### PR TITLE
Fix matrix usage in dogfooding

### DIFF
--- a/hack/tekton_in_kind.sh
+++ b/hack/tekton_in_kind.sh
@@ -83,7 +83,7 @@ fi
 
 # Create the kind cluster
 # create a cluster with the local registry enabled in containerd
-running_cluster=$(kind get clusters | grep tekton || true)
+running_cluster=$(kind get clusters | grep "$KIND_CLUSTER_NAME" || true)
 if [ "${running_cluster}" != "$KIND_CLUSTER_NAME" ]; then
  cat <<EOF | kind create cluster --config=-
 kind: Cluster

--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -142,8 +142,9 @@ spec:
         name: kaniko4ci
       matrix:
         params:
-        - name: CONTEXT
-          value: [$(tasks.check-git-files-changed.results.files)]
+          - name: CONTEXT
+            value:
+              - $(tasks.check-git-files-changed.results.files[0])
       params:
       - name: pullRequestNumber
         value: "$(params.pullRequestNumber)"

--- a/tekton/ci/shared/common-tasks.yaml
+++ b/tekton/ci/shared/common-tasks.yaml
@@ -24,16 +24,17 @@ spec:
       description: passed or failed
     - name: files
       description: list of files modified that match
+      type: array
   steps:
     - name: check-files-changed
-      image: alpine/git
+      image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:d6a49b0d6822f4db7ede60d3f6bb41c1278079ad7c631fcaf00a609a977d0ac0 # golang 1.18.7
       env:
       - name: GIT_CLONE_DEPTH
         value: $(params.gitCloneDepth)
       - name: REGEX
         value: $(params.regex)
       script: |
-        #!/bin/sh
+        #!/usr/bin/env bash
         set -ex
         set -o pipefail
 
@@ -41,7 +42,7 @@ spec:
         CHECK="failed"
         cd $(workspaces.input.path)
         git diff-tree --no-commit-id --name-only -r HEAD $BACK | \
-            grep -E "${REGEX}" > $(results.files.path) || true
+            grep -E "${REGEX}" | jq -ncR '[inputs]' > $(results.files.path) || true
         git diff-tree --no-commit-id --name-only -r HEAD $BACK | \
             grep -E "${REGEX}" && CHECK="passed"
         printf $CHECK > $(results.check.path)


### PR DESCRIPTION
# Changes

Matrix does not support array results as inputs yet, so switch to using the first item of the list for now.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._