### PR TITLE
Updated images-build task to utilize matrix as input

### DIFF
--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -150,7 +150,7 @@ spec:
         params:
           - name: CONTEXT
             value:
-              - $(tasks.check-git-files-changed.results.files[0])
+              - $(tasks.check-git-files-changed.results.files)
       params:
       - name: pullRequestNumber
         value: "$(params.pullRequestNumber)"


### PR DESCRIPTION
Modified the images-build task to accept matrix input, enabling the build of all modified Docker files. This update replaces the prior method that limited builds to only the first file. This improvement, addresses request [#1531](https://github.com/tektoncd/plumbing/issues/1531).


# Changes

Updated the images-build task to now accept a matrix input, allowing all modified Docker files in a GitHub commit to be built. This replaces the previous method where only the first file at index [0] was built.

/kind misc

Fixes: #1531

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
