### PR TITLE
Migrate bundles to new syntax

### DIFF
--- a/tekton/ci/cluster-interceptors/add-pr-body/tekton/release-pipeline.yaml
+++ b/tekton/ci/cluster-interceptors/add-pr-body/tekton/release-pipeline.yaml
@@ -48,8 +48,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: workarea
@@ -62,8 +68,14 @@ spec:
     - name: unit-tests
       runAfter: [git-clone]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -74,8 +86,14 @@ spec:
     - name: build
       runAfter: [git-clone]
       taskRef:
-        name: golang-build
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -116,8 +134,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -138,8 +162,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/cluster-interceptors/build-id/tekton/release-pipeline.yaml
+++ b/tekton/ci/cluster-interceptors/build-id/tekton/release-pipeline.yaml
@@ -48,8 +48,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: workarea
@@ -62,8 +68,14 @@ spec:
     - name: unit-tests
       runAfter: [git-clone]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -74,8 +86,14 @@ spec:
     - name: build
       runAfter: [git-clone]
       taskRef:
-        name: golang-build
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -116,8 +134,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -138,8 +162,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/custom-tasks/pr-commenter/tekton/release-pipeline.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/tekton/release-pipeline.yaml
@@ -48,8 +48,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: workarea
@@ -62,8 +68,14 @@ spec:
     - name: unit-tests
       runAfter: [git-clone]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -74,8 +86,14 @@ spec:
     - name: build
       runAfter: [git-clone]
       taskRef:
-        name: golang-build
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-build:0.3
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -116,8 +134,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -138,8 +162,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/custom-tasks/pr-status-updater/tekton/release-pipeline.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/tekton/release-pipeline.yaml
@@ -48,8 +48,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: workarea
@@ -62,8 +68,14 @@ spec:
     - name: unit-tests
       runAfter: [git-clone]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -74,8 +86,14 @@ spec:
     - name: build
       runAfter: [git-clone]
       taskRef:
-        name: golang-build
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-build:0.3
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -116,8 +134,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -138,8 +162,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/interceptors/add-pr-body/tekton/release-pipeline.yaml
+++ b/tekton/ci/interceptors/add-pr-body/tekton/release-pipeline.yaml
@@ -48,8 +48,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: workarea
@@ -62,8 +68,14 @@ spec:
     - name: unit-tests
       runAfter: [git-clone]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -74,8 +86,14 @@ spec:
     - name: build
       runAfter: [git-clone]
       taskRef:
-        name: golang-build
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -116,8 +134,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -138,8 +162,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/interceptors/add-team-members/tekton/release-pipeline.yaml
+++ b/tekton/ci/interceptors/add-team-members/tekton/release-pipeline.yaml
@@ -48,8 +48,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.3
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: workarea
@@ -62,8 +68,14 @@ spec:
     - name: unit-tests
       runAfter: [git-clone]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.1
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -74,8 +86,14 @@ spec:
     - name: build
       runAfter: [git-clone]
       taskRef:
-        name: golang-build
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-build:0.1
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
       params:
         - name: package
           value: $(params.package)/$(params.subfolder)
@@ -116,8 +134,14 @@ spec:
     - name: publish-to-bucket
       runAfter: [publish-images]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret
@@ -138,8 +162,14 @@ spec:
           operator: in
           values: ["true"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       workspaces:
         - name: credentials
           workspace: release-secret

--- a/tekton/ci/jobs/e2e-kind.yaml
+++ b/tekton/ci/jobs/e2e-kind.yaml
@@ -134,8 +134,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)
@@ -199,8 +205,14 @@ spec:
   finally:
     - name: upload-logs
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.1
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       params:
         - name: path
           value: artifacts

--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -121,8 +121,14 @@ spec:
           operator: in
           values: ["passed"]
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: source
@@ -155,8 +161,14 @@ spec:
           operator: in
           values: ["passed"]
       taskRef:
-        name: github-add-comment
-        bundle: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.3
+          - name: name
+            value: github-add-comment
+          - name: kind
+            value: task
       params:
         - name: COMMENT_OR_FILE
           value: "catlin.txt"

--- a/tekton/ci/jobs/tekton-catalog-diff-task.yaml
+++ b/tekton/ci/jobs/tekton-catalog-diff-task.yaml
@@ -18,8 +18,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       workspaces:
         - name: output
           workspace: source
@@ -36,8 +42,14 @@ spec:
       runAfter:
         - clone-repo
       taskRef:
-        name: git-cli
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-cli:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-cli:0.3
+          - name: name
+            value: git-cli
+          - name: kind
+            value: task
       workspaces:
         - name: source
           workspace: source
@@ -94,8 +106,14 @@ spec:
           operator: notin
           values: [""]
       taskRef:
-        name: github-add-comment
-        bundle: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/github-add-comment:0.3
+          - name: name
+            value: github-add-comment
+          - name: kind
+            value: task
       params:
         - name: COMMENT_OR_FILE
           value: diff-task-results.txt

--- a/tekton/ci/jobs/tekton-docs-reviews.yaml
+++ b/tekton/ci/jobs/tekton-docs-reviews.yaml
@@ -28,8 +28,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)
@@ -62,8 +68,14 @@ spec:
         operator: in
         values: ["passed"]
       taskRef:
-        name: github-request-reviewers
-        bundle: gcr.io/tekton-releases/catalog/upstream/github-request-reviewers:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/github-request-reviewers:0.1
+          - name: name
+            value: github-request-reviewers
+          - name: kind
+            value: task
       params:
       - name: PACKAGE
         value: "$(params.package)"

--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -164,8 +164,14 @@ spec:
     - name: clone-repo
       runAfter: ['split-full-repo-name']
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: https://github.com/$(tasks.split-full-repo-name.results.repoOwner)/$(tasks.split-full-repo-name.results.repoName).git
@@ -219,8 +225,14 @@ spec:
     - name: upload-artifacts
       runAfter: ['run-go-coverage']
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       params:
         - name: path
           value: artifacts

--- a/tekton/ci/jobs/tekton-golang-lint.yaml
+++ b/tekton/ci/jobs/tekton-golang-lint.yaml
@@ -44,8 +44,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)
@@ -91,8 +97,14 @@ spec:
           operator: in
           values: ["passed"]
       taskRef:
-        name: golangci-lint
-        bundle: gcr.io/tekton-releases/catalog/upstream/golangci-lint:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golangci-lint:0.2
+          - name: name
+            value: golangci-lint
+          - name: kind
+            value: task
       workspaces:
         - name: input
           workspace: sources

--- a/tekton/ci/jobs/tekton-golang-tests.yaml
+++ b/tekton/ci/jobs/tekton-golang-tests.yaml
@@ -34,8 +34,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)
@@ -79,8 +85,14 @@ spec:
         operator: in
         values: ["passed"]
       taskRef:
-        name: golang-test
-        bundle: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/golang-test:0.2
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
       matrix:
         params:
         - name: context

--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -94,8 +94,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/ci/jobs/tekton-org-validation.yaml
+++ b/tekton/ci/jobs/tekton-org-validation.yaml
@@ -55,8 +55,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/ci/jobs/tekton-python-unit-tests.yaml
+++ b/tekton/ci/jobs/tekton-python-unit-tests.yaml
@@ -30,8 +30,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)
@@ -75,8 +81,14 @@ spec:
         operator: in
         values: ["passed"]
       taskRef:
-        name: pytest
-        bundle: gcr.io/tekton-releases/catalog/upstream/pytest:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/pytest:0.1
+          - name: name
+            value: pytest
+          - name: kind
+            value: task
       params:
       - name: SOURCE_PATH
         value: "$(params.path)"

--- a/tekton/ci/jobs/tekton-teps-validation.yaml
+++ b/tekton/ci/jobs/tekton-teps-validation.yaml
@@ -52,8 +52,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-batch-merge
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
+          - name: name
+            value: git-batch-merge
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/ci/shared/gubernator-metadata.yaml
+++ b/tekton/ci/shared/gubernator-metadata.yaml
@@ -255,8 +255,14 @@ spec:
     - name: upload-data
       runAfter: ["create-data"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       params:
         - name: path
           value: "."
@@ -321,8 +327,14 @@ spec:
     - name: upload-data
       runAfter: ["create-data"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       params:
         - name: path
           value: "."

--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -107,8 +107,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -145,8 +145,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       params:
         - name: url
           value: $(params.gitRepository)

--- a/tekton/resources/cd/install-tekton-release.yaml
+++ b/tekton/resources/cd/install-tekton-release.yaml
@@ -154,8 +154,14 @@ spec:
   tasks:
     - name: git-clone
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       params:
         - name: url
           value: https://$(params.gitRepository)
@@ -173,8 +179,14 @@ spec:
           operator: notin
           values: ["latest"]
       taskRef:
-        name: gcs-download
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+          - name: name
+            value: gcs-download
+          - name: kind
+            value: task
       params:
         - name: path
           value: release
@@ -194,8 +206,14 @@ spec:
           operator: in
           values: ["latest"]
       taskRef:
-        name: gcs-download
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+          - name: name
+            value: gcs-download
+          - name: kind
+            value: task
       params:
         - name: path
           value: release

--- a/tekton/resources/cd/notification-template.yaml
+++ b/tekton/resources/cd/notification-template.yaml
@@ -36,8 +36,14 @@ spec:
       name: $(tt.params.nameAndNamespace)-slack
     spec:
       taskRef:
-        name: send-to-webhook-slack
-        bundle: gcr.io/tekton-releases/catalog/upstream/send-to-webhook-slack:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/send-to-webhook-slack:0.1
+          - name: name
+            value: send-to-webhook-slack
+          - name: kind
+            value: task
       params:
         - name: webhook-secret
           value: robocat-slack-app-webhook

--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -311,8 +311,14 @@ spec:
   tasks:
     - name: clone-repo
       taskRef:
-        name: git-clone
-        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.5
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/git-clone:0.5
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
       params:
         - name: url
           value: https://github.com/$(params.package)
@@ -324,8 +330,14 @@ spec:
           subPath: repo
     - name: clone-bucket
       taskRef:
-        name: gcs-download
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-download:0.1
+          - name: name
+            value: gcs-download
+          - name: kind
+            value: task
       params:
         - name: path
           value: .

--- a/tekton/resources/release/release-logs/save-release-logs.yaml
+++ b/tekton/resources/release/release-logs/save-release-logs.yaml
@@ -80,8 +80,14 @@ spec:
     - name: upload-data
       runAfter: ["collect-logs"]
       taskRef:
-        name: gcs-upload
-        bundle: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+        resolver: bundles
+        params:
+          - name: bundle
+            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
+          - name: name
+            value: gcs-upload
+          - name: kind
+            value: task
       params:
         - name: path
           value: "logs.txt"


### PR DESCRIPTION
# Changes

Legacy bundles are not supported in v0.44.0.
Conversion should migrate automatically to the remote resolution syntax, but due to a bug it doesn't work:
- https://github.com/tektoncd/pipeline/issues/6058

Migrate all bundle references to the new format to avoid the issue in the convertion.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._