### PR TITLE
Bump Hub build, test and integration CI image to go 1.22

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -972,7 +972,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:98b6252cb90293d9c0459ead56e49285c1470e7434ff8af492decc7de50d6f7f # golang 1.20
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240326-621cd95055@sha256:0defbe8768d90765a2fdf5eae8119dba16ca5955691c4d697297db89d3f5c5af # golang 1.22
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -998,7 +998,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:98b6252cb90293d9c0459ead56e49285c1470e7434ff8af492decc7de50d6f7f # golang 1.20
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240326-621cd95055@sha256:0defbe8768d90765a2fdf5eae8119dba16ca5955691c4d697297db89d3f5c5af # golang 1.22
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1024,7 +1024,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:98b6252cb90293d9c0459ead56e49285c1470e7434ff8af492decc7de50d6f7f # golang 1.20
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240326-621cd95055@sha256:0defbe8768d90765a2fdf5eae8119dba16ca5955691c4d697297db89d3f5c5af # golang 1.22
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
This will bump tektoncd/hub build, unit and integration test CI image to use go 1.22

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._