### PR TITLE
Switch Kind Cluster to v1.24.X for Beta Integration Test

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1401,7 +1401,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.23.x"
+            - "v1.24.x"
             - "--nodes"
             - "3"
             - "--e2e-script"


### PR DESCRIPTION
# Changes

Switch Kind Cluster to v1.24.X for Beta Integration Test. Last piece of version switching for kind cluster (https://github.com/tektoncd/plumbing/pull/1332)

Signed-off-by: Xinru Zhang [xinruzhang@google.com](mailto:xinruzhang@google.com)

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._