### PR TITLE
Fix: Missing workspace bindings for Tasks

### DIFF
--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -120,6 +120,8 @@ spec:
         The token should be storage as a stringData with key "token" and
         value "your access token".
     - name: credentials
+      description: |
+        Path containing the GCS credentials to use during upload.
   tasks:
     - name: check-name-matches
       taskRef:
@@ -154,6 +156,10 @@ spec:
               printf '$(params.package)' | awk -F/ '{printf($2)}' | tee /tekton/results/repoName
     - name: clone-coverage-upload
       runAfter: ['split-full-repo-name']
+      workspaces:
+        - name: source
+        - name: credentials
+        - name: github-token
       taskSpec:
         steps:
           - name: clone
@@ -217,7 +223,7 @@ spec:
         workspaces:
         - name: source
           description: Location where the git repo will be installed.
-          mountPath: /go/src/github.com/tektoncd/$(params.repoName)
+          mountPath: /go/src/github.com/tektoncd/$(tasks.split-full-repo-name.results.repoName)
         - name: github-token
           description: |
             A secret workspace where the github personal access token resides.


### PR DESCRIPTION
This PR adds the missing workspace bindings for the clone-coverage-upload Task.
It fixes broken test: `pull-tekton-pipeline-go-coverage-df` 🤞 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._