### PR TITLE
Do not fail on missing dockerfile

### DIFF
--- a/tekton/ci/jobs/tekton-image-build.yaml
+++ b/tekton/ci/jobs/tekton-image-build.yaml
@@ -47,7 +47,9 @@ spec:
       while [ ! -f "${CONTEXT}/Dockerfile" ]; do
         if [ "${CONTEXT}" == "/" ]; then
           echo "No Dockerfile found in ${FQ_DOCKER_FILE}'s directory or any of its parents"
-          exit 1
+          # The file may be missing if it was deleted as part of the PR
+          # so we stop building but do not fail
+          exit 0
         fi
         CONTEXT=$(dirname ${CONTEXT})
       done


### PR DESCRIPTION
# Changes

When a dockerfile is removed, the build CI job fails today as it see the file in the list of modified ones, but cannot locate it to run the test.

This still logs the missing file condition, but do not fail, so that we may pass CI on PRs that delete a dockerfile, like:
- https://github.com/tektoncd/plumbing/pull/2065
- https://github.com/tektoncd/plumbing/pull/2064

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._