### PR TITLE
Add "-post-comment" filter to "ci-job-triggers" trigger group

### DIFF
--- a/tekton/resources/cd/eventlistener.yaml
+++ b/tekton/resources/cd/eventlistener.yaml
@@ -179,6 +179,7 @@ spec:
                 (body.taskRun.metadata.name.indexOf('-check-') == -1) &&
                 (body.taskRun.metadata.name.indexOf('-clone-repo') == -1) &&
                 (body.taskRun.metadata.name.indexOf('-git-clone') == -1) &&
+                (body.taskRun.metadata.name.indexOf('-post-comment') == -1) &&
                 'ownerReferences' in body.taskRun.metadata
             - name: "overlays"
               value:


### PR DESCRIPTION
Prior to this commit, the cloud events triggered by [post-comment][post-comment] pipeline task pass the `ci-job-triggers` trigger group filter. This causes the corresponding github checks to pass even though the [lint-catalog][lint-catalog] is failed. This commit updates the filter for `post-comment` task run which blocks it from updating github checks.

/kind bug

[lint-catalog]: https://github.com/tektoncd/plumbing/blob/7a844829fdffe75a8fcb0b18b1411776b059ec62/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml#L152
[post-comment]: https://github.com/tektoncd/plumbing/blob/7a844829fdffe75a8fcb0b18b1411776b059ec62/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml#L166

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._