### PR TITLE
Cleanup supported k8s version in test-runner

### DIFF
--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -166,7 +166,7 @@ RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${K
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 
 # Extra tools through go install
-ARG KIND_VERSION="v0.14.0"
+ARG KIND_VERSION="v0.20.0"
 RUN GO111MODULE="on" go install github.com/google/go-licenses@latest && \
     GO111MODULE="on" go install github.com/jstemmer/go-junit-report@latest && \
     GO111MODULE="on" go install github.com/raviqqe/liche@latest && \

--- a/tekton/images/test-runner/setup-kind.sh
+++ b/tekton/images/test-runner/setup-kind.sh
@@ -83,36 +83,25 @@ if [[ "${E2E_ENV}" != "" && ! -f "${E2E_ENV}" ]]; then
 fi
 
 # The version map correlated with this version of KinD
-KIND_VERSION="v0.11.1"
 case ${K8S_VERSION} in
-  v1.20.x)
-    K8S_VERSION="1.20.15"
-    KIND_IMAGE_SHA="sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.21.x)
-    K8S_VERSION="1.21.10"
-    KIND_IMAGE_SHA="sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.22.x)
-    K8S_VERSION="1.22.7"
-    KIND_IMAGE_SHA="sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
-  v1.23.x)
-    K8S_VERSION="1.23.4"
-    KIND_IMAGE_SHA="sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
-    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
-    ;;
   v1.24.x)
-    K8S_VERSION="1.24.7"
-    KIND_IMAGE_SHA="sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315"
+    K8S_VERSION="1.24.15"
+    KIND_IMAGE_SHA="sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab"
     KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   v1.25.x)
-    K8S_VERSION="1.25.3"
-    KIND_IMAGE_SHA="sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
+    K8S_VERSION="1.25.11"
+    KIND_IMAGE_SHA="sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.26.x)
+    K8S_VERSION="1.26.6"
+    KIND_IMAGE_SHA="sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb"
+    KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
+    ;;
+  v1.27.x)
+    K8S_VERSION="1.27.3"
+    KIND_IMAGE_SHA="sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
     KIND_IMAGE="kindest/node:${K8S_VERSION}@${KIND_IMAGE_SHA}"
     ;;
   *) abort "Unsupported version: ${K8S_VERSION}" ;;
@@ -222,8 +211,7 @@ kind create cluster --config kind.yaml
 #############################################################
 echo '--- Setup metallb'
 
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
 network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Step 1 for https://github.com/tektoncd/plumbing/issues/1499

This commit
- removes support for EOL k8s versions i.e. 1.20, 1.21, 1.22, 1.23.
- updates support for k8s 1.24 to the latest patch - 1.24.15
- updates support for k8s 1.25 to the latest patch - 1.25.11
- adds support for latest k8s versions including 1.26 and 1.27.
- updates MetalLB to v0.13.10 which doesn't deploy pod security policy which is not supported in k8s 1.25+.

References:
- https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0
- https://metallb.universe.tf/release-notes/#version-0-13-5

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._