### PR TITLE
Use latest Results release

### DIFF
--- a/tekton/cd/results/base/kustomization.yaml
+++ b/tekton/cd/results/base/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://storage.googleapis.com/tekton-releases/results/previous/v0.3.0/release.yaml
+  - https://storage.googleapis.com/tekton-releases/results/latest/release.yaml

--- a/tekton/cd/results/overlays/dogfooding/bec.yaml
+++ b/tekton/cd/results/overlays/dogfooding/bec.yaml
@@ -9,4 +9,4 @@ spec:
     requestPath: /
     # This currently points to the prometheus port as a very rough
     # health check to determine whether the server is alive.
-    port: 8080
+    port: 9090

--- a/tekton/cd/results/overlays/dogfooding/ingress.yaml
+++ b/tekton/cd/results/overlays/dogfooding/ingress.yaml
@@ -22,6 +22,6 @@ spec:
           service:
             name: tekton-results-api-service
             port:
-              number: 50051
+              number: 8080
         path: /*
         pathType: ImplementationSpecific


### PR DESCRIPTION
# Changes
Use latest Results release.
The API service port was changed to 8080 in recent version.
The metrics port used for monitoring was changed to 9090.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._