### PR TITLE
Fix: StepResults usage typo

### DIFF
--- a/tekton/ci/stepactions/git-batch-merge.yaml
+++ b/tekton/ci/stepactions/git-batch-merge.yaml
@@ -152,5 +152,5 @@ spec:
     RESULT_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD)"
     TREE_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD^{tree})"
     # Make sure we don't add a trailing newline to the result!
-    echo -n "$(echo $RESULT_SHA | tr -d '\n')" > $(results.commit.path)
-    echo -n "$(echo $TREE_SHA | tr -d '\n')" > $(results.tree.path)
+    echo -n "$(echo $RESULT_SHA | tr -d '\n')" > $(step.results.commit.path)
+    echo -n "$(echo $TREE_SHA | tr -d '\n')" > $(step.results.tree.path)


### PR DESCRIPTION
The results declared in stepaction was being written to `results.<name>.path` instead of `step.results.<name>.path`. As a result, variable replacement was not being performed. This PR fixes that 🤞.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._