### PR TITLE
Fix kustomize for new version

### DIFF
--- a/tekton/cd/chains/base/kustomization.yaml
+++ b/tekton/cd/chains/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cd/chains/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/chains/overlays/dogfooding/kustomization.yaml
@@ -1,6 +1,8 @@
-bases:
-  - ../../base
-patchesStrategicMerge:
-  - chains-config.yaml
-  - config-observability.yaml
-  - serviceaccount.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: chains-config.yaml
+- path: config-observability.yaml
+- path: serviceaccount.yaml

--- a/tekton/cd/dashboard/base/kustomization.yaml
+++ b/tekton/cd/dashboard/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cd/dashboard/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/kustomization.yaml
@@ -1,7 +1,8 @@
-bases:
-- ../../base
-patchesStrategicMerge:
-- tekton-dashboard-service.yaml
 resources:
 - ingress.yaml
 - extensions.yaml
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: tekton-dashboard-service.yaml

--- a/tekton/cd/dashboard/overlays/robocat/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/robocat/kustomization.yaml
@@ -1,6 +1,7 @@
-bases:
-- ../../base
-patchesStrategicMerge:
-- tekton-dashboard-service.yaml
 resources:
 - ingress.yaml
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: tekton-dashboard-service.yaml

--- a/tekton/cd/pipeline/base/kustomization.yaml
+++ b/tekton/cd/pipeline/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/dogfooding/kustomization.yaml
@@ -1,9 +1,11 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../base
-patchesStrategicMerge:
-- config-defaults.yaml
-- config-observability.yaml
-- webhook.yaml
-- controller.yaml
-- feature-flags.yaml
-- git-resolver-config.yaml
+patches:
+- path: config-defaults.yaml
+- path: config-observability.yaml
+- path: webhook.yaml
+- path: controller.yaml
+- path: feature-flags.yaml
+- path: git-resolver-config.yaml

--- a/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/robocat/kustomization.yaml
@@ -1,6 +1,7 @@
-bases:
-- ../../base
-patchesStrategicMerge:
-- feature-flags.yaml
 resources:
 - tekton-storage-secret.yaml
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: feature-flags.yaml

--- a/tekton/cd/results/base/kustomization.yaml
+++ b/tekton/cd/results/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
-  - https://storage.googleapis.com/tekton-releases/results/latest/release.yaml
+- https://storage.googleapis.com/tekton-releases/results/latest/release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cd/results/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/results/overlays/dogfooding/kustomization.yaml
@@ -1,9 +1,10 @@
-bases:
-- ../../base
-patchesStrategicMerge:
-- service.yaml
-- watcher.yaml
 resources:
 - ingress.yaml
 - bec.yaml
 - rbac.yaml
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: service.yaml
+- path: watcher.yaml

--- a/tekton/cd/triggers/base/kustomization.yaml
+++ b/tekton/cd/triggers/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cd/triggers/overlays/dogfooding/kustomization.yaml
+++ b/tekton/cd/triggers/overlays/dogfooding/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../base
-patchesStrategicMerge:
-- feature-flags.yaml
+patches:
+- path: feature-flags.yaml

--- a/tekton/cd/triggers/overlays/robocat/kustomization.yaml
+++ b/tekton/cd/triggers/overlays/robocat/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../base
-# patchesStrategicMerge:
-# -

--- a/tekton/ci/bases/kustomization.yaml
+++ b/tekton/ci/bases/kustomization.yaml
@@ -1,7 +1,11 @@
-commonLabels:
-  app: tekton.ci
 resources:
-  - template.yaml
-  - trigger.yaml
+- template.yaml
+- trigger.yaml
 configurations:
 - kustomizeconfig/trigger.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app: tekton.ci

--- a/tekton/ci/cluster-interceptors/add-pr-body/tekton/kustomization.yaml
+++ b/tekton/ci/cluster-interceptors/add-pr-body/tekton/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - publish.yaml
-  - release-pipeline.yaml
+- publish.yaml
+- release-pipeline.yaml

--- a/tekton/ci/cluster-interceptors/build-id/tekton/kustomization.yaml
+++ b/tekton/ci/cluster-interceptors/build-id/tekton/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - publish.yaml
-  - release-pipeline.yaml
+- publish.yaml
+- release-pipeline.yaml

--- a/tekton/ci/custom-tasks/pr-commenter/tekton/kustomization.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/tekton/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - publish.yaml
-  - release-pipeline.yaml
+- publish.yaml
+- release-pipeline.yaml

--- a/tekton/ci/custom-tasks/pr-status-updater/tekton/kustomization.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/tekton/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - publish.yaml
-  - release-pipeline.yaml
+- publish.yaml
+- release-pipeline.yaml

--- a/tekton/ci/infra/kustomization.yaml
+++ b/tekton/ci/infra/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
 - 0001_rbac.yaml
 - ingress.yaml
 - namespace.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/interceptors/add-pr-body/tekton/kustomization.yaml
+++ b/tekton/ci/interceptors/add-pr-body/tekton/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - publish.yaml
-  - release-pipeline.yaml
+- publish.yaml
+- release-pipeline.yaml

--- a/tekton/ci/interceptors/add-team-members/tekton/kustomization.yaml
+++ b/tekton/ci/interceptors/add-team-members/tekton/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - publish.yaml
-  - release-pipeline.yaml
+- publish.yaml
+- release-pipeline.yaml

--- a/tekton/ci/jobs/kustomization.yaml
+++ b/tekton/ci/jobs/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
 - tekton-yamllint.yaml
 - tekton-github-tasks-completed.yaml
 - tekton-golang-coverage.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/kustomization.yaml
+++ b/tekton/ci/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 - stepactions
 - jobs
 - repos
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/repos/catalog/base/kustomization.yaml
+++ b/tekton/ci/repos/catalog/base/kustomization.yaml
@@ -1,10 +1,12 @@
-bases:
-  - ../../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../bases

--- a/tekton/ci/repos/catalog/community-catalog/kustomization.yaml
+++ b/tekton/ci/repos/catalog/community-catalog/kustomization.yaml
@@ -1,16 +1,18 @@
 namePrefix: tekton-catalog-
-bases:
-  - ../base
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/tekton/ci/repos/catalog/kustomization.yaml
+++ b/tekton/ci/repos/catalog/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-  - community-catalog
-  - verified-catalogs
+- community-catalog
+- verified-catalogs
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/repos/catalog/verified-catalogs/base/kustomization.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/base/kustomization.yaml
@@ -1,11 +1,13 @@
 namePrefix: tekton-verified-catalog-
-bases:
-  - ../../base
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/tekton/ci/repos/catalog/verified-catalogs/golang/kustomization.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/golang/kustomization.yaml
@@ -1,10 +1,12 @@
 namePrefix: golang-
-bases:
-  - ../base
 
 patches:
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/tekton/ci/repos/catalog/verified-catalogs/kustomization.yaml
+++ b/tekton/ci/repos/catalog/verified-catalogs/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
-  - golang
+- golang
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/repos/community/kustomization.yaml
+++ b/tekton/ci/repos/community/kustomization.yaml
@@ -1,16 +1,18 @@
 namePrefix: tekton-community-
-bases:
-  - ../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../bases

--- a/tekton/ci/repos/kustomization.yaml
+++ b/tekton/ci/repos/kustomization.yaml
@@ -1,7 +1,9 @@
 resources:
-  - community
-  - plumbing
-  - catalog
-  - website
-  - pipeline
-  - shared
+- community
+- plumbing
+- catalog
+- website
+- pipeline
+- shared
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/repos/pipeline/kustomization.yaml
+++ b/tekton/ci/repos/pipeline/kustomization.yaml
@@ -1,16 +1,18 @@
 namePrefix: tekton-pipeline-
-bases:
-  - ../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../bases

--- a/tekton/ci/repos/plumbing/kustomization.yaml
+++ b/tekton/ci/repos/plumbing/kustomization.yaml
@@ -1,16 +1,18 @@
 namePrefix: tekton-plumbing-
-bases:
-  - ../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../bases

--- a/tekton/ci/repos/shared/all/kustomization.yaml
+++ b/tekton/ci/repos/shared/all/kustomization.yaml
@@ -1,16 +1,18 @@
 namePrefix: all-
-bases:
-  - ../../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../bases

--- a/tekton/ci/repos/shared/doc-reviews/kustomization.yaml
+++ b/tekton/ci/repos/shared/doc-reviews/kustomization.yaml
@@ -1,22 +1,24 @@
-bases:
-  - ../../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger-pr.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
-      name: pull-request
-  - path: trigger-comment.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
-      name: issue-comment
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger-pr.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: pull-request
+    version: v1beta1
+- path: trigger-comment.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: issue-comment
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../bases

--- a/tekton/ci/repos/shared/kustomization.yaml
+++ b/tekton/ci/repos/shared/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
 - all
 - doc-reviews
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/repos/website/kustomization.yaml
+++ b/tekton/ci/repos/website/kustomization.yaml
@@ -1,16 +1,18 @@
 namePrefix: tekton-website-
-bases:
-  - ../../bases
 
 patches:
-  - path: template.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: TriggerTemplate
-      name: ci-pipeline
-  - path: trigger.yaml
-    target:
-      group: triggers.tekton.dev
-      version: v1beta1
-      kind: Trigger
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: ci-pipeline
+    version: v1beta1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    version: v1beta1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../bases

--- a/tekton/ci/shared/kustomization.yaml
+++ b/tekton/ci/shared/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - eventlistener.yaml
 - gubernator-metadata.yaml
 - labels.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/ci/stepactions/kustomization.yaml
+++ b/tekton/ci/stepactions/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
 - git-batch-merge.yaml
 - gcs-upload.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/catalog/kustomization.yaml
+++ b/tekton/cronjobs/bases/catalog/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/cleanup/kustomization.yaml
+++ b/tekton/cronjobs/bases/cleanup/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/configmap/kustomization.yaml
+++ b/tekton/cronjobs/bases/configmap/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/folder/kustomization.yaml
+++ b/tekton/cronjobs/bases/folder/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/helm/kustomization.yaml
+++ b/tekton/cronjobs/bases/helm/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/image-build/kustomization.yaml
+++ b/tekton/cronjobs/bases/image-build/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-image-build.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/nightly-tests/kustomization.yaml
+++ b/tekton/cronjobs/bases/nightly-tests/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-nightly-test.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/peribolos/kustomization.yaml
+++ b/tekton/cronjobs/bases/peribolos/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/release/kustomization.yaml
+++ b/tekton/cronjobs/bases/release/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-with-uuid.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/bases/tekton-service/kustomization.yaml
+++ b/tekton/cronjobs/bases/tekton-service/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - trigger-resource-cd.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/catalog/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/catalog/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - tekton-upstream
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/catalog/tekton-upstream/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/catalog/tekton-upstream/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -tekton-upstream
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/catalog
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-tekton-upstream"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-p-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-bastion-p
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/cleanup
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-bastion-p"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/bastion-z-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-bastion-z
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/cleanup
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-bastion-z"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/cleanup/default-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/default-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/cleanup
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-default"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/cleanup/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - tekton-ci-nightly
 - tekton-nightly-nightly
 - bastion-p-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/cleanup/tekton-ci-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/tekton-ci-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-tekton-ci
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/cleanup
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-tekton-ci"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/cleanup/tekton-nightly-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/cleanup/tekton-nightly-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-tekton-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/cleanup
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-tekton-nightly"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/configmaps/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/configmaps/kustomization.yaml
@@ -3,3 +3,5 @@ resources:
 - prow-labels-sync-hourly
 - prow-config-hourly
 - prow-plugins-hourly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/configmaps/labels-sync-hourly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/configmaps/labels-sync-hourly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -label-sync-dogfooding
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/configmap
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-label-sync-dogfooding"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/configmaps/prow-config-hourly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/configmaps/prow-config-hourly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -prow-config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/configmap
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-prow-config"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/configmaps/prow-labels-sync-hourly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/configmaps/prow-labels-sync-hourly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -label-sync
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/configmap
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-label-sync"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/configmaps/prow-plugins-hourly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/configmaps/prow-plugins-hourly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -prow-plugins
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/configmap
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-prow-plugins"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/helm/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/helm/kustomization.yaml
@@ -1,2 +1,2 @@
-# yamllint disable-line rule:empty-values
-resources:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -alpine-git-nonroot
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-alpine-git-nonroot"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -buildx-gcloud
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-buildx-gcloud"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-  - ../../../bases/image-build
-patchesStrategicMerge:
-  - cronjob.yaml
-nameSuffix: "-catlin"
+nameSuffix: -catlin
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../bases/image-build
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/coverage-image-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/coverage-image-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -coverage
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-coverage"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -go-rest-api-test
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-go-rest-api-test"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/hub-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/hub-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -hub
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-hub"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/kind-e2e-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kind-e2e-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -kind-e2e
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-kind-e2e"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/kind-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kind-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -kind
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-kind"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/ko-gcloud-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/ko-gcloud-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -ko-gcloud
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-ko-gcloud"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/ko-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/ko-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -ko
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-ko"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/koparse-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/koparse-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -koparse
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-koparse"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/kubectl-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kubectl-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -kubectl
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-kubectl"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
 - kind-nightly
 - go-rest-api-test-nightly
 - kind-e2e-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/images/pipeline-test-runner-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/pipeline-test-runner-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -test-runner
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-test-runner"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/teps-community-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/teps-community-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -teps
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-teps"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/images/tkn-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/images/tkn-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -tkn
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/image-build
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-tkn"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/kustomization.yaml
@@ -4,7 +4,6 @@ commonAnnotations:
 resources:
 - cleanup
 - configmaps
-- helm
 - images
 - manifests
 - releases
@@ -12,3 +11,5 @@ resources:
 - nightly-tests
 - catalog
 - peribolos
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/manifests/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
 - plumbing-tekton
 - plumbing-tekton-cronjobs
 - plumbing-tekton-cronjobs-robocat
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs-robocat/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-tekton-cronjobs-robocat
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/folder
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-tekton-cronjobs-robocat"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton-cronjobs/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-tekton-cronjobs
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/folder
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-tekton-cronjobs"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/manifests/plumbing-tekton/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/manifests/plumbing-tekton/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dogfooding-tekton
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/folder
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dogfooding-tekton"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/kustomization.yaml
@@ -2,3 +2,5 @@ namespace: default
 resources:
 - s390x
 - ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/catalog-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/catalog-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -catalog-ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-catalog-ppc64le"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/cli-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -cli-ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-cli-ppc64le"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/dashboard-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dashboard-ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dashboard-ppc64le"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - operator-nightly-test
 - dashboard-nightly-test
 - catalog-nightly-test
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/operator-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -operator-ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-operator-ppc64le"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/pipeline-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pipeline-ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pipeline-ppc64le"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/ppc64le/triggers-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -triggers-ppc64le
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-triggers-ppc64le"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/catalog-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -catalog-s390x
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-catalog-s390x"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/cli-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -cli-s390x
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-cli-s390x"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/dashboard-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dashboard-s390x
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dashboard-s390x"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - operator-nightly-test
 - dashboard-nightly-test
 - catalog-nightly-test
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/operator-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -operator-s390x
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-operator-s390x"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/pipeline-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/pipeline-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pipeline-s390x
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pipeline-s390x"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/nightly-tests/s390x/triggers-nightly-test/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/nightly-tests/s390x/triggers-nightly-test/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -triggers-s390x
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../../bases/nightly-tests
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-triggers-s390x"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/peribolos/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/peribolos/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - tektoncd
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/peribolos/tektoncd/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/peribolos/tektoncd/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -tektoncd
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/peribolos
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-tektoncd"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/add-pr-body-ci-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -add-pr-body-ci-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-add-pr-body-ci-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/add-pr-body-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/add-pr-body-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -add-pr-body-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-add-pr-body-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/add-team-members-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/add-team-members-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -add-team-mem-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-add-team-mem-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/cel-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/cel-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -cel-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-cel-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/chains-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/chains-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -chains-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-chains-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/cloudevents-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -cloudevents-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-cloudevents-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/concurrency-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/concurrency-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -concurrency-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-concurrency-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/dashboard-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/dashboard-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -dashboard-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-dashboard-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/kustomization.yaml
@@ -18,3 +18,5 @@ resources:
 - pr-status-updater-nightly
 - concurrency-nightly
 - workflows-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/releases/operator-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/operator-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -operator-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-operator-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-in-pod-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pipeline-in-pod-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pipeline-in-pod-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/pipeline-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pipeline-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pipeline-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-to-taskrun-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pipeline-to-tr-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pipeline-to-tr-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/pipelines-in-pipelines-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipelines-in-pipelines-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pip-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pip-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/pr-commenter-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pr-commenter-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pr-commenter-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pr-commenter-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/pr-status-updater-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pr-status-updater-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -pr-status-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-pr-status-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/task-loops-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/task-loops-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -task-loops-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-task-loops-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/triggers-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/triggers-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -triggers-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-triggers-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/wait-task-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/wait-task-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -wait-task-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-wait-task-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/releases/workflows-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/releases/workflows-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -workflows-nightly-release
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/release
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-workflows-nightly-release"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/tekton/dashboard-to-robocat-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/dashboard-to-robocat-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robotcat-dashboard
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/tekton-service
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robotcat-dashboard"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/tekton/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
 - dashboard-to-robocat-nightly
 - pipeline-to-robocat-nightly
 - triggers-to-robotcat-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/dogfooding/tekton/pipeline-to-robocat-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/pipeline-to-robocat-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robotcat-pipeline
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/tekton-service
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robotcat-pipeline"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/dogfooding/tekton/triggers-to-robotcat-nightly/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/tekton/triggers-to-robotcat-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robotcat-triggers
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/tekton-service
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robotcat-triggers"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/robocat/cleanup/kustomization.yaml
+++ b/tekton/cronjobs/robocat/cleanup/kustomization.yaml
@@ -1,2 +1,2 @@
-# yamllint disable-line rule:empty-values
-resources:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/configmaps/kustomization.yaml
+++ b/tekton/cronjobs/robocat/configmaps/kustomization.yaml
@@ -1,2 +1,2 @@
-# yamllint disable-line rule:empty-values
-resources:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/helm/cert-manager-nightly/kustomization.yaml
+++ b/tekton/cronjobs/robocat/helm/cert-manager-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robocat-cert-manager
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/helm
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robocat-cert-manager"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/robocat/helm/kustomization.yaml
+++ b/tekton/cronjobs/robocat/helm/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
 - cert-manager-nightly
 - minio-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/helm/minio-nightly/kustomization.yaml
+++ b/tekton/cronjobs/robocat/helm/minio-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -minio-helm
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/helm
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-minio-helm"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/robocat/images/kustomization.yaml
+++ b/tekton/cronjobs/robocat/images/kustomization.yaml
@@ -1,2 +1,2 @@
-# yamllint disable-line rule:empty-values
-resources:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/kustomization.yaml
+++ b/tekton/cronjobs/robocat/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 - manifests
 - releases
 - tekton
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/manifests/cadmin-nightly/kustomization.yaml
+++ b/tekton/cronjobs/robocat/manifests/cadmin-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robotcat-cadmin
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/folder
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robotcat-cadmin"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/robocat/manifests/certificates-on-demand/kustomization.yaml
+++ b/tekton/cronjobs/robocat/manifests/certificates-on-demand/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robotcat-cluster-issuer
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/folder
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robotcat-cluster-issuer"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/robocat/manifests/kustomization.yaml
+++ b/tekton/cronjobs/robocat/manifests/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
 - cadmin-nightly
 - certificates-on-demand
 - plumbing-tekton-resources-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/manifests/plumbing-tekton-resources-nightly/kustomization.yaml
+++ b/tekton/cronjobs/robocat/manifests/plumbing-tekton-resources-nightly/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
+nameSuffix: -robotcat-tekton-resources
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../../bases/folder
-patchesStrategicMerge:
-- cronjob.yaml
-nameSuffix: "-robotcat-tekton-resources"
+patches:
+- path: cronjob.yaml

--- a/tekton/cronjobs/robocat/releases/kustomization.yaml
+++ b/tekton/cronjobs/robocat/releases/kustomization.yaml
@@ -1,2 +1,2 @@
-# yamllint disable-line rule:empty-values
-resources:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/cronjobs/robocat/tekton/kustomization.yaml
+++ b/tekton/cronjobs/robocat/tekton/kustomization.yaml
@@ -1,2 +1,2 @@
-# yamllint disable-line rule:empty-values
-resources:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - resources
 - ci
 - mario-bot
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/mario-bot/kustomization.yaml
+++ b/tekton/mario-bot/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - mario-github-comment.yaml
 - mario-image-build-trigger.yaml
 - ingress.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/cd/kustomization.yaml
+++ b/tekton/resources/cd/kustomization.yaml
@@ -2,18 +2,18 @@ commonAnnotations:
   managed-by: Tekton
 
 patches:
-- target:
-    kind: ServiceAccount|Deployment|EventListener|TriggerBinding|TriggerTemplate
-  patch: |-
+- patch: |-
     - op: replace
       path: /metadata/namespace
       value: default
-- target:
-    kind: RoleBinding|ClusterRoleBinding
-  patch: |-
+  target:
+    kind: ServiceAccount|Deployment|EventListener|TriggerBinding|TriggerTemplate
+- patch: |-
     - op: replace
       path: /subjects/0/namespace
       value: default
+  target:
+    kind: RoleBinding|ClusterRoleBinding
 
 resources:
 - bindings.yaml
@@ -30,3 +30,5 @@ resources:
 - ci-triggers.yaml
 - peribolos-template.yaml
 - install-tekton-release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/ci/kustomization.yaml
+++ b/tekton/resources/ci/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - bindings.yaml
 - github-template.yaml
 - github-gubernator-template.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/images/kustomization.yaml
+++ b/tekton/resources/images/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 - eventlistener.yaml
 - docker-multi-arch-template.yaml
 - ko-multi-arch-template.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 - ci
 - nightly-release
 - nightly-tests
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/nightly-release/base/kustomization.yaml
+++ b/tekton/resources/nightly-release/base/kustomization.yaml
@@ -1,11 +1,15 @@
 namePrefix: nightly-release-
-commonLabels:
-  app: tekton.plumbing
 commonAnnotations:
   release: nightly
 resources:
-  - template.yaml
-  - trigger.yaml
+- template.yaml
+- trigger.yaml
 configurations:
 - kustomizeconfig/eventlistener.yaml
 - kustomizeconfig/pipeline.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    app: tekton.plumbing

--- a/tekton/resources/nightly-release/kustomization.yaml
+++ b/tekton/resources/nightly-release/kustomization.yaml
@@ -22,3 +22,5 @@ resources:
 - overlays/pr-status-updater
 - overlays/concurrency
 - overlays/workflows
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/nightly-release/overlays/add-pr-body-ci/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/add-pr-body-ci/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: add-pr-body-ci-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/plumbing/tekton/ci/cluster-interceptors/add-pr-body/tekton/?ref=main
+- github.com/tektoncd/plumbing/tekton/ci/cluster-interceptors/add-pr-body/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/add-pr-body/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/add-pr-body/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: add-pr-body-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/plumbing/tekton/ci/interceptors/add-pr-body/tekton/?ref=main
+- github.com/tektoncd/plumbing/tekton/ci/interceptors/add-pr-body/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/add-team-members/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/add-team-members/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: add-team-members-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/plumbing/tekton/ci/interceptors/add-team-members/tekton/?ref=main
+- github.com/tektoncd/plumbing/tekton/ci/interceptors/add-team-members/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/cel/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/cel/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: cel-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/cel/tekton/?ref=main
+- github.com/tektoncd/experimental/cel/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/chains/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/chains/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: chains-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/chains/release/?ref=main
+- github.com/tektoncd/chains/release/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/cloudevents/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/cloudevents/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: cloudevents-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/cloudevents/tekton/?ref=main
+- github.com/tektoncd/experimental/cloudevents/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/concurrency/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/concurrency/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: concurrency-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/tekton/?ref=main
+- github.com/tektoncd/experimental/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/dashboard/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: dashboard-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/dashboard/tekton/?ref=main
+- github.com/tektoncd/dashboard/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/operator/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/operator/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: operator-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/operator/tekton?ref=main
+- github.com/tektoncd/operator/tekton?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/pipeline-in-pod/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-in-pod/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: pipeline-in-pod-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/tekton/?ref=main
+- github.com/tektoncd/experimental/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline-to-taskrun/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: pipeline-to-taskrun-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/pipeline-to-taskrun/tekton/?ref=main
+- github.com/tektoncd/experimental/pipeline-to-taskrun/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/pipeline/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: pipeline-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/pipeline/tekton/?ref=main
+- github.com/tektoncd/pipeline/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/pipelines-in-pipelines/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pipelines-in-pipelines/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: pipelines-in-pipelines-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/pipelines-in-pipelines/tekton/?ref=main
+- github.com/tektoncd/experimental/pipelines-in-pipelines/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/pr-commenter/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pr-commenter/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: pr-commenter-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-commenter/tekton/?ref=main
+- github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-commenter/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/pr-status-updater/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/pr-status-updater/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: pr-status-updater-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-status-updater/tekton/?ref=main
+- github.com/tektoncd/plumbing/tekton/ci/custom-tasks/pr-status-updater/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/task-loops/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/task-loops/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: task-loops-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/task-loops/tekton/?ref=main
+- github.com/tektoncd/experimental/task-loops/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/triggers/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: triggers-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/triggers/tekton/?ref=main
+- github.com/tektoncd/triggers/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/wait-task/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/wait-task/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: wait-task-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/wait-task/tekton/?ref=main
+- github.com/tektoncd/experimental/wait-task/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-release/overlays/workflows/kustomization.yaml
+++ b/tekton/resources/nightly-release/overlays/workflows/kustomization.yaml
@@ -1,18 +1,19 @@
 namePrefix: workflows-
-bases:
-  - ../../base
-patchesJson6902:
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: TriggerTemplate
-      name: template
-    path: template.yaml
-  - target:
-      group: triggers.tekton.dev
-      version: v1alpha1
-      kind: Trigger
-      name: nightly
-    path: trigger.yaml
 resources:
-  - github.com/tektoncd/experimental/tekton/?ref=main
+- github.com/tektoncd/experimental/tekton/?ref=main
+- ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: template.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: TriggerTemplate
+    name: template
+    version: v1alpha1
+- path: trigger.yaml
+  target:
+    group: triggers.tekton.dev
+    kind: Trigger
+    name: nightly
+    version: v1alpha1

--- a/tekton/resources/nightly-tests/base/kustomization.yaml
+++ b/tekton/resources/nightly-tests/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - deploy_tekton_component.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - test_tekton_cli.yaml
 - k8s_cluster_setup.yaml
 - ../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - test_tekton_component.yaml
 - test_tekton_cli.yaml
 - ../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/nightly-tests/kustomization.yaml
+++ b/tekton/resources/nightly-tests/kustomization.yaml
@@ -18,3 +18,5 @@ resources:
 - operator-deploy-test-ppc64le-template.yaml
 - dashboard-deploy-test-ppc64le-template.yaml
 - catalog-deploy-test-ppc64le-template.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/org-permissions/kustomization.yaml
+++ b/tekton/resources/org-permissions/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - peribolos.yaml
 - peribolos-trigger.yaml
 - peribolos-sync.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/release/base/kustomization.yaml
+++ b/tekton/resources/release/base/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
 - prerelease_checks.yaml
 - github_release.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/release/kustomization.yaml
+++ b/tekton/resources/release/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
 - release-logs
 - overlays/default
 - overlays/tekton-nightly
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tekton/resources/release/overlays/default/kustomization.yaml
+++ b/tekton/resources/release/overlays/default/kustomization.yaml
@@ -1,3 +1,5 @@
 namespace: default
-bases:
-  - ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/tekton/resources/release/overlays/tekton-nightly/kustomization.yaml
+++ b/tekton/resources/release/overlays/tekton-nightly/kustomization.yaml
@@ -1,3 +1,5 @@
 namespace: tekton-nightly
-bases:
-  - ../../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/tekton/resources/release/release-logs/kustomization.yaml
+++ b/tekton/resources/release/release-logs/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
 - rbac.yaml
 - release-logs-triggers.yaml
 - save-release-logs.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
# Changes

The new version of kustomize does not like empty kustomize files (cronjobs/helm) and raises a number of warnings about deprecated features.

This was generated with:

```shell
find . -name "kustomization.yaml" |while read aa; do pushd $(dirname $aa); kustomize edit fix; popd; done
```

With the only manual change being the removal of the helm cronjob (which was empty).
/kind misc


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._