### PR TITLE
update testsuite name from eventListener to eventlistener

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
@@ -47,7 +47,7 @@ spec:
     - |
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       go build -o tkn $(params.package)/cmd/tkn
-      for testsuite in clustertask eventListener pipeline pipelinerun resource task; do
+      for testsuite in clustertask eventlistener pipeline pipelinerun resource task; do
         header "Running Go $(params.tags) ${testsuite} tests"
         report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite}
       done

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
@@ -47,7 +47,7 @@ spec:
     - |
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       go build -o tkn $(params.package)/cmd/tkn
-      for testsuite in clustertask eventListener pipeline pipelinerun plugin task; do
+      for testsuite in clustertask eventlistener pipeline pipelinerun plugin task; do
         header "Running Go $(params.tags) ${testsuite} tests"
         report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite} --kubeconfig $(workspaces.k8s-shared.path)/config
       done


### PR DESCRIPTION

# Changes
e2e Testsuite name changed from `eventListener` to `eventlistener` in this PR,  https://github.com/tektoncd/cli/pull/2018
update P and Z CI jobs to use updated name. 


/kind misc
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._