### PR TITLE
fix pipelines ci failures due to push permissions

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
@@ -7,6 +7,9 @@ spec:
   - name: k8s-shared
     description: workspace to get k8s config file
     mountPath: /root/.kube
+  - name: registry-shared
+    description: workspace for docker config
+    mountPath: /root/.docker
   - name: source-code
     description: workspace with source code for tekton component
     mountPath: /workspace

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
@@ -25,6 +25,9 @@ spec:
   - name: k8s-shared
     description: workspace for k8s config, configuration file is expected to have `config` name
     mountPath: /root/.kube
+  - name: registry-shared
+    description: workspace for docker config
+    mountPath: /root/.docker
   - name: source-code
     description: workspace with source code for tekton component
   steps:

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -133,6 +133,9 @@ spec:
           - name: k8s-shared
             workspace: shared-workspace
             subPath: k8s-shared
+          - name: registry-shared
+            workspace: shared-workspace
+            subPath: registry-shared
           - name: source-code
             workspace: shared-workspace
             subPath: source-code

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
@@ -133,6 +133,9 @@ spec:
           - name: k8s-shared
             workspace: shared-workspace
             subPath: k8s-shared
+          - name: registry-shared
+            workspace: shared-workspace
+            subPath: registry-shared
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
@@ -152,6 +155,9 @@ spec:
           - name: k8s-shared
             workspace: shared-workspace
             subPath: k8s-shared
+          - name: registry-shared
+            workspace: shared-workspace
+            subPath: registry-shared
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
@@ -160,7 +166,7 @@ spec:
           - name: package
             value: github.com/tektoncd/pipeline
           - name: container-registry
-            value: $(params.container-registry)
+            value: "192.168.0.13:6001"
           - name: target-arch
             value: $(params.target-arch)
           - name: tags


### PR DESCRIPTION
# Changes
Added missing docker config workspace to push test images.

pipeline e2e and examples tests are failing on Z and PPC64LE platform due to missing /.docker/config.json file. use shared registry workspace available in pipeline to push images to registry.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._