### PR TITLE
Remove the package path from pipeline images

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/pipeline-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/pipeline-nightly/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
               - name: CR_URI
                 value: ghcr.io
               - name: CR_PATH
-                value: tektoncd
+                value: tektoncd/pipeline
               - name: CR_REGIONS
                 value: ""
               - name: CR_USER

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -29,6 +29,8 @@
           value: release.json
         - name: serviceAccountImagesPath
           value: credentials
+        - name: koExtraArgs
+          value: ""
         timeouts:
           pipeline: 2h30m0s
         workspaces:


### PR DESCRIPTION
# Changes

For publishing to ghcr.io, remove the package path from the images, and add "pipeline", so that the images will be in the format:

- ghcr.io/tektoncd/pipeline/<image-name>

as opposed to the current:

- ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/<image-name>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._