### PR TITLE
Add koparse support for no-preserve-path

### DIFF
--- a/tekton/images/koparse/koparse/koparse.py
+++ b/tekton/images/koparse/koparse/koparse.py
@@ -16,7 +16,7 @@ This script does two things:
 """
 
 import argparse
-import os
+import hashlib
 import re
 import string
 import sys
@@ -69,7 +69,24 @@ def parse_release(base: str, path: str) -> List[str]:
     return images
 
 
-def compare_expected_images(expected: List[str], actual: List[str]) -> None:
+def md5(input: str) -> str:
+    return hashlib.md5(input.encode()).hexdigest()
+
+
+def convert_image_path(image: str) -> str:
+    # Separate the image name from path in <container-reg>/<path>/<image-name>:<tag>
+    parts = image.split(":")
+    image_without_tag = parts[0]
+    tag = ""
+
+    if len(parts) == 2:
+        tag = f":{parts[1]}"
+    
+    image_name = image_without_tag.split("/")[-1]
+
+    return f"{image_name}-{md5(image_without_tag)}{tag}"
+
+def compare_expected_images(expected: List[str], actual: List[str], container_registry: str, preserve_path: bool) -> None:
     """Ensures that the list of actual images includes only the expected images
 
     Args:
@@ -82,6 +99,10 @@ def compare_expected_images(expected: List[str], actual: List[str]) -> None:
         if DIGEST_MARKER not in image:
             raise BadActualImageFormatError(image)
 
+    if not preserve_path:
+        expected = [convert_image_path(image) for image in expected]
+
+    expected = ["/".join([container_registry, image]) for image in expected]
     actual_no_digest = [image.split(DIGEST_MARKER)[0] for image in actual]
 
     missing = set(expected) - set(actual_no_digest)
@@ -91,20 +112,51 @@ def compare_expected_images(expected: List[str], actual: List[str]) -> None:
         raise ImagesMismatchError(list(missing), list(extra))
 
 
+def backwards_compatible_params(container_registry: str, base: str, images: List[str]) -> tuple[str, str, List[str]]:
+    # For backwards compatibility, if container registry is not provided, we assume it's
+    # the first section of the base, which is the legacy behavior. We then need to strip
+    # container registry out of the expected images and base
+    if not container_registry:
+        container_registry = "/".join(base.split("/")[:2])
+        base = "/".join(base.split("/")[2:])
+        images = ["/".join(image.split("/")[2:]) for image in images]
+    return container_registry, base, images
+
+
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser(
         description="Parse expected built images from a release.yaml created by `ko`")
     arg_parser.add_argument("--path", type=str, required=True,
                             help="Path to the release.yaml")
+    arg_parser.add_argument("--container-registry", dest="container_registry", type=str, required=False,
+                            help="Container registry URI and path e.g. gcr.io/tekton-releases")
     arg_parser.add_argument("--base", type=str, required=True,
                             help="String prefix which is used to find images within the release.yaml")
     arg_parser.add_argument("--images", type=str, required=True, nargs="+",
                             help="List of all images expected to be built, without digests")
+    arg_parser.add_argument("--preserve-path", dest="preserve_path", type=bool, required=False, default=True,
+                            help="Whether ko is configured to preserve the images base path")
     args = arg_parser.parse_args()
 
     try:
-        images = parse_release(args.base, args.path)
-        compare_expected_images(args.images, images)
+        container_registry, expected_images, base = backwards_compatible_params(
+            args.container_registry, args.images, args.base)
+
+        # For backwards compatibility, if container registry is not provided, we assume it's
+        # the first section of the base, which is the legacy behavior. We then need to strip
+        # container registry out of the expected images and base
+        if not args.container_registry:
+            container_registry = "/".join(args.base.split("/")[:1])
+            base = "/".join(args.base.split("/")[2:])
+            expected_images = ["/".join(image.split("/")[2:]) for image in args.images]
+
+        if args.preserve_path:
+            search_path = "/".join([container_registry, args.base])
+        else:
+            search_path = container_registry
+
+        images = parse_release(search_path, args.path)
+        compare_expected_images(images, images, container_registry, args.preserve_path)
     except (IOError, BadActualImageFormatError) as e:
         sys.stderr.write("Error determining built images: %s\n" % e)
         sys.exit(1)

--- a/tekton/images/koparse/koparse/test_koparse.py
+++ b/tekton/images/koparse/koparse/test_koparse.py
@@ -6,9 +6,13 @@ import unittest
 import koparse
 
 
-IMAGE_BASE = "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/"
+IMAGE_PATH = "github.com/tektoncd/pipeline/cmd/"
+CONTAINER_REGISTRY = "gcr.io/tekton-releases"
+IMAGE_BASE = CONTAINER_REGISTRY + "/" + IMAGE_PATH
 PATH_TO_TEST_RELEASE_YAML = os.path.join(os.path.dirname(
     os.path.abspath(__file__)), "test_release.yaml")
+PATH_TO_TEST_RELEASE_YAML_NO_PATH = os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), "test_release_no_preserve_path.yaml")
 PATH_TO_WRONG_FILE = os.path.join(os.path.dirname(
     os.path.abspath(__file__)), "koparse.py")
 BUILT_IMAGES = [
@@ -17,11 +21,17 @@ BUILT_IMAGES = [
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller@sha256:bdc6f22a44944c829983c30213091b60f490b41f89577e8492f6a2936be0df41",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook@sha256:cca7069a11aaf0d9d214306d456bc40b2e33e5839429bf07c123ad964d495d8a",
 ]
+BUILT_IMAGES_NO_PATH = [
+    "gcr.io/tekton-releases/kubeconfigwriter-3d37fea0b053ea82d66b7c0bae03dcb0:v20201022-ceeec6463e.1_1A@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35",
+    "gcr.io/tekton-releases/git-init-4874978a9786b6625dd8b6ef2a21aa70@sha256:7d5520efa2d55e1346c424797988c541327ee52ef810a840b5c6f278a9de934a",
+    "gcr.io/tekton-releases/controller-10a3e32792f33651396d02b6855a6e36@sha256:bdc6f22a44944c829983c30213091b60f490b41f89577e8492f6a2936be0df41",
+    "gcr.io/tekton-releases/webhook-d4749e605405422fd87700164e31b2d1@sha256:cca7069a11aaf0d9d214306d456bc40b2e33e5839429bf07c123ad964d495d8a",
+]
 EXPECTED_IMAGES = [
-    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v20201022-ceeec6463e.1_1A",
-    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
-    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller",
-    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook",
+    "github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v20201022-ceeec6463e.1_1A",
+    "github.com/tektoncd/pipeline/cmd/git-init",
+    "github.com/tektoncd/pipeline/cmd/controller",
+    "github.com/tektoncd/pipeline/cmd/webhook",
 ]
 
 
@@ -30,6 +40,10 @@ class TestKoparse(unittest.TestCase):
     def test_parse_release(self):
         images = koparse.parse_release(IMAGE_BASE, PATH_TO_TEST_RELEASE_YAML)
         self.assertListEqual(images, BUILT_IMAGES)
+
+    def test_parse_release_no_path(self):
+        images = koparse.parse_release(CONTAINER_REGISTRY, PATH_TO_TEST_RELEASE_YAML_NO_PATH)
+        self.assertListEqual(images, BUILT_IMAGES_NO_PATH)
 
     def test_parse_release_no_file(self):
         with self.assertRaises(IOError):
@@ -40,23 +54,45 @@ class TestKoparse(unittest.TestCase):
         self.assertEqual(images, [])
 
     def test_compare_expected_images(self):
-        koparse.compare_expected_images(EXPECTED_IMAGES, BUILT_IMAGES)
+        koparse.compare_expected_images(EXPECTED_IMAGES, BUILT_IMAGES, CONTAINER_REGISTRY, True)
+
+    def test_compare_expected_images_no_path(self):
+        koparse.compare_expected_images(EXPECTED_IMAGES, BUILT_IMAGES_NO_PATH, CONTAINER_REGISTRY, False)
 
     def test_compare_expected_images_bad_format(self):
         with self.assertRaises(koparse.BadActualImageFormatError):
-            koparse.compare_expected_images(EXPECTED_IMAGES, EXPECTED_IMAGES)
+            koparse.compare_expected_images(EXPECTED_IMAGES, EXPECTED_IMAGES, CONTAINER_REGISTRY, True)
 
     def test_compare_expected_images_missing(self):
         extra_expected = (EXPECTED_IMAGES[:] +
                           ["gcr.io/knative-releases/something-else"])
         with self.assertRaises(koparse.ImagesMismatchError):
-            koparse.compare_expected_images(extra_expected, BUILT_IMAGES)
+            koparse.compare_expected_images(extra_expected, BUILT_IMAGES, CONTAINER_REGISTRY, True)
 
     def test_compare_expected_images_too_many(self):
         extra_actual = (BUILT_IMAGES[:] +
                         ["gcr.io/knative-releases/something-else@sha256:somedigest"])
         with self.assertRaises(koparse.ImagesMismatchError):
-            koparse.compare_expected_images(EXPECTED_IMAGES, extra_actual)
+            koparse.compare_expected_images(EXPECTED_IMAGES, extra_actual, CONTAINER_REGISTRY, True)
+
+    def test_md5(self):
+        self.assertEqual(koparse.md5("some input test string"), "e426c968ded84c5ea8b2e3b5e3e7a865")
+
+    def test_convert_image_path(self):
+        self.assertEqual(koparse.convert_image_path(EXPECTED_IMAGES[1]), "git-init-4874978a9786b6625dd8b6ef2a21aa70")
+
+    def test_convert_image_path_with_tag(self):
+        self.assertEqual(koparse.convert_image_path(EXPECTED_IMAGES[0]), "kubeconfigwriter-3d37fea0b053ea82d66b7c0bae03dcb0:v20201022-ceeec6463e.1_1A")
+
+    def test_backwards_compatible_params_no_cr(self):
+        self.assertEqual(
+            koparse.backwards_compatible_params(
+                "", "cr.io/test/a/b/c", ["cr.io/test/a/b/c/image1", "cr.io/test/a/b/c/image2"]),
+            ("cr.io/test", "a/b/c", ["a/b/c/image1", "a/b/c/image2"]))
+
+    def test_backwards_compatible_params_no_cr(self):
+        params = ("cr.io/test", "a/b/c", ["a/b/c/image1", "a/b/c/image2"])
+        self.assertEqual(koparse.backwards_compatible_params(*params), params)
 
 
 if __name__ == "__main__":

--- a/tekton/images/koparse/koparse/test_release_no_preserve_path.yaml
+++ b/tekton/images/koparse/koparse/test_release_no_preserve_path.yaml
@@ -1,0 +1,352 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-pipelines-admin
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - secrets
+  - events
+  - serviceaccounts
+  - configmaps
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  - pipelineresources/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-controller-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-admin
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - knative
+    - tekton-pipelines
+    kind: ClusterTask
+    plural: clustertasks
+  scope: Cluster
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+spec:
+  group: caching.internal.knative.dev
+  names:
+    categories:
+    - all
+    - knative-internal
+    - caching
+    kind: Image
+    plural: images
+    shortNames:
+    - img
+    singular: image
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - knative
+    - tekton-pipelines
+    kind: Pipeline
+    plural: pipelines
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - knative
+    - tekton-pipelines
+    kind: PipelineRun
+    plural: pipelineruns
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - knative
+    - tekton-pipelines
+    kind: Task
+    plural: tasks
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - knative
+    - tekton-pipelines
+    kind: TaskRun
+    plural: taskruns
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-controller
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: tekton-pipelines-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-webhook
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: tekton-pipelines-webhook
+---
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: tekton-pipelines
+---
+apiVersion: v1
+data:
+  image: gcr.io/k8s-prow/entrypoint@sha256:7c7cd8906ce4982ffee326218e9fc75da2d4896d53cabc9833b9cc8d2d6b2b8f
+kind: ConfigMap
+metadata:
+  name: config-entrypoint
+  namespace: tekton-pipelines
+---
+apiVersion: v1
+data:
+  loglevel.controller: info
+  loglevel.webhook: info
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: tekton-pipelines
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tekton-pipelines-controller
+    spec:
+      containers:
+      - args: [
+        "-logtostderr",
+        "-stderrthreshold",
+        "INFO",
+        "-kubeconfig-writer-image", "gcr.io/tekton-releases/kubeconfigwriter-3d37fea0b053ea82d66b7c0bae03dcb0:v20201022-ceeec6463e.1_1A@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35",
+        "-git-image",
+        "gcr.io/tekton-releases/git-init-4874978a9786b6625dd8b6ef2a21aa70@sha256:7d5520efa2d55e1346c424797988c541327ee52ef810a840b5c6f278a9de934a",
+      ]
+        image: gcr.io/tekton-releases/controller-10a3e32792f33651396d02b6855a6e36@sha256:bdc6f22a44944c829983c30213091b60f490b41f89577e8492f6a2936be0df41
+        name: tekton-pipelines-controller
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+      serviceAccountName: tekton-pipelines-controller
+      volumes:
+      - configMap:
+          name: config-logging
+        name: config-logging
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tekton-pipelines-webhook
+    spec:
+      containers:
+      - image: gcr.io/tekton-releases/webhook-d4749e605405422fd87700164e31b2d1@sha256:cca7069a11aaf0d9d214306d456bc40b2e33e5839429bf07c123ad964d495d8a
+        name: webhook
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+      serviceAccountName: tekton-pipelines-controller
+      volumes:
+      - configMap:
+          name: config-logging
+        name: config-logging

--- a/tekton/resources/images/single-arch-template.yaml
+++ b/tekton/resources/images/single-arch-template.yaml
@@ -52,22 +52,39 @@ spec:
           - name: contextPath
           - name: imageUrl
           - name: tags
+          - name: secretPath
+          - name: registryUser
         workspaces:
           - name: source
           - name: secret
+        stepTemplate:
+          env:
+            - name: CONTAINER_REGISTRY_CREDENTIALS
+              value: "$(workspaces.secret.path)/$(params.secretPath)"
+            - name: CONTAINER_REGISTRY_USER
+              value: "$(params.registryUser)"
+            - name: CONTEXT_PATH
+              value: $(params.contextPath)
+            - name: TAGS
+              value: $(params.tags)
+            - name: IMAGE_URL
+              value: $(params.imageUrl)
         steps:
+          - name: container-registry-auth
+            image: cgr.dev/chainguard/crane:latest-dev@sha256:ff0b6317f47e938e8e05cb087727072f4f05aef5c8f3231a8836ca7937509ff6
+            script: |
+              #!/bin/sh
+              set -ex
+
+              # Login to the container registry
+              DOCKER_CONFIG=$(cat ${CONTAINER_REGISTRY_CREDENTIALS} | \
+                crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin $(params.imageRegistry) 2>&1 | \
+                sed 's,^.*logged in via \(.*\)$,\1,g')
+
+              cp ${DOCKER_CONFIG} /workspace/docker-config.json
           - name: build-and-push
             workingDir: $(workspaces.source.path)
             image: gcr.io/kaniko-project/executor:v1.8.0-debug
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: $(workspaces.secret.path)/release.json
-              - name: CONTEXT_PATH
-                value: $(params.contextPath)
-              - name: TAGS
-                value: $(params.tags)
-              - name: IMAGE_URL
-                value: $(params.imageUrl)
             script: |
               #!/busybox/sh
               # Setup the destination parameters


### PR DESCRIPTION
# Changes

Add support for the case of path not preserved in ko. The implementation is done in a backwards compatible way so that if ko is invoked with the same parameters as before it will work in the same way.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._