### PR TITLE
Remove lifecycle plugin from tektoncd org

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -35,7 +35,6 @@ plugins:
       - hold
       - label
       - lgtm
-      - lifecycle
       - milestone
       - project
       - retitle
@@ -59,7 +58,6 @@ plugins:
       - hold
       - label
       - lgtm
-      - lifecycle
       - milestone
       - project
       - retitle


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As described in tektoncd/community#1092, the `lifecycle` plugin is becoming more of a problem than a solution. See the linked issue for more details.

Closes tektoncd/community#1092

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._