### PR TITLE
experiment: Add Wolfi based images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -360,3 +360,12 @@ updates:
       all:
         patterns:
           - "*"
+  - package-ecosystem: "terraform"
+    directory: "/tekton/images"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 **/.bin
 **/.DS_Store
+
+.terraform**
+terraform.tfstate**

--- a/tekton/images/README.md
+++ b/tekton/images/README.md
@@ -1,4 +1,35 @@
 # Container Images for Tekton infrastructure
 
-This folder contains various container images used by Tekton infrastructure
-to run Tekton's own CI/CD.
+This folder contains various container images used by Tekton infrastructure to
+run Tekton's own CI/CD.
+
+## Wolfi images (experimental)
+
+Some directories include experimental support for
+[Wolfi](https://github.com/wolfi-dev/) images built via
+[apko](https://github.com/chainguard-dev/apko) + terraform.
+
+These images are built declaratively from Wolfi packages and are automatically
+signed + attested during publishing.
+
+To build these images, run:
+
+```sh
+TF_VAR_target_repository=ttl.sh/path/to/registry terraform apply
+```
+
+To build a single image (for example, `ko-gcloud`):
+
+```sh
+TF_VAR_target_repository=ttl.sh/path/to/registry terraform apply -target=module.ko-gcloud
+```
+
+### Signing and attestations
+
+If you wish to sign/attest the image locally (optional for development, but
+terraform will output a warning), you can enable it by setting
+`TF_COSIGN_LOCAL=1`:
+
+```sh
+TF_COSIGN_LOCAL=1 TF_VAR_target_repository=ttl.sh/path/to/registry terraform apply -target=module.ko-gcloud
+```

--- a/tekton/images/ko-gcloud/apko.yaml
+++ b/tekton/images/ko-gcloud/apko.yaml
@@ -1,0 +1,27 @@
+contents:
+  packages:
+    - bash
+    - busybox
+    - git
+    - go
+    - google-cloud-sdk
+    - ko
+    - kubectl
+    - kustomize
+    # Pin to python 3.11 until issues with 3.12 are resolved.
+    # ref: https://issuetracker.google.com/issues/303737178
+    - python3~3.11
+    - yq
+
+entrypoint:
+  command: /bin/bash
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532

--- a/tekton/images/ko-gcloud/main.tf
+++ b/tekton/images/ko-gcloud/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    apko = {
+      source = "chainguard-dev/apko"
+    }
+    oci = {
+      source = "chainguard-dev/oci"
+    }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "image" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.9"
+
+  target_repository = var.target_repository
+  config = file("${path.module}/apko.yaml")
+  default_annotations = {
+    "org.opencontainers.image.url": "https://github.com/tektoncd/plumbing/tree/main/tekton/images/ko-gcloud"
+  }
+}
+
+resource "oci_tag" "latest" {
+  digest_ref = module.image.image_ref
+  tag        = "latest-wolfi"
+}
+
+output "image_ref" {
+  value = oci_tag.latest.tagged_ref
+}

--- a/tekton/images/ko/apko.yaml
+++ b/tekton/images/ko/apko.yaml
@@ -1,0 +1,20 @@
+contents:
+  packages:
+    - bash
+    - busybox
+    - git
+    - ko
+    - kustomize
+
+entrypoint:
+  command: /bin/bash
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532

--- a/tekton/images/ko/main.tf
+++ b/tekton/images/ko/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    apko = {
+      source = "chainguard-dev/apko"
+    }
+    oci = {
+      source = "chainguard-dev/oci"
+    }
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "image" {
+  source  = "chainguard-dev/apko/publisher"
+  version = "0.0.9"
+
+  target_repository = var.target_repository
+  config = file("${path.module}/apko.yaml")
+  default_annotations = {
+    "org.opencontainers.image.url": "https://github.com/tektoncd/plumbing/tree/main/tekton/images/ko"
+  }
+}
+
+resource "oci_tag" "latest" {
+  digest_ref = module.image.image_ref
+  tag        = "latest-wolfi"
+}
+
+output "image_ref" {
+  value = oci_tag.latest.tagged_ref
+}

--- a/tekton/images/main.tf
+++ b/tekton/images/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    oci = {
+        source = "chainguard-dev/oci" 
+        version = "~> 0.0.10"
+    }
+    apko = {
+        source = "chainguard-dev/apko"
+        version = "~> 0.10.7"
+    }
+  }
+}
+
+provider "apko" {
+  extra_repositories = ["https://packages.wolfi.dev/os"]
+  extra_keyring      = ["https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"]
+  extra_packages     = ["wolfi-baselayout"]
+  default_archs      = ["x86_64", "aarch64"]
+  default_annotations = {
+    "org.opencontainers.image.authors" = "Tekton Authors <tekton-dev@googlegroups.com>"
+  }
+}
+
+variable "target_repository" {
+  description = "The docker repo into which the image and attestations should be published."
+}
+
+module "ko" {
+    source = "./ko"
+    target_repository = "${var.target_repository}/ko"
+}
+
+module "ko-gcloud" {
+    source = "./ko-gcloud"
+    target_repository = "${var.target_repository}/ko-gcloud"
+}


### PR DESCRIPTION
Opening as a draft since if we actually want to do this or not, but opening up for discussion. (cc @afrittoli)

Adds some initial images (ko, ko-gcloud) based on [Wolfi](https://wolfi.dev) packages using [apko](https://github.com/chainguard-dev/apko). (tl;dr apko = ko for apks).

These images are smaller and are kept up to date with upstream with a focus on minimal CVEs.

(computed using `crane manifest $IMG | jq '.config.size + ([.layers[].size] | add)' | numfmt --to=iec`)

Image | Size
----- | ----
gcr.io/tekton-releases/dogfooding/ko:latest | 277M us-docker.pkg.dev/wlynch-chainguard/public/ko@latest-wolfi | 31M gcr.io/tekton-releases/dogfooding/ko-gcloud:latest | 606M us-docker.pkg.dev/wlynch-chainguard/public/ko-gcloud@latest-wolfi | 304M

CVE Scans:

```
$ grype gcr.io/tekton-releases/dogfooding/ko:latest
 ✔ Vulnerability DB                [no update available]
 ✔ Parsed image                                                                                                                                                                                                 sha256:a41f5ae73e4a3aa0652d8653d22cd8dcf499f1ad2e78c3c1433127fe3ee6d61f
 ✔ Cataloged packages              [231 packages]
 ✔ Scanned for vulnerabilities     [23 vulnerability matches]
   ├── by severity: 1 critical, 7 high, 13 medium, 0 low, 0 negligible (2 unknown)
   └── by status:   12 fixed, 11 not-fixed, 0 ignored (4 dropped)
```

```
$ grype us-docker.pkg.dev/wlynch-chainguard/public/ko:latest-wolfi
 ✔ Vulnerability DB                [no update available]
 ✔ Parsed image                                                                                                                                                                                                 sha256:e5b9decd9f30c3500f7e289c7abd7d054e122b128877215b47b78b769e915329
 ✔ Cataloged packages              [191 packages]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored (4 dropped)
```

These aren't wired up to CI yet, but they're configured to publish to a different tag (`latest-wolfi`)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._