### PR TITLE
Add example testsuite for tekton-pipeline CI job for ppc64le

### DIFF
--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -147,11 +147,41 @@ spec:
             value: $(params.container-registry)
           - name: target-arch
             value: $(params.target-arch)
+        - name: examples-test-pipeline
+          runAfter: [e2e-test-pipeline]
+          taskRef:
+            name: test-e2e-tekton-component
+          workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: registry-shared
+            workspace: shared-workspace
+            subPath: registry-shared
+          - name: source-code
+            workspace: shared-workspace
+            subPath: source-code
+          retries: 2
+          params:
+          - name: package
+            value: github.com/tektoncd/pipeline
+          - name: container-registry
+            value: "192.168.156.194:5000"
+          - name: target-arch
+            value: $(params.target-arch)
+          - name: tags
+            value: "examples"
         finally:
         - name: delete-k8s-cluster
           taskRef:
             name: create-delete-k8s-cluster-$(tt.params.targetArch)
           workspaces:
+          - name: k8s-shared
+            workspace: shared-workspace
+            subPath: k8s-shared
+          - name: registry-shared
+            workspace: shared-workspace
+            subPath: registry-shared
           - name: ssh-secret
             workspace: ssh-secret
           params:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
This PR adds the previously missing example-test in the tekton-pipeline CI job for ppc64le
# Changes
Added the previously missing example-test-pipeline for the tekton-pipeline CI job.

Additionally have hard coded the value for container registry with an insecure local registry to fix pipelines CI failure due to push permission error as mentioned in this PR #1399 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._