### PR TITLE
increase TaskRunTimeout for s390x dashboard tasks

### DIFF
--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -32,7 +32,6 @@ spec:
       namespace: $(tt.params.namespace)
     spec:
       timeout:
-        pipeline: "3h4m0s"
         tasks: "2h0m0s"
       workspaces:
       # this workspace will be used to share info between tasks

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -31,7 +31,9 @@ spec:
       generateName: tekton-dashboard-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout:
+        pipeline: "3h4m0s"
+        tasks: "2h0m0s"
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace


### PR DESCRIPTION
e2e-dashboard tests are running in docker-in-docker. its taking long time to complete. so increase task and pipeline run timeout for s390x tekton dashboard jobs.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._