### PR TITLE
Configure the git resolver with the GitHub API token

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/git-resolver-config.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/git-resolver-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-resolver-config
+  namespace: tekton-pipelines-resolvers
+data:
+  api-token-secret-key: GITHUB_TOKEN
+  api-token-secret-name: github-token
+  api-token-secret-namespace: default
+  default-org: ""
+  default-revision: main
+  default-url: https://github.com/tektoncd/catalog.git
+  fetch-timeout: 1m
+  scm-type: github
+  server-url: ""

--- a/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
@@ -7,3 +7,4 @@ patchesStrategicMerge:
 - webhook.yaml
 - controller.yaml
 - feature-flags.yaml
+- git-resolver-config.yaml


### PR DESCRIPTION
# Changes

I'm not 100% sure if this is right - specifically, this is trying to write to the `git-resolver-config` `ConfigMap` in the `tekton-pipelines-resolvers` namespace, but I put it in the same directory as the rest of the pipelines overlays. @afrittoli - I _think_ this should work correctly, but I defer to you. =)

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._