### PR TITLE
Add individual dependabot entries for dockerfile dirs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/tekton/images"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "ok-to-test"
-      - "dependencies"
-      - "release-note-none"
-      - "kind/misc"
   - package-ecosystem: "gomod"
     directory: "/bots/buildcaptain"
     schedule:
@@ -119,6 +110,141 @@ updates:
       - "kind/misc"
   - package-ecosystem: "gomod"
     directory: "/tekton/ci/cluster-interceptors/add-pr-body"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/pipelinerun-logs"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/koparse"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/ko-gcloud"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/skopeo"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/alpine-git-nonroot"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/kind-e2e"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/kind"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/test-runner"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/ko"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/kubectl"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/tkn"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/openssh-server"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/hub"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/coverage"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+  - package-ecosystem: "docker"
+    directory: "/tekton/images/buildx-gcloud"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Dependabot is currently failing with:

```
Dependabot couldn't find a Dockerfile.

Dependabot requires a Dockerfile to evaluate your Docker dependencies. It had expected to find one at the path: /tekton/images/Dockerfile.
```

This was generated with:

```sh
for dir in `dirname $(find . -type f -name 'Dockerfile' | grep -v "vendor")`; do
p="${dir:1}"
echo "  - package-ecosystem: \"docker\"
    directory: \"${p}\"
    schedule:
      interval: \"weekly\"
    labels:
      - \"ok-to-test\"
      - \"dependencies\"
      - \"release-note-none\"
      - \"kind/misc\""
done
```

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._