### PR TITLE
Revert "Migrate Triggers e2e test to kind"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1738,58 +1738,29 @@ presubmits:
   - name: pull-tekton-triggers-integration-tests
     labels:
       preset-presubmit-sh: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      pipeline-kind-e2e: "true"
     agent: kubernetes
     always_run: true
     decorate: true
     rerun_command: "/test pull-tekton-triggers-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-triggers-integration-tests),?(\\s+|$)"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: pipeline-kind-e2e
-                    operator: Exists
-              topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-        cloud.google.com/gke-nodepool: n2-standard-4-kind
-      tolerations:
-        - key: kind-only
-          operator: Equal
-          value: "true"
-          effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:d6a49b0d6822f4db7ede60d3f6bb41c1278079ad7c631fcaf00a609a977d0ac0 # golang 1.18.7
-          imagePullPolicy: Always
-          command:
-            - /usr/local/bin/entrypoint.sh
-          args:
-            - "--service-account=/etc/test-account/service-account.json"
-            - "--" # end bootstrap args, scenario args below
-            - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-            - "/usr/local/bin/kind-e2e"
-            - "--k8s-version"
-            - "v1.23.x"
-            - "--nodes"
-            - "3"
-            - "--e2e-script"
-            - "./test/e2e-tests.sh"
-            - "--e2e-env"
-            - "./test/e2e-tests-kind-prow.env"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 3500m
-              memory: 4Gi
-            limits:
-              cpu: 3500m
-              memory: 8Gi
+      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:d6a49b0d6822f4db7ede60d3f6bb41c1278079ad7c631fcaf00a609a977d0ac0 # golang 1.18.7
+        imagePullPolicy: Always
+        command:
+        - /usr/local/bin/entrypoint.sh
+        args:
+        - "--scenario=kubernetes_execute_bazel"
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--service-account=/etc/test-account/service-account.json"
+        - "--upload=gs://tekton-prow/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
+        - "./test/presubmit-tests.sh"
+        - "--integration-tests"
   - name: pull-tekton-triggers-go-coverage
     labels:
       preset-github-token: "true"


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

This reverts commit 89106702e317eb026cd895df6aeab28350eb9d18.

We had some new test failures once we switched to kind.

Temporary till we fix tektoncd/triggers#1519

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._