### PR TITLE
Move CLI e2e job to kind

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -739,35 +739,48 @@ presubmits:
   - name: pull-tekton-cli-integration-tests
     labels:
       preset-presubmit-sh: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     agent: kubernetes
     always_run: true
     decorate: true
     rerun_command: "/test pull-tekton-cli-integration-tests"
     trigger: "(?m)^/test (all|pull-tekton-cli-integration-tests),?(\\s+|$)"
     spec:
+      nodeSelector:
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+        cloud.google.com/gke-nodepool: n2-standard-4-kind
+      tolerations:
+        - key: kind-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       containers:
       - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:bc9ad50aa7a1fef839543b282d7058f9505349637169d2e1d01771a574181070 # golang 1.20
         imagePullPolicy: Always
+        securityContext:
+          privileged: true
         command:
         - /usr/local/bin/entrypoint.sh
         args:
-        - "--scenario=kubernetes_execute_bazel"
-        - "--clean"
-        - "--job=$(JOB_NAME)"
-        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
         - "--service-account=/etc/test-account/service-account.json"
-        - "--upload=gs://tekton-prow/pr-logs"
         - "--" # end bootstrap args, scenario args below
         - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-        - "./test/presubmit-tests.sh"
-        - "--integration-tests"
+        - "/usr/local/bin/kind-e2e"
+        - "--k8s-version"
+        - "v1.25.x"
+        - "--nodes"
+        - "3"
+        - "--e2e-script"
+        - "./test/e2e-tests.sh"
+        - "--e2e-env"
+        - "./test/e2e-tests-kind-prow.env"
         resources:
           requests:
-            cpu: 2000m
+            cpu: 3500m
             memory: 4Gi
           limits:
-            cpu: 4000m
+            cpu: 3500m
             memory: 8Gi
   tektoncd/dashboard:
   - name: pull-tekton-dashboard-build-tests


### PR DESCRIPTION
This will move CLI e2e job to kind to make
it fast instead of spinning a gcp cluster
on every run

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._