### PR TITLE
Dogfood StepActions via go-coverage CI pipeline

### DIFF
--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -1,5 +1,5 @@
-apiVersion: tekton.dev/v1beta1
-kind: Task
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
 metadata:
   name: go-coverage
   annotations:
@@ -37,46 +37,37 @@ spec:
       default: 0
     - name: githubTokenFile
       description: The file within workspace that contains the GitHub token.
-  workspaces:
-  - name: source
-    description: Location where the git repo will be installed.
-    mountPath: /go/src/github.com/tektoncd/$(params.repoName)
-  - name: github-token
-    description: |
-      A secret workspace where the github personal access token resides.
-      The token should be storage as a stringData with key "token" and
-      value "your access token".
-  steps:
-    - name: run-coverage
-      image: gcr.io/tekton-releases/dogfooding/coverage:latest
-      env:
-        - name: PULL_PULL_SHA
-          value: $(params.gitRevision)
-        - name: PULL_NUMBER
-          value: $(params.pullRequestNumber)
-        - name: JOB_TYPE
-          value: $(params.jobType)
-        - name: BUILD_NUMBER
-          value: $(params.buildUUID)
-        - name: REPO_NAME
-          value: $(params.repoName)
-        - name: REPO_OWNER
-          value: $(params.repoOwner)
-        - name: JOB_NAME
-          value: $(params.jobName)
-      command:
-        - /coverage
-      args:
-        - "--postsubmit-gcs-bucket=$(params.postSubmitGcsBucket)"
-        - "--postsubmit-job-name=$(params.postSubmitJobName)"
-        - "--artifacts=$(workspaces.source.path)/artifacts"
-        - "--profile-name=$(params.profileName)"
-        - "--cov-target=$(params.covTarget)"
-        - "--cov-threshold-percentage=$(params.covThresholdPercentage)"
-        - "--github-token=$(workspaces.github-token.path)/$(params.githubTokenFile)"
-      workingDir: "$(workspaces.source.path)"
+    - name: sourcePath
+      description: Location where the git repo will be installed.
+  image: gcr.io/tekton-releases/dogfooding/coverage:latest
+  env:
+    - name: PULL_PULL_SHA
+      value: $(params.gitRevision)
+    - name: PULL_NUMBER
+      value: $(params.pullRequestNumber)
+    - name: JOB_TYPE
+      value: $(params.jobType)
+    - name: BUILD_NUMBER
+      value: $(params.buildUUID)
+    - name: REPO_NAME
+      value: $(params.repoName)
+    - name: REPO_OWNER
+      value: $(params.repoOwner)
+    - name: JOB_NAME
+      value: $(params.jobName)
+  command:
+    - /coverage
+  args:
+    - "--postsubmit-gcs-bucket=$(params.postSubmitGcsBucket)"
+    - "--postsubmit-job-name=$(params.postSubmitJobName)"
+    - "--artifacts=$(params.sourcePath)/artifacts"
+    - "--profile-name=$(params.profileName)"
+    - "--cov-target=$(params.covTarget)"
+    - "--cov-threshold-percentage=$(params.covThresholdPercentage)"
+    - "--github-token=$(params.githubTokenFile)"
+  workingDir: "$(params.sourcePath)"
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: go-coverage-pipeline
@@ -161,85 +152,77 @@ spec:
             script: |
               printf '$(params.package)' | awk -F/ '{printf($1)}' | tee /tekton/results/repoOwner
               printf '$(params.package)' | awk -F/ '{printf($2)}' | tee /tekton/results/repoName
-    - name: clone-repo
+    - name: clone-coverage-upload
       runAfter: ['split-full-repo-name']
-      taskRef:
-        resolver: bundles
-        params:
-          - name: bundle
-            value: gcr.io/tekton-releases/catalog/upstream/git-batch-merge:0.2
-          - name: name
-            value: git-batch-merge
-          - name: kind
-            value: task
-      params:
-        - name: url
-          value: https://github.com/$(tasks.split-full-repo-name.results.repoOwner)/$(tasks.split-full-repo-name.results.repoName).git
-        - name: mode
-          value: "merge"
-        - name: revision
-          value: $(params.pullRequestBaseRef)
-        - name: refspec
-          value: refs/heads/$(params.pullRequestBaseRef):refs/heads/$(params.pullRequestBaseRef)
-        - name: batchedRefs
-          value: "refs/pull/$(params.pullRequestNumber)/head"
-      workspaces:
-        - name: output
-          workspace: source
-    - name: run-go-coverage
-      runAfter: ['clone-repo']
-      taskRef:
-        name: go-coverage
-      params:
-        - name: pullRequestNumber
-          value: $(params.pullRequestNumber)
-        - name: gitRevision
-          value: $(params.gitRevision)
-        - name: buildUUID
-          value: $(params.buildUUID)
-        - name: repoName
-          value: $(tasks.split-full-repo-name.results.repoName)
-        - name: repoOwner
-          value: $(tasks.split-full-repo-name.results.repoOwner)
-        - name: jobType
-          value: $(params.jobType)
-        - name: jobName
-          value: $(params.jobName)
-        - name: postSubmitGcsBucket
-          value: $(params.postSubmitGcsBucket)
-        - name: postSubmitJobName
-          value: $(params.postSubmitJobName)
-        - name: covTarget
-          value: $(params.covTarget)
-        - name: profileName
-          value: $(params.profileName)
-        - name: covThresholdPercentage
-          value: $(params.covThresholdPercentage)
-        - name: githubTokenFile
-          value: $(params.githubTokenFile)
-      workspaces:
+      taskSpec:
+        steps:
+          - name: clone
+            ref:
+              name: git-batch-merge
+            params:
+              - name: url
+                value: https://github.com/$(tasks.split-full-repo-name.results.repoOwner)/$(tasks.split-full-repo-name.results.repoName).git
+              - name: mode
+                value: "merge"
+              - name: revision
+                value: $(params.pullRequestBaseRef)
+              - name: refspec
+                value: refs/heads/$(params.pullRequestBaseRef):refs/heads/$(params.pullRequestBaseRef)
+              - name: batchedRefs
+                value: "refs/pull/$(params.pullRequestNumber)/head"
+              - name: sourcePath
+                value: $(workspaces.source.path)
+          - name: coverage
+            ref:
+              name: go-coverage
+            params:
+              - name: pullRequestNumber
+                value: $(params.pullRequestNumber)
+              - name: gitRevision
+                value: $(params.gitRevision)
+              - name: buildUUID
+                value: $(params.buildUUID)
+              - name: repoName
+                value: $(tasks.split-full-repo-name.results.repoName)
+              - name: repoOwner
+                value: $(tasks.split-full-repo-name.results.repoOwner)
+              - name: jobType
+                value: $(params.jobType)
+              - name: jobName
+                value: $(params.jobName)
+              - name: postSubmitGcsBucket
+                value: $(params.postSubmitGcsBucket)
+              - name: postSubmitJobName
+                value: $(params.postSubmitJobName)
+              - name: covTarget
+                value: $(params.covTarget)
+              - name: profileName
+                value: $(params.profileName)
+              - name: covThresholdPercentage
+                value: $(params.covThresholdPercentage)
+              - name: githubTokenFile
+                value: $(workspaces.github-token.path)/$(params.githubTokenFile)
+              - name: sourcePath
+                value: $(workspaces.source.path)
+          - name: upload
+            ref:
+              name: gcs-upload
+            params:
+              - name: path
+                value: $(workspaces.source.path)/artifacts
+              - name: location
+                value: gs://$(params.uploadGcsBucket)/pr-logs/pull/$(tasks.split-full-repo-name.results.repoOwner)_$(tasks.split-full-repo-name.results.repoName)/$(params.pullRequestNumber)/$(params.jobName)/$(params.buildUUID)/artifacts
+              - name: credentialsPath
+                value: $(workspaces.credentials.path)
+        workspaces:
         - name: source
-          workspace: source
+          description: Location where the git repo will be installed.
+          mountPath: /go/src/github.com/tektoncd/$(params.repoName)
         - name: github-token
-          workspace: github-token
-    - name: upload-artifacts
-      runAfter: ['run-go-coverage']
-      taskRef:
-        resolver: bundles
-        params:
-          - name: bundle
-            value: gcr.io/tekton-releases/catalog/upstream/gcs-upload:0.3
-          - name: name
-            value: gcs-upload
-          - name: kind
-            value: task
-      params:
-        - name: path
-          value: artifacts
-        - name: location
-          value: gs://$(params.uploadGcsBucket)/pr-logs/pull/$(tasks.split-full-repo-name.results.repoOwner)_$(tasks.split-full-repo-name.results.repoName)/$(params.pullRequestNumber)/$(params.jobName)/$(params.buildUUID)/artifacts
-      workspaces:
+          description: |
+            A secret workspace where the github personal access token resides.
+            The token should be storage as a stringData with key "token" and
+            value "your access token".
         - name: credentials
-          workspace: credentials
-        - name: source
-          workspace: source
+          description: |
+            Path containing the GCS credentials to use during upload.

--- a/tekton/ci/kustomization.yaml
+++ b/tekton/ci/kustomization.yaml
@@ -5,5 +5,6 @@ commonAnnotations:
 resources:
 - infra
 - shared
+- stepactions
 - jobs
 - repos

--- a/tekton/ci/stepactions/gcs-upload.yaml
+++ b/tekton/ci/stepactions/gcs-upload.yaml
@@ -1,0 +1,92 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: gcs-upload
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.54.0"
+    tekton.dev/categories: Cloud, Storage
+    tekton.dev/tags: cloud, gcs
+    tekton.dev/displayName: "Upload to GCS"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  params:
+  - name: path
+    description: The path to files or directories to the source path that you'd like to upload.
+    type: string
+  - name: credentialsPath
+    description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+    type: string
+  - name: location
+    description: The address (including "gs://") where you'd like to upload files to.
+    type: string
+  - name: deleteExtraFiles
+    description: |
+      When "true", delete extra files under location not found under path.
+      By default extra files are not deleted.
+
+      NOTE: this option can delete data quickly if you specify the wrong
+      source/destination combination. "BE CAREFUL WHEN USING THIS OPTION!".
+
+      NOTE: this option is implemented via "gsutil rsync". If the target bucket
+      contains a large number of files, it may take a long time for gsutil to
+      fetch the remote metadata for sync.
+
+      NOTE: setting this option to "true" is not compatible with replaceExistingFiles="false"
+    default: "false"
+    type: string
+  - name: replaceExistingFiles
+    description: |
+      When "false", files that already exists are skipped. Default: "true"
+
+      NOTE: setting this option to "false" is not compatible with deleteExtraFiles="true"
+    default: "true"
+  - name: serviceAccountPath
+    description: The path inside the credentialsPath  to the GOOGLE_APPLICATION_CREDENTIALS key file.
+    type: string
+    default: service_account.json
+  env:
+    - name: CRED_PATH
+      value: "$(params.credentialsPath)/$(params.serviceAccountPath)"
+    - name: SOURCE
+      value: "$(params.path)"
+    - name: LOCATION
+      value: "$(params.location)"
+    - name: DELETE_EXTRA_FILES
+      value: $(params.deleteExtraFiles)
+    - name: REPLACE_EXISTING_FILES
+      value: $(params.replaceExistingFiles)
+  image: gcr.io/google.com/cloudsdktool/cloud-sdk:379.0.0-slim@sha256:d844877c7aaa06a0072979230c68417ddb0f27087277f29747c7169d6ed0d2b9 #tag: 379.0.0-slim
+  script: |
+    #!/usr/bin/env bash
+    set -xe
+
+    if [[ -f "$CRED_PATH" ]]; then
+      GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
+    fi
+
+    if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+      echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+      gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+    fi
+
+    CP_PARAMS=""
+    if [[ "$REPLACE_EXISTING_FILES" == "false" ]]; then
+        CP_PARAMS="-n"
+    fi
+
+    if [[ -d "$SOURCE" ]]; then
+      # Copying one folder
+      if [[ "$DELETE_EXTRA_FILES" == "true" ]]; then
+          if [[ "$REPLACE_EXISTING_FILES" == "false" ]]; then
+            echo "\"deleteExtraFiles\"" can be used only when \"replaceExistingFiles\"" is true"
+            exit 1
+          fi
+        # When deleteExtraFiles is requested, use rsync
+        gsutil -m rsync -d -r "${SOURCE}" "${LOCATION}"
+      else
+        gsutil -m cp ${CP_PARAMS} -r "${SOURCE}" "${LOCATION}"
+      fi
+    else
+      # Copying one file
+      gsutil cp ${CP_PARAMS} "${SOURCE}" "${LOCATION}"
+    fi

--- a/tekton/ci/stepactions/git-batch-merge.yaml
+++ b/tekton/ci/stepactions/git-batch-merge.yaml
@@ -1,0 +1,156 @@
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: git-batch-merge
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.54.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git batch merge"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  params:
+    - name: sourcePath
+      description: The git repo will be cloned onto this path
+    - name: url
+      description: git url to clone
+      type: string
+    - name: revision
+      description: base git revision to checkout (branch, tag, sha, ref…)
+      type: string
+      default: master
+    - name: refspec
+      description: base git refspec to fetch before checking out revision
+      type: string
+      default: "refs/heads/master:refs/heads/master"
+    - name: batchedRefs
+      description: git refs to fetch and batch on top of revision using the given mode (must be a valid refname, no commit SHA's)
+      type: string
+    - name: gitUserName
+      description: git user name to use for creating the batched commit (First Last)
+      type: string
+      default: GitBatch Task
+    - name: gitUserEmail
+      description: git user email to use for creating the batched commit (First.Last@domain.com)
+      type: string
+      default: GitBatch.Task@tekton.dev
+    - name: mode
+      description: git operation to perform while batching (choose from merge, cherry-pick)
+      type: string
+      default: merge
+    - name: submodules
+      description: defines if the resource should initialize and fetch the submodules
+      type: string
+      default: "true"
+    - name: depth
+      description: performs a shallow clone where only the most recent commit(s) will be fetched
+      type: string
+      default: "0"
+    - name: sslVerify
+      description: defines if http.sslVerify should be set to true or false in the global git config
+      type: string
+      default: "true"
+    - name: subdirectory
+      description: subdirectory inside the "output" workspace to clone the git repo into
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+      type: string
+      default: "false"
+    - name: gitInitImage
+      description: The image used where the git-init binary is.
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.18.1"
+      type: string
+  results:
+    - name: commit
+      description: The final commit SHA that was obtained after batching all provided refs onto revision
+    - name: tree
+      description: The git tree SHA that was obtained after batching all provided refs onto revision.
+  env:
+    - name: PARAM_SOURCE_PATH
+      value: $(params.sourcePath)
+    - name: PARAM_SUB_DIR
+      value: $(params.subdirectory)
+    - name: PARAM_DELETE_EXISTING
+      value: $(params.deleteExisting)
+    - name: PARAM_BATCHED_REFS
+      value: $(params.batchedRefs)
+    - name: PARAM_REF_SPEC
+      value: $(params.refspec)
+    - name: PARAM_URL
+      value: $(params.url)
+    - name: PARAM_REVISION
+      value: $(params.revision)
+    - name: PARAM_SSL_VERIFY
+      value: $(params.sslVerify)
+    - name: PARAM_SUBMODULES
+      value: $(params.submodules)
+    - name: PARAM_DEPTH
+      value: $(params.depth)
+    - name: PARAM_GIT_USER_NAME
+      value: $(params.gitUserName)
+    - name: PARAM_GIT_USER_EMAIL
+      value: $(params.gitUserEmail)
+    - name: PARAM_MODE
+      value: $(params.mode)
+  image: $(params.gitInitImage)
+  script: |
+    CHECKOUT_DIR="${PARAM_SOURCE_PATH}/${PARAM_SUB_DIR}"
+
+    cleandir() {
+      # Delete any existing contents of the repo directory if it exists.
+      #
+      # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+      # or the root of a mounted volume.
+      if [[ -d "$CHECKOUT_DIR" ]] ; then
+        # Delete non-hidden files and directories
+        rm -rf "$CHECKOUT_DIR"/*
+        # Delete files and directories starting with . but excluding ..
+        rm -rf "$CHECKOUT_DIR"/.[!.]*
+        # Delete files and directories starting with .. plus any other character
+        rm -rf "$CHECKOUT_DIR"/..?*
+      fi
+    }
+
+    if [[ "${PARAM_DELETE_EXISTING}" == "true" ]] ; then
+      cleandir
+    fi
+
+    p="${PARAM_BATCHED_REFS}"
+    refs="${PARAM_REF_SPEC}"
+    for ref in $p; do
+      refs="$refs $ref:refs/batch/$ref"
+    done
+
+    /ko-app/git-init \
+      -url "${PARAM_URL}" \
+      -revision "${PARAM_REVISION}" \
+      -refspec "$refs" \
+      -path "$CHECKOUT_DIR" \
+      -sslVerify="${PARAM_SSL_VERIFY}" \
+      -submodules="${PARAM_SUBMODULES}" \
+      -depth "${PARAM_DEPTH}"
+
+    git -C $CHECKOUT_DIR config user.name "${PARAM_GIT_USER_NAME}"
+    git -C $CHECKOUT_DIR config user.email "${PARAM_GIT_USER_EMAIL}"
+
+    mode="${PARAM_MODE}"
+    if [[ $mode == "merge" ]]; then
+      for ref in $p; do
+         git -C $CHECKOUT_DIR merge --quiet --allow-unrelated-histories refs/batch/$ref
+      done
+    elif [[ $mode == "cherry-pick" ]]; then
+      for ref in $p; do
+         git -C $CHECKOUT_DIR cherry-pick --allow-empty --keep-redundant-commits refs/batch/$ref
+      done
+    else
+        echo "unsupported mode $mode"
+        exit 1
+    fi
+
+    RESULT_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD)"
+    TREE_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD^{tree})"
+    # Make sure we don't add a trailing newline to the result!
+    echo -n "$(echo $RESULT_SHA | tr -d '\n')" > $(results.commit.path)
+    echo -n "$(echo $TREE_SHA | tr -d '\n')" > $(results.tree.path)

--- a/tekton/ci/stepactions/kustomization.yaml
+++ b/tekton/ci/stepactions/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- git-batch-merge.yaml
+- gcs-upload.yaml


### PR DESCRIPTION
StepActions were released in Tekton Pipelines v0.54.0. This PR uses step actions in our dogfooding cluster. Specifically, it uses stepactions to convert three sequential tasks into a single task with three steps.

Once we have a step action catalog, we can remove the step actions and reference them via remote resolvers.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc