### PR TITLE
Add golang verified catalog build test infra

### DIFF
--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -16,6 +16,9 @@ spec:
   params:
     - name: gitCloneDepth
       description: Number of commits in the change + 1
+    - name: versioning
+      description: The versioning strategy of the catalog, either "git" or "directory"
+      default: git
   steps:
     - name: find-changed-tasks
       image: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
@@ -54,7 +57,7 @@ spec:
         echo '```' >> catlin.txt
 
         # performing catlin validate
-        catlin validate $(cat changed-files.txt) | tee -a catlin.txt
+        catlin validate $(cat changed-files.txt) --versioning $(params.versioning) | tee -a catlin.txt
         echo '```' >> catlin.txt
         echo "</details>" >> catlin.txt
 
@@ -106,6 +109,9 @@ spec:
       description: The pull request base branch
     - name: pullRequestNumber
       description: The pullRequestNumber
+    - name: versioning
+      description: The versioning strategy of the catalog, either "git" or "directory"
+      default: git
   tasks:
     - name: check-name-match
       taskRef:
@@ -154,6 +160,8 @@ spec:
       params:
         - name: gitCloneDepth
           value: $(params.gitCloneDepth)
+        - name: versioning
+          value: $(params.versioning)
   finally:
     - name: post-comment
       when:

--- a/tekton/ci/repos/catalog/base/kustomization.yaml
+++ b/tekton/ci/repos/catalog/base/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../../../bases
+
+patches:
+  - path: template.yaml
+    target:
+      group: triggers.tekton.dev
+      version: v1beta1
+      kind: TriggerTemplate
+      name: ci-pipeline

--- a/tekton/ci/repos/catalog/base/template.yaml
+++ b/tekton/ci/repos/catalog/base/template.yaml
@@ -9,7 +9,6 @@
           prow.k8s.io/build-id: $(tt.params.buildUUID)
           tekton.dev/source-event-id: $(tt.params.sourceEventId)
           tekton.dev/kind: ci
-          tekton.dev/check-name: pull-catalog-catlin-lint
           tekton.dev/pr-number: $(tt.params.pullRequestNumber)
         annotations:
           tekton.dev/gitRevision: "$(tt.params.gitRevision)"

--- a/tekton/ci/repos/catalog/community-catalog/kustomization.yaml
+++ b/tekton/ci/repos/catalog/community-catalog/kustomization.yaml
@@ -1,0 +1,16 @@
+namePrefix: tekton-catalog-
+bases:
+  - ../base
+
+patches:
+  - path: template.yaml
+    target:
+      group: triggers.tekton.dev
+      version: v1beta1
+      kind: TriggerTemplate
+      name: ci-pipeline
+  - path: trigger.yaml
+    target:
+      group: triggers.tekton.dev
+      version: v1beta1
+      kind: Trigger

--- a/tekton/ci/repos/catalog/community-catalog/template.yaml
+++ b/tekton/ci/repos/catalog/community-catalog/template.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/resourcetemplates/0/spec/params/0
+  value: 
+    name: versioning
+    value: directory
+- op: add
+  path: /spec/resourcetemplates/0/metadata/labels/tekton.dev~1check-name
+  value: pull-catalog-catlin-lint

--- a/tekton/ci/repos/catalog/community-catalog/trigger.yaml
+++ b/tekton/ci/repos/catalog/community-catalog/trigger.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /spec/interceptors/0/params/0/value
+  value: >-
+    body.repository.name == 'catalog'

--- a/tekton/ci/repos/catalog/verified-catalogs/base/kustomization.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/base/kustomization.yaml
@@ -1,6 +1,6 @@
-namePrefix: tekton-catalog-
+namePrefix: tekton-verified-catalog-
 bases:
-  - ../../bases
+  - ../../base
 
 patches:
   - path: template.yaml
@@ -9,8 +9,3 @@ patches:
       version: v1beta1
       kind: TriggerTemplate
       name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger

--- a/tekton/ci/repos/catalog/verified-catalogs/base/template.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/base/template.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/resourcetemplates/0/spec/params/0
+  value: 
+    name: versioning
+    value: git
+- op: add
+  path: /spec/resourcetemplates/0/metadata/labels/tekton.dev~1check-name
+  value: pull-tekton-catalog-build-tests

--- a/tekton/ci/repos/catalog/verified-catalogs/golang/kustomization.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/golang/kustomization.yaml
@@ -1,0 +1,10 @@
+namePrefix: golang-
+bases:
+  - ../base
+
+patches:
+  - path: trigger.yaml
+    target:
+      group: triggers.tekton.dev
+      version: v1beta1
+      kind: Trigger

--- a/tekton/ci/repos/catalog/verified-catalogs/golang/trigger.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/golang/trigger.yaml
@@ -1,4 +1,4 @@
 - op: replace
   path: /spec/interceptors/0/params/0/value
   value: >-
-    body.repository.name == 'catalog'
+    body.repository.name == 'golang'

--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -27,7 +27,8 @@ spec:
           params:
             - name: "filter"
               value: >-
-                body.repository.full_name.startsWith('tektoncd/') &&
+                (body.repository.full_name.startsWith('tektoncd/') || 
+                (body.repository.full_name.startsWith('tektoncd-catalog/')) &&
                 body.action in ['opened', 'synchronize', 'reopened']
             - name: "overlays"
               value:
@@ -65,7 +66,8 @@ spec:
           params:
             - name: "filter"
               value: >-
-                body.repository.full_name.startsWith('tektoncd/') &&
+                (body.repository.full_name.startsWith('tektoncd/') || 
+                (body.repository.full_name.startsWith('tektoncd-catalog/')) &&
                 body.action == 'created' &&
                 'pull_request' in body.issue &&
                 body.issue.state == 'open' &&


### PR DESCRIPTION
This commit adds the required build test infra for the [golang][golang] verified catalog. The functionalities for the [tektoncd/catalog][catalog] repo are unchanged.

Changes include:
- Add an extra `versioning` param to the `catlin-lint` pipeline and task to support both git-based versioning and directory-based versioning path validation
- Update the `eventlistener.yaml` to accept webhook events from both `tektoncd` and `tektoncd-catalog` orgs
- Refactored the directory structure for `/tekton/ci/repos/catalog`, creating sub-directory `verified-catalog` for verified catalog and `community-catalog` for the current [tektoncd/catalog][catalog] repo.

[golang]: https://github.com/tektoncd-catalog/golang
[catalog]: https://github.com/tektoncd/catalog

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._