### PR TITLE
Use Kind cluster while running nightly catalog e2e

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2037,6 +2037,8 @@ periodics:
   name: periodic-tekton-catalog-integration-tests
   labels:
     preset-presubmit-sh: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
   agent: kubernetes
   decorate: true
   extra_refs:
@@ -2045,23 +2047,41 @@ periodics:
     base_ref: main
     path_alias: github.com/tektoncd/catalog
   spec:
+    nodeSelector:
+      cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+      cloud.google.com/gke-nodepool: n2-standard-4-kind
+    tolerations:
+    - key: kind-only
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+    - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:11dc05cf6e81786ce5935e43aad29a84d6b662804cb57f740c9fb3e1e73ff5f7 # golang 1.19
       imagePullPolicy: Always
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 3500m
+          memory: 4Gi
+        limits:
+          cpu: 3500m
+          memory: 8Gi
       command:
       - /usr/local/bin/entrypoint.sh
       args:
-      - "--scenario=kubernetes_execute_bazel"
-      - "--clean"
-      - "--job=$(JOB_NAME)"
-      - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-      - "--root=/go/src"
       - "--service-account=/etc/test-account/service-account.json"
-      - "--upload=gs://tekton-prow/pr-logs"
       - "--" # end bootstrap args, scenario args below
       - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-      - "./test/presubmit-tests.sh"
-      - "--integration-tests"
+      - "/usr/local/bin/kind-e2e"
+      - "--k8s-version"
+      - "v1.25.x"
+      - "--nodes"
+      - "3"
+      - "--e2e-script"
+      - "./test/e2e-tests.sh"
+      - "--e2e-env"
+      - "./test/e2e-tests-kind-prow.env"
       env:
       - name: TEST_RUN_ALL_TESTS
         value: "true"


### PR DESCRIPTION
# Changes

Catalog nightly jobs were still spawing gke cluster which:
1. takes lot of time to spin
2. there are some issues while testing latest git-clone which runs as non-root

Moving it to kind based so that above problems can be rectified

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._