### PR TITLE
Fix invalid metadata.description

### DIFF
--- a/tekton/ci/jobs/tekton-github-tasks-completed.yaml
+++ b/tekton/ci/jobs/tekton-github-tasks-completed.yaml
@@ -3,9 +3,9 @@ kind: Task
 metadata:
   name: github-tasks-completed
   namespace: tekton-ci
+spec:
   description: |
     Verifies that a PR has all the tasks completed. A task is considered to be any part of the text that looks like a github markdown checkbox ("- []").
-spec:
   params:
     - name: body
       description: The body of the Pull Request

--- a/tekton/ci/jobs/tekton-kind-label.yaml
+++ b/tekton/ci/jobs/tekton-kind-label.yaml
@@ -3,9 +3,9 @@ kind: Task
 metadata:
   name: kind-label
   namespace: tekton-ci
+spec:
   description: |
     Verifies that a PR has one valid kind label
-spec:
   params:
   - name: labels
     description: The labels attached to the Pull Request


### PR DESCRIPTION
# Changes

Two tasks have an invalid `.metadata.description` field. Move the description to `.spec.description` instead.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._