### PR TITLE
Add pipelinerun settings for chains v0.16

### DIFF
--- a/tekton/cd/chains/overlays/dogfooding/chains-config.yaml
+++ b/tekton/cd/chains/overlays/dogfooding/chains-config.yaml
@@ -9,5 +9,8 @@ data:
   artifacts.taskrun.format: in-toto
   artifacts.taskrun.signer: kms
   artifacts.taskrun.storage: oci
+  artifacts.pipelinerun.format: in-toto
+  artifacts.pipelinerun.signer: kms
+  artifacts.pipelinerun.storage: oci
   signers.kms.kmsref: gcpkms://projects/tekton-releases/locations/global/keyRings/chains/cryptoKeys/signing-key
   transparency.enabled: manual


### PR DESCRIPTION
# Changes

Chains v0.16 supports attestations for `PipelineRun`, so adding the corresponding settings to the config map to avoid invalid default settings upon deployment.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._