### PR TITLE
Remove PIPELINE_FEATURE_GATE env var

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1359,9 +1359,6 @@ presubmits:
             limits:
               cpu: 3500m
               memory: 8Gi
-          env:
-            - name: PIPELINE_FEATURE_GATE
-              value: "alpha"
   - name: pull-tekton-pipeline-beta-integration-tests
     labels:
       preset-presubmit-sh: "true"

--- a/tekton/images/test-runner/setup-kind.sh
+++ b/tekton/images/test-runner/setup-kind.sh
@@ -76,12 +76,6 @@ while [[ $# -ne 0 ]]; do
   shift
 done
 
-# If E2E_ENV is set but the file doesn't exist, fall back on the old approach of invoking presubmit-tests.sh directly.
-if [[ "${E2E_ENV}" != "" && ! -f "${E2E_ENV}" ]]; then
-  ./test/presubmit-tests.sh --integration-tests
-  exit $?
-fi
-
 # The version map correlated with this version of KinD
 KIND_VERSION="v0.11.1"
 case ${K8S_VERSION} in


### PR DESCRIPTION
This environment variable is used for setting the correct value of "enable-api-fields" for backports to Pipelines before the files test/e2e-tests-kind-prow-<flag>.env were added (https://github.com/tektoncd/plumbing/pull/1145). However, the earliest version of Pipelines that is still supported is v0.41.0, which does have the .env files (example: https://github.com/tektoncd/pipeline/blob/release-v0.41.x/test/e2e-tests-kind-prow-alpha.env). Therefore, this fallback is no longer needed. This commit removes this logic to reduce confusion.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._