### PR TITLE
Fix peribolos secret in the tekton-cd el

### DIFF
--- a/tekton/resources/cd/peribolos-template.yaml
+++ b/tekton/resources/cd/peribolos-template.yaml
@@ -24,7 +24,7 @@ spec:
         workspaces:
           - name: github-oauth
             secret:
-              secretName: bot-token-github
+              secretName: peribolos-token-github
           - name: shared-workspace
             volumeClaimTemplate:
               spec:


### PR DESCRIPTION
# Changes

When peribolos is run via cron, it uses a different template, so we must update the secret there too.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

/kind misc