### PR TITLE
Update test-runner image to the latest…

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -412,7 +412,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-catlin-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -438,7 +438,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-catlin-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -464,7 +464,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-catlin-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -515,7 +515,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -548,7 +548,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -581,7 +581,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -647,7 +647,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -680,7 +680,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-cross-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -713,7 +713,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -756,7 +756,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -793,7 +793,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -819,7 +819,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -855,7 +855,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -892,7 +892,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -918,7 +918,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -945,7 +945,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -972,7 +972,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -998,7 +998,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1024,7 +1024,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1051,7 +1051,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1084,7 +1084,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1127,7 +1127,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1195,7 +1195,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1228,7 +1228,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1302,7 +1302,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1348,7 +1348,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1406,7 +1406,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1443,7 +1443,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1469,7 +1469,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1505,7 +1505,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -1625,7 +1625,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-results-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1651,7 +1651,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-results-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1696,7 +1696,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1750,7 +1750,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1776,7 +1776,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-triggers-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1802,7 +1802,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1853,7 +1853,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-gen-crd-api-reference-docs-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -2019,7 +2019,7 @@ periodics:
         value: "true"
         effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
       imagePullPolicy: Always
       command:
         - /usr/local/bin/entrypoint.sh
@@ -2071,7 +2071,7 @@ periodics:
       value: "true"
       effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
       imagePullPolicy: Always
       securityContext:
         privileged: true
@@ -2123,7 +2123,7 @@ periodics:
         value: "true"
         effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240619-d8417ca086@sha256:5cc038f2e63b8d0ba676e2be2870d9ccabcbd11b4b799e9f63c04705ad6fa37d # go 1.22, kind 0.23, ko 0.15.4
+    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
       imagePullPolicy: Always
       command:
         - /usr/local/bin/entrypoint.sh


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

… for some reason the other one is not the correct one (still
go-licenses 1.6.0 where we want 1.0.0).

```
$ docker run -ti --rm --entrypoint=/bin/bash gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:…
/usr/local/go/bin/go-licenses: go1.22.1
	path	github.com/google/go-licenses
	mod	github.com/google/go-licenses	v1.0.0	h1:g1cIS3R6lP1bTILdSHWyVOMMzD/VuEg1SG/kWES80eY=
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

This will fix dependabot pull-requests issues on tektoncd/pipeline at
least.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
