### PR TITLE
Provide workspace optional flag for CI tests

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
@@ -8,6 +8,7 @@ spec:
     description: workspace to get k8s config file
     mountPath: /root/.kube
   - name: registry-shared
+    optional: true
     description: workspace for docker config
     mountPath: /root/.docker
   - name: source-code

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
@@ -26,6 +26,7 @@ spec:
     description: workspace for k8s config, configuration file is expected to have `config` name
     mountPath: /root/.kube
   - name: registry-shared
+    optional: true
     description: workspace for docker config
     mountPath: /root/.docker
   - name: source-code


### PR DESCRIPTION
# Changes
For all CI jobs `registry-shared` workspace is not required. so providing optional flag in the workspace pipelines. This will fix CI Jobs `TaskRunValidationFailed` issue https://dashboard.dogfooding.tekton.dev/#/namespaces/bastion-z/pipelineruns/tekton-triggers-s390x-nightly-run-v5nf8?pipelineTask=e2e-test-triggers&retry=1

/kind misc
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._