### PR TITLE
Use 1.20 go image for tektoncd/chains

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -513,7 +513,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:bc9ad50aa7a1fef839543b282d7058f9505349637169d2e1d01771a574181070 # golang 1.20
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -546,7 +546,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:bc9ad50aa7a1fef839543b282d7058f9505349637169d2e1d01771a574181070 # golang 1.20
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -579,7 +579,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+        - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:bc9ad50aa7a1fef839543b282d7058f9505349637169d2e1d01771a574181070 # golang 1.20
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION

# Changes

One of the dependencies used by chains, cosign, now requires go 1.20. This updates the prow jobs to use that version of go.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._