### PR TITLE
Resore default values for nightlies

### DIFF
--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -98,6 +98,14 @@ spec:
             env:
               - name: SINK_URL
                 value: "el-tekton-nightly.tekton-nightly.svc.cluster.local:8080"
+              - name: CR_URI
+                value: gcr.io
+              - name: CR_PATH
+                value: tekton-nightly
+              - name: CR_REGIONS
+                value: "us eu asia"
+              - name: CR_USER
+                value: _json_key
               - name: PROJECT_NAME
                 value: "project-name"
             volumeMounts:


### PR DESCRIPTION
# Changes

The cronjobs for nightly builds has been extended with new values that can be used to adopt a different registry. Until migration is complete, set the values for GCP as default to restore the nightly builds.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._