### PR TITLE
Bum cli e2e job to go 1.22

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -756,7 +756,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:bc9ad50aa7a1fef839543b282d7058f9505349637169d2e1d01771a574181070 # golang 1.20
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240326-621cd95055@sha256:0defbe8768d90765a2fdf5eae8119dba16ca5955691c4d697297db89d3f5c5af # golang 1.22
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
This will bump tektoncd/cli integration test CI to have go 1.22

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._