### PR TITLE
Fix Rerun and Trigger Commands

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -800,8 +800,8 @@ presubmits:
     agent: kubernetes
     always_run: true
     decorate: true
-    rerun_command: "/test tekton-dashboard-unit-tests"
-    trigger: "(?m)^/test (all|tekton-dashboard-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-tekton-dashboard-unit-tests"
+    trigger: "(?m)^/test (all|pull-tekton-dashboard-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:11dc05cf6e81786ce5935e43aad29a84d6b662804cb57f740c9fb3e1e73ff5f7 # golang 1.19
@@ -899,8 +899,8 @@ presubmits:
     agent: kubernetes
     always_run: true
     decorate: true
-    rerun_command: "/test tekton-experimental-unit-tests"
-    trigger: "(?m)^/test (all|tekton-experimental-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-tekton-experimental-unit-tests"
+    trigger: "(?m)^/test (all|pull-tekton-experimental-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
@@ -1209,8 +1209,8 @@ presubmits:
     agent: kubernetes
     always_run: true
     decorate: true
-    rerun_command: "/test tekton-pipeline-unit-tests"
-    trigger: "(?m)^/test (all|tekton-pipeline-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-tekton-pipeline-unit-tests"
+    trigger: "(?m)^/test (all|pull-tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
@@ -1549,8 +1549,8 @@ presubmits:
     agent: kubernetes
     always_run: true
     decorate: true
-    rerun_command: "/test tekton-resolution-unit-tests"
-    trigger: "(?m)^/test (all|tekton-resolution-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-tekton-resolution-unit-tests"
+    trigger: "(?m)^/test (all|pull-tekton-resolution-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
@@ -1632,8 +1632,8 @@ presubmits:
     agent: kubernetes
     always_run: true
     decorate: true
-    rerun_command: "/test tekton-results-unit-tests"
-    trigger: "(?m)^/test (all|tekton-results-unit-tests),?(\\s+|$)"
+    rerun_command: "/test pull-tekton-results-unit-tests"
+    trigger: "(?m)^/test (all|pull-tekton-results-unit-tests),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Prior to this change, some rerun and trigger commands did not match the name of the tests. This leads to confusion when trying to use the commands on a pull request.

Ran into this issue when reruning https://github.com/tektoncd/pipeline/pull/6659.

This change adds the prefix `"pull-"` to commands that were missing it, while the test name has that prefix.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._