### PR TITLE
fix: ignore unknown/unknown platform in cmd/combine

### DIFF
--- a/cmd/combine/main.go
+++ b/cmd/combine/main.go
@@ -64,6 +64,11 @@ func main() {
 			if desc.Platform == nil {
 				return fmt.Errorf("found nil platform for manifest %s", desc.Digest)
 			}
+			// skip unknown platforms.
+			// Docker uses these to store attestation data: https://docs.docker.com/build/attestations/attestation-storage/#examples
+			if desc.Platform.OS == "unknown" || desc.Platform.Architecture == "unknown" {
+				continue
+			}
 			b, err := json.Marshal(desc.Platform)
 			if err != nil {
 				return fmt.Errorf("marshalling platform: %w", err)


### PR DESCRIPTION
To avoid a similar future issue to https://github.com/tektoncd/pipeline/pull/6260, ignore `unknown/unknown` which buildkit might start injecting into index manifests in the future.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._


PR friction log:
- I forgot to set a `/kind` at first and CI failed; I edited the description to set `/kind` but the label didn't show up, and `/test` didn't rerun the check.
- unit tests failed immediately, but the link goes to a Prow page that says the test has been running for 36 minutes with no link to logs that I can find. `/test` also didn't rerun the check.