### PR TITLE
Add tektoncd-catalog org under Prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -72,6 +72,19 @@ branch-protection:
           required_status_checks:
             contexts:
             - check-pr-has-kind-label
+    tektoncd-catalog:
+      # Protect all branches in tektoncd-catalog
+      # This means all prow jobs with "always_run" set are required
+      # to pass before tide can merge the PR.
+      # Currently this is manually enabled by the tekton org admins,
+      # but it's stated here for documentation and reference purposes.
+      protect: true
+      # Admins can overrule checks
+      enforce_admins: false
+      # Enforce EasyCLA for all repos
+      required_status_checks:
+        contexts:
+        - EasyCLA
 
 sinker:
   resync_period: 1m
@@ -100,6 +113,7 @@ tide:
     - tektoncd/results
     - tektoncd/triggers
     - tektoncd/website
+    - tektoncd-catalog/golang
     labels:
     - lgtm
     - approved
@@ -129,6 +143,7 @@ tide:
     tektoncd/results: rebase
     tektoncd/triggers: rebase
     tektoncd/website: rebase
+    tektoncd-catalog/golang: rebase
   target_url: https://prow.tekton.dev/tide
   priority:
   - labels: ["kind/flake", "priority/critical-urgent"]

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -15,12 +15,37 @@
 approve:
 - repos:
   - tektoncd
+  - tektoncd-catalog
   require_self_approval: true
   ignore_review_state: false
   commandHelpLink: https://prow.tekton.dev/command-help
 
 plugins:
   tektoncd:
+    plugins:
+      - approve
+      - assign
+      - blunderbuss
+      - buildifier
+      - cat
+      - dog
+      - golint
+      - heart
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - milestone
+      - project
+      - retitle
+      - size
+      - skip
+      - trigger
+      - verify-owners
+      - wip
+      - yuks
+  tektoncd-catalog:
     plugins:
       - approve
       - assign
@@ -59,6 +84,11 @@ plugins:
 
 external_plugins:
   tektoncd:
+  - name: needs-rebase
+    events:
+      - issue_comment
+      - pull_request
+  tektoncd-catalog:
   - name: needs-rebase
     events:
       - issue_comment


### PR DESCRIPTION
This commit adds `tektoncd-catalog` org to `prow/config.yaml` and `prow/plugins.yaml` files. It applies the same configuration to `tektoncd-catalog` as `tektoncd` org to achieve the same level of automation and administration.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._