### PR TITLE
Cronjob timings and timeout modified for ppc64le jobs

### DIFF
--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/catalog-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/catalog-nightly-test/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-test-trigger
 spec:
-  schedule: "0 17 * * *"
+  schedule: "0 0 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-test-trigger
 spec:
-  schedule: "0 3 * * *"
+  schedule: "30 3 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-test-trigger
 spec:
-  schedule: "0 8 * * *"
+  schedule: "0 7 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-test-trigger
 spec:
-  schedule: "0 5 * * *"
+  schedule: "30 10 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-test-trigger
 spec:
-  schedule: "0 19 * * *"
+  schedule: "0 14 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-test-trigger
 spec:
-  schedule: "0 21 * * *"
+  schedule: "30 17 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
@@ -31,7 +31,7 @@ spec:
       generateName: tekton-catalog-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout: 3h
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace

--- a/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
@@ -31,7 +31,7 @@ spec:
       generateName: tekton-cli-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout: 3h
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -31,7 +31,7 @@ spec:
       generateName: tekton-dashboard-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout: 3h
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -31,7 +31,7 @@ spec:
       generateName: tekton-operator-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout: 3h
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -31,7 +31,7 @@ spec:
       generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout: 3h
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace

--- a/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
@@ -31,7 +31,7 @@ spec:
       generateName: tekton-triggers-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
     spec:
-      timeout: 2h
+      timeout: 3h
       workspaces:
       # this workspace will be used to share info between tasks
       - name: shared-workspace


### PR DESCRIPTION
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)

This PR modifies the cronjob timings and timeout for all the tekton nightly jobs for ppc64le .

# Changes
Due to transitioning to a new automation process, wherein VMs are dynamically provisioned and clusters installed, the time required for cluster creation has increased from 5-7 minutes to 30-35 minutes. Consequently, Tekton jobs are failing due to pipeline timeout errors. To address this, 

1.  the timeout for Tekton jobs has been extended from 2 hours to 3 hours, and 
2. cronjob timings have been adjusted to avoid clashes with other jobs.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._