### PR TITLE
ppc64le job config modified with JFrog registry

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/catalog-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/catalog-nightly-test/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NAMESPACE
               value: "bastion-p"
             - name: REGISTRY
-              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+              value: "na.artifactory.swg-devops.com/sys-linux-power-team-ftp3distro-docker-images-docker-local/tekton"
             - name: TARGET_ARCH
               value: "ppc64le"
             - name: REMOTE_SECRET_NAME

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NAMESPACE
               value: "bastion-p"
             - name: REGISTRY
-              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+              value: "na.artifactory.swg-devops.com/sys-linux-power-team-ftp3distro-docker-images-docker-local/tekton"
             - name: TARGET_ARCH
               value: "ppc64le"
             - name: REMOTE_SECRET_NAME

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NAMESPACE
               value: "bastion-p"
             - name: REGISTRY
-              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+              value: "na.artifactory.swg-devops.com/sys-linux-power-team-ftp3distro-docker-images-docker-local/tekton"
             - name: TARGET_ARCH
               value: "ppc64le"
             - name: REMOTE_SECRET_NAME

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NAMESPACE
               value: "bastion-p"
             - name: REGISTRY
-              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+              value: "na.artifactory.swg-devops.com/sys-linux-power-team-ftp3distro-docker-images-docker-local/tekton"
             - name: TARGET_ARCH
               value: "ppc64le"
             - name: REMOTE_SECRET_NAME

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NAMESPACE
               value: "bastion-p"
             - name: REGISTRY
-              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+              value: "na.artifactory.swg-devops.com/sys-linux-power-team-ftp3distro-docker-images-docker-local/tekton"
             - name: TARGET_ARCH
               value: "ppc64le"
             - name: REMOTE_SECRET_NAME

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             - name: NAMESPACE
               value: "bastion-p"
             - name: REGISTRY
-              value: "ppc64le-cluster.bastion-p.svc.cluster.local:443"
+              value: "na.artifactory.swg-devops.com/sys-linux-power-team-ftp3distro-docker-images-docker-local/tekton"
             - name: TARGET_ARCH
               value: "ppc64le"
             - name: REMOTE_SECRET_NAME


### PR DESCRIPTION
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)

This PR modifies the registry for all the tekton nightly jobs for ppc64le . 

# Issue 
We encountered recurring x509 certificate errors on the ppc64le side, causing inconsistency in our operations despite repeated fixes. This inconsistency resulted in significant time wastage and hindered productivity.

# Changes
 To mitigate this issue effectively, we transitioned to a JFrog registry. This solution eliminates the x509 certificate error entirely, providing a reliable and stable environment for our operations


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._