### PR TITLE
Move the pipeline nightly build to ghcr

### DIFF
--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -84,6 +84,12 @@ spec:
                       "gitRepository": "$GIT_REPO",
                       "versionTag": "$VERSION_TAG",
                       "projectName": "$PROJECT_NAME"
+                    },
+                    "registry": {
+                      "baseUri": "$CR_URI",
+                      "path": "$CR_PATH",
+                      "regions": "$CR_REGIONS",
+                      "user": "$CR_USER"
                     }
                   }
                 }

--- a/tekton/cronjobs/dogfooding/releases/pipeline-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-nightly/cronjob.yaml
@@ -14,6 +14,14 @@ spec:
             env:
               - name: PROJECT_NAME
                 value: pipeline
+              - name: CR_URI
+                value: ghcr.io
+              - name: CR_PATH
+                value: tektoncd
+              - name: CR_REGIONS
+                value: ""
+              - name: CR_USER
+                value: tekton-robot
           initContainers:
           - name: git
             env:

--- a/tekton/resources/nightly-release/base/template.yaml
+++ b/tekton/resources/nightly-release/base/template.yaml
@@ -18,5 +18,11 @@ spec:
   - name: imageRegistryPath
     description: Registry project where the images will be published to.
     default: tekton-nightly
+  - name: imageRegistryRegions
+    description: Regions of the registry (for gcr.io)
+    default: "us eu asia"
+  - name: imageRegistryUser
+    description: Registry user for authentication.
+    default: _json_key
   - name: projectName
     description: Name of the Tekton project to release (e.g. pipeline, triggers, etc).

--- a/tekton/resources/nightly-release/bindings.yaml
+++ b/tekton/resources/nightly-release/bindings.yaml
@@ -14,3 +14,11 @@ spec:
     value: $(body.params.release.versionTag)
   - name: projectName
     value: $(body.params.release.projectName)
+  - name: imageRegistry
+    value: $(body.params.registry.baseUri)
+  - name: imageRegistryPath
+    value: $(body.params.registry.path)
+  - name: imageRegistryRegions
+    value: $(body.params.registry.regions)
+  - name: imageRegistryUser
+    value: $(body.params.registry.user)

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -19,10 +19,16 @@
           value: $(tt.params.imageRegistry)
         - name: imageRegistryPath
           value: $(tt.params.imageRegistryPath)
+        - name: imageRegistryUser
+          value: $(tt.params.imageRegistryUser)
+        - name: imageRegistryRegions
+          value: $(tt.params.imageRegistryRegions)
         - name: versionTag
           value: $(tt.params.versionTag)
         - name: serviceAccountPath
           value: release.json
+        - name: serviceAccountImagesPath
+          value: credentials
         timeouts:
           pipeline: 2h30m0s
         workspaces:
@@ -37,3 +43,6 @@
           - name: release-secret
             secret:
               secretName: release-secret
+          - name: release-image-secret
+            secret:
+              secretName: ghcr-creds


### PR DESCRIPTION
# Changes

After the following changes on pipeline side:
- Regions configurable: Make image registry regions configurable https://github.com/tektoncd/pipeline#8246
- Auth for ghcr.io: Support separate bucket and image reg creds https://github.com/tektoncd/pipeline#8251
- Link images to project: Add OCI source label to images https://github.com/tektoncd/pipeline#8247

This change enables publishing the nightly build
images to ghcr.io.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._