### PR TITLE
Use kind to run e2e CI on catalog

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1473,29 +1473,57 @@ presubmits:
   - name: pull-tekton-catalog-integration-tests
     labels:
       preset-presubmit-sh: "true"
+      preset-dind-enable: "true"
+      preset-kind-volume-mounts: "true"
     agent: kubernetes
     always_run: true
     decorate: true
     rerun_command: "/test pull-tekton-catalog-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-catalog-integration-tests),?(\\s+|$)"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: operator-kind-e2e
+                    operator: Exists
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+        cloud.google.com/gke-nodepool: n2-standard-4-kind
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20220316-golang-v1-16
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:11dc05cf6e81786ce5935e43aad29a84d6b662804cb57f740c9fb3e1e73ff5f7
         imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 3500m
+            memory: 4Gi
+          limits:
+            cpu: 3500m
+            memory: 8Gi
         command:
         - /usr/local/bin/entrypoint.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
         - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://tekton-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "/usr/local/bin/kind-e2e"
+        - "--k8s-version"
+        - "v1.25.x"
+        - "--nodes"
+        - "3"
+        - "--e2e-script"
+        - "./test/e2e-tests-prow.sh"
+        - "--e2e-env"
+        - "./test/e2e-tests-kind-prow.env"
   tektoncd/resolution:
   - name: pull-tekton-resolution-build-tests
     labels:


### PR DESCRIPTION
# Changes

Similar to other repositories, making catalog e2e tests run on kind

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._