### PR TITLE
Upgrade alpha integration tests kind cluster

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1358,7 +1358,7 @@ presubmits:
             - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
             - "/usr/local/bin/kind-e2e"
             - "--k8s-version"
-            - "v1.28.x"
+            - "v1.29.x"
             - "--nodes"
             - "3"
             - "--e2e-script"


### PR DESCRIPTION
This PR upgrades alpha integration test kind cluster to kubernetes evrsion `1.29.x`. This will allow us to test https://github.com/tektoncd/pipeline/pull/8052 in this version in our CI.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._