### PR TITLE
Fix ulimit issue introduced with Docker 25 in the test-runner image

### DIFF
--- a/tekton/images/test-runner/runner.sh
+++ b/tekton/images/test-runner/runner.sh
@@ -50,6 +50,8 @@ export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Docker in Docker enabled, initializing..."
     printf '=%.0s' {1..80}; echo
+    # Fix ulimit issue introduced with Docker 25
+    sed -i 's/ulimit -Hn/ulimit -n/' /etc/init.d/docker || true
     # If we have opted in to docker in docker, start the docker daemon,
     service docker start
     # the service can be started but the docker socket not ready, wait for ready


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Resolves issue seen in Dashboard integration tests using latest test-runner image. Would also affect any other docker-in-docker jobs using the latest image.

```
Docker in Docker enabled, initializing...
================================================================================
/etc/init.d/docker: 62: ulimit: error setting limit (Invalid argument)
Waiting for docker to be ready, sleeping for 1 seconds.
Waiting for docker to be ready, sleeping for 2 seconds.
Waiting for docker to be ready, sleeping for [3](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:3) seconds.
Waiting for docker to be ready, sleeping for [4](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:4) seconds.
Waiting for docker to be ready, sleeping for [5](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:5) seconds.
Waiting for docker to be ready, sleeping for [6](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:6) seconds.
Waiting for docker to be ready, sleeping for [7](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:7) seconds.
Waiting for docker to be ready, sleeping for [8](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:8) seconds.
Waiting for docker to be ready, sleeping for [9](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:9) seconds.
Waiting for docker to be ready, sleeping for [10](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:10) seconds.
Waiting for docker to be ready, sleeping for [11](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:11) seconds.
Waiting for docker to be ready, sleeping for [12](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:12) seconds.
Waiting for docker to be ready, sleeping for [13](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:13) seconds.
Waiting for docker to be ready, sleeping for [14](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:14) seconds.
Waiting for docker to be ready, sleeping for [15](https://prow.tekton.dev/spyglass/lens/buildlog/iframe?req=%7B%22artifacts%22%3A%5B%22build-log.txt%22%5D%2C%22index%22%3A1%2C%22src%22%3A%22gs%2Ftekton-prow%2Fpr-logs%2Fpull%2Ftektoncd_dashboard%2F3361%2Fpull-tekton-dashboard-integration-tests%2F1772406843407077376%22%7D&topURL=https%3A//prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_dashboard/3361/pull-tekton-dashboard-integration-tests/1772406843407077376&lensIndex=1#build-log.txt:15) seconds.
Reached maximum attempts, not waiting any longer...
```

Apply the same fix adopted by kubernetes/test-infra and others to revert the `ulimit` command in the docker init script to the previous version.

See for example https://github.com/kubernetes/test-infra/pull/31908/files

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._