### PR TITLE
Remove resource test in cli

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
@@ -47,7 +47,7 @@ spec:
     - |
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       go build -o tkn $(params.package)/cmd/tkn
-      for testsuite in clustertask eventlistener pipeline pipelinerun resource task; do
+      for testsuite in clustertask eventlistener pipeline pipelinerun plugin task; do
         header "Running Go $(params.tags) ${testsuite} tests"
         report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite}
       done


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

PipelineResource is deprecated in latest release of pipelines. Skipping 'resource' tests while running cli e2e tests and added new 'plugin' related to tests. https://github.com/tektoncd/pipeline/pull/6150.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._