### PR TITLE
Fix description field on tasks

### DIFF
--- a/tekton/ci/jobs/tekton-github-tasks-completed.yaml
+++ b/tekton/ci/jobs/tekton-github-tasks-completed.yaml
@@ -3,9 +3,9 @@ kind: Task
 metadata:
   name: github-tasks-completed
   namespace: tekton-ci
+spec:
   description: |
     Verifies that a PR has all the tasks completed. A task is considered to be any part of the text that looks like a github markdown checkbox ("- []").
-spec:
   params:
     - name: body
       description: The body of the Pull Request

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -3,9 +3,9 @@ kind: Task
 metadata:
   name: kind-label
   namespace: tekton-ci
+spec:
   description: |
     Verifies that a PR has one valid kind label
-spec:
   params:
   - name: labels
     description: The labels attached to the Pull Request


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
`description` should be set as `spec.description`, NOT as `metadata.description`.

This is preventing a number of jobs from running successfully, e.g. https://dashboard.dogfooding.tekton.dev/#/namespaces/default/pipelineruns/deploy-resources-tekton-sgmwh?pipelineTask=deploy&step=deploy-from-folder

```
Error from server (BadRequest): error when creating "target.yaml": Task in version "v1beta1" cannot be handled as a Task: strict decoding error: unknown field "metadata.description"
Error from server (BadRequest): error when creating "target.yaml": Task in version "v1beta1" cannot be handled as a Task: strict decoding error: unknown field "metadata.description"
+ echo 'Something went wrong when creating resources'
+ exit 1
Something went wrong when creating resources
```
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._