### PR TITLE
Ignore deprecated tasks while catlin validate

### DIFF
--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -63,6 +63,7 @@ spec:
 
         # performing catlin script validattion only on yaml files
         for file in $(cat changed-files.txt);do
+          cat ${file}/*.yaml | grep 'tekton.dev/deprecated: \"true\"' && continue
           catlin lint script ${file}/*.yaml | tee -a catlin-script.txt
         done
 


### PR DESCRIPTION
# Changes

Catlin was running linter on tasks which we are marking as deprecated. Ideally those tasks
should be skipped as those tasks need not to be validated from now on

/kind bug
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._