### PR TITLE
Remove `embedded-status` feature flag

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1362,8 +1362,6 @@ presubmits:
           env:
             - name: PIPELINE_FEATURE_GATE
               value: "alpha"
-            - name: EMBEDDED_STATUS_GATE
-              value: "minimal"
   - name: pull-tekton-pipeline-beta-integration-tests
     labels:
       preset-presubmit-sh: "true"

--- a/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: tekton-pipelines
 data:
   enable-api-fields: "alpha"
-  embedded-status: "minimal"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit removes the `embedded-status` feature flag config for the dogfooding cluster
and the prow env setup.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._