### PR TITLE
Bump k8s version in operator jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1122,7 +1122,7 @@ presubmits:
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
         - "/usr/local/bin/kind-e2e"
         - "--k8s-version"
-        - "v1.24.x"
+        - "v1.25.x"
         - "--nodes"
         - "3"
         - "--e2e-script"


### PR DESCRIPTION
This will bump k8s version in operator
intergration tests to move to 1.25, to bump
to pipeline 0.51

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._