### PR TITLE
Use kubernetes 1.25 on kind for pipeline

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1297,7 +1297,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.24.x"
+            - "v1.25.x"
             - "--nodes"
             - "3"
             - "--e2e-script"
@@ -1343,7 +1343,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.24.x"
+            - "v1.25.x"
             - "--nodes"
             - "3"
             - "--e2e-script"
@@ -1401,7 +1401,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.24.x"
+            - "v1.25.x"
             - "--nodes"
             - "3"
             - "--e2e-script"
@@ -1956,7 +1956,7 @@ periodics:
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
       - "/usr/local/bin/kind-e2e"
       - "--k8s-version"
-      - "v1.24.x"
+      - "v1.25.x"
       - "--nodes"
       - "3"
       - "--e2e-script"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The most recent version of pipeline will need 1.25 as minimum version
for Kubernetes, so switching to it.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
