### PR TITLE
Enable OCI bundles use in dogfooding

### DIFF
--- a/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/feature-flags.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   enable-api-fields: "alpha"
   enable-step-actions: "true"
+  enable-tekton-oci-bundles: "true"


### PR DESCRIPTION
# Changes

OCI bundles are still used in dogfooding through the old bundles syntax. The syntax is translated automatically to the remote resolution syntax, but it still requires the oci bundles flag to be enabled first.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._