### PR TITLE
Publish StepActions to Tekton Bundles

### DIFF
--- a/tekton/resources/cd/catalog-template.yaml
+++ b/tekton/resources/cd/catalog-template.yaml
@@ -97,11 +97,6 @@ spec:
         workspace: shared
   - name: publish
     runAfter: ['create-dockerfile']
-    workspaces:
-      - name: catalog
-        workspace: shared
-      - name: dockerconfig
-        workspace: shared
     params:
     - name: REGISTRY
       value: "$(params.registry)"
@@ -109,8 +104,62 @@ spec:
       value: "$(params.registryPath)"
     - name: TAG
       value: "$(tasks.git-clone.results.commit)"
-    taskRef:
-      name: tekton-catalog-publish
+    workspaces:
+      - name: shared
+    taskSpec:
+      params:
+        - name: REGISTRY
+        - name: PATH
+        - name: TAG
+      workspaces:
+        - name: shared
+      steps:
+        - name: publish-tasks
+          ref:
+            resolver: git
+            params:
+              - name: url
+                value: https://github.com/tektoncd/catalog.git
+              - name: revision
+                value: main
+              - name: pathInRepo
+                value: stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
+          params:
+            - name: catalogPath
+              value: ${workspaces.shared.path}
+            - name: dockerconfigPath
+              value: ${workspaces.shared.path}
+            - name: RESOURCE
+              value: "task"
+            - name: REGISTRY
+              value: "$(params.REGISTRY)"
+            - name: PATH
+              value: "$(params.PATH)/tasks"
+            - name: TAG
+              value: "$(params.TAG)"
+        - name: publish-steps
+          ref:
+            resolver: git
+            params:
+              - name: url
+                value: https://github.com/tektoncd/catalog.git
+              - name: revision
+                value: main
+              - name: pathInRepo
+                value: stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
+          params:
+            - name: catalogPath
+              value: ${workspaces.shared.path}
+            - name: dockerconfigPath
+              value: ${workspaces.shared.path}
+            - name: RESOURCE
+              value: "stepaction"
+            - name: REGISTRY
+              value: "$(params.REGISTRY)"
+            - name: PATH
+              value: "$(params.PATH)/stepactions"
+            - name: TAG
+              value: "$(params.TAG)"
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate


### PR DESCRIPTION
This PR updates the pipeline that is used to publish Tasks to Tekton Bundle hosted at gcr.io/tekton-releases/catalog/upstream.

This PR makes use of the newly added StepAction `tekton-catalog-publush` to publish `Tasks` to `gcr.io/tekton-releases/catalog/upstream/tasks/` and `StepActions` to
`gcr.io/tekton-releases/catalog/upstream/stepactions`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc