### PR TITLE
Patch missing kustomization files for verified catalog build tests

### DIFF
--- a/tekton/ci/repos/catalog/kustomization.yaml
+++ b/tekton/ci/repos/catalog/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - community-catalog
+  - verified-catalogs

--- a/tekton/ci/repos/catalog/verified-catalogs/kustomization.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - golang


### PR DESCRIPTION
Prior to this change, the `kustomization.yaml` files are missing in the `tekton/ci/repos/catalog/` and the underlying `verified-catalog/` directories. It caused error when running `kustomize build` command from `tekton/` directory. 

This commit adds the missing kustomization files for [#1334][#1334] ([error log][error log]).

/kind bug

[#1334]: https://github.com/tektoncd/plumbing/pull/1334
[error log]: https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns/deploy-resources-tekton-49vpr?pipelineTask=deploy&step=deploy-from-folder

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._