### PR TITLE
Enable feature flags for running tests on s390x/ppc64le platform

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
@@ -57,5 +57,7 @@ spec:
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       # extend test timeout (from 10 minutes to 20 minutes) to resolve https://github.com/tektoncd/pipeline/issues/3627
       sed -i 's/timeout  = 10/timeout  = 20/g' test/wait.go
+      #Enable Step Actions,Disable Affinity Assistant feature flags to run testcases in the cluster
+      kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-step-actions":"true","disable-affinity-assistant":"true"}}'
       header "Running Go $(params.tags) tests"
       report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path) -kubeconfig /root/.kube/config

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
@@ -56,5 +56,7 @@ spec:
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       # extend test timeout (from 10 minutes to 20 minutes) to resolve https://github.com/tektoncd/pipeline/issues/3627
       sed -i 's/timeout  = 10/timeout  = 20/g' test/wait.go
+      #Enable Step Actions,Disable Affinity Assistant feature flags for some tests in the cluster
+      kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-step-actions":"true","disable-affinity-assistant":"true"}}'
       header "Running Go $(params.tags) tests"
       report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path) -kubeconfig $(workspaces.k8s-shared.path)/config


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Stepactions/affinity Testscases are failing in s390x/ppc64le CI environment. Need to enabling the feature flags of pipelines before running testcases. this PR will fix this issues. 



/kind misc
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._