### PR TITLE
Remove bucket config

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/config-artifact-bucket.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/config-artifact-bucket.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-artifact-bucket
-  namespace: tekton-pipelines
-data:
-  bucket.service.account.field.name: GOOGLE_APPLICATION_CREDENTIALS
-  bucket.service.account.secret.key: release.json
-  bucket.service.account.secret.name: release-secret

--- a/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
@@ -1,7 +1,6 @@
 bases:
 - ../../base
 patchesStrategicMerge:
-- config-artifact-bucket.yaml
 - config-defaults.yaml
 - config-observability.yaml
 - webhook.yaml


### PR DESCRIPTION
# Changes

PipelineResources are not used anymore in dogfooding. The bucket config is incomplete, unused, and it generates a lot of spam in the logs, so removing it.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._