### PR TITLE
Fix extra open parenthesis in the event listener

### DIFF
--- a/tekton/ci/shared/eventlistener.yaml
+++ b/tekton/ci/shared/eventlistener.yaml
@@ -28,7 +28,7 @@ spec:
             - name: "filter"
               value: >-
                 (body.repository.full_name.startsWith('tektoncd/') || 
-                (body.repository.full_name.startsWith('tektoncd-catalog/')) &&
+                body.repository.full_name.startsWith('tektoncd-catalog/')) &&
                 body.action in ['opened', 'synchronize', 'reopened']
             - name: "overlays"
               value:
@@ -67,7 +67,7 @@ spec:
             - name: "filter"
               value: >-
                 (body.repository.full_name.startsWith('tektoncd/') || 
-                (body.repository.full_name.startsWith('tektoncd-catalog/')) &&
+                body.repository.full_name.startsWith('tektoncd-catalog/')) &&
                 body.action == 'created' &&
                 'pull_request' in body.issue &&
                 body.issue.state == 'open' &&


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the extra open parenthesis issue in the event listener.

/kind bug


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._