### PR TITLE
Remove empty cronjobs folder from robocat

### DIFF
--- a/tekton/cronjobs/robocat/kustomization.yaml
+++ b/tekton/cronjobs/robocat/kustomization.yaml
@@ -2,12 +2,7 @@ commonAnnotations:
   managed-by: Tekton
 
 resources:
-- cleanup
-- configmaps
 - helm
-- images
 - manifests
-- releases
-- tekton
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
# Changes

Some of the cronjobs folders in robocat to not contain any resource, which fails with the new version of kustomize.

Remove all empty ones.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._