### PR TITLE
Pin test-runner image for pipelines integration tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1287,7 +1287,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Use specific version when https://github.com/tektoncd/plumbing/pull/1167 has merged
+        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:01bace96516d22d70c092ff9c01f9ffe7af806c7475157dcaa7cdb45d84bd68b # golang 1.18.7
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1333,7 +1333,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Use specific version when https://github.com/tektoncd/plumbing/pull/1167 has merged
+        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:01bace96516d22d70c092ff9c01f9ffe7af806c7475157dcaa7cdb45d84bd68b # golang 1.18.7
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1391,7 +1391,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:latest # TODO(abayer): Use specific version when https://github.com/tektoncd/plumbing/pull/1167 has merged
+        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:01bace96516d22d70c092ff9c01f9ffe7af806c7475157dcaa7cdb45d84bd68b # golang 1.18.7
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Using the "latest" tag poses security risks and can introduce unanticipated changes into our CI. This commit updates the test-runner image used for tekton pipelines integration tests to be the same one used for unit tests.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._