### PR TITLE
Fix: typo in workspace reference

### DIFF
--- a/tekton/resources/cd/catalog-template.yaml
+++ b/tekton/resources/cd/catalog-template.yaml
@@ -126,9 +126,9 @@ spec:
                 value: stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
           params:
             - name: catalogPath
-              value: ${workspaces.shared.path}
+              value: $(workspaces.shared.path)
             - name: dockerconfigPath
-              value: ${workspaces.shared.path}
+              value: $(workspaces.shared.path)
             - name: RESOURCE
               value: "task"
             - name: REGISTRY
@@ -149,9 +149,9 @@ spec:
                 value: stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
           params:
             - name: catalogPath
-              value: ${workspaces.shared.path}
+              value: $(workspaces.shared.path)
             - name: dockerconfigPath
-              value: ${workspaces.shared.path}
+              value: $(workspaces.shared.path)
             - name: RESOURCE
               value: "stepaction"
             - name: REGISTRY


### PR DESCRIPTION
This PR fixes a typo that was made in the original PR https://github.com/tektoncd/plumbing/pull/1879.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind bug