### PR TITLE
Fix param order in koparse backwards_compatible_params

### DIFF
--- a/tekton/images/koparse/koparse/koparse.py
+++ b/tekton/images/koparse/koparse/koparse.py
@@ -139,8 +139,8 @@ if __name__ == "__main__":
     args = arg_parser.parse_args()
 
     try:
-        container_registry, expected_images, base = backwards_compatible_params(
-            args.container_registry, args.images, args.base)
+        container_registry, base, expected_images = backwards_compatible_params(
+            args.container_registry, args.base, args.images)
 
         if args.preserve_path:
             search_path = "/".join([container_registry, args.base])


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
See for example: https://dashboard.dogfooding.tekton.dev/#/namespaces/tekton-nightly/pipelineruns/wait-task-release-nightly-qk72w?pipelineTask=publish-images&step=koparse

```
2024-09-19T09:14:57.305509466Z + IMAGES_PATH=[gcr.io/tekton-nightly/github.com/tektoncd/experimental](http://gcr.io/tekton-nightly/github.com/tektoncd/experimental)
2024-09-19T09:14:57.305584903Z + '[' wait-task '!='  ]
2024-09-19T09:14:57.307406787Z + IMAGES_PATH=[gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task](http://gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task)
2024-09-19T09:14:57.307428664Z + [IMAGES=gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task/cmd/controller:v20240919-2ce2f72e49](http://images=gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task/cmd/controller:v20240919-2ce2f72e49)
2024-09-19T09:14:57.307563297Z + koparse --path /workspace/output/v20240919-2ce2f72e49/release.yaml --base [gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task](http://gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task) --images [gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task/cmd/controller:v20240919-2ce2f72e49](http://gcr.io/tekton-nightly/github.com/tektoncd/experimental/wait-task/cmd/controller:v20240919-2ce2f72e49)
2024-09-19T09:14:59.511998655Z Traceback (most recent call last):
2024-09-19T09:14:59.512055747Z   File "/usr/local/bin/koparse", line 142, in <module>
2024-09-19T09:14:59.512668819Z     container_registry, expected_images, base = backwards_compatible_params(
2024-09-19T09:14:59.512690946Z                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-19T09:14:59.512697022Z   File "/usr/local/bin/koparse", line 120, in backwards_compatible_params
2024-09-19T09:14:59.512943282Z     container_registry = "/".join(base.split("/")[:2])
2024-09-19T09:14:59.512956609Z                                   ^^^^^^^^^^
2024-09-19T09:14:59.513050417Z AttributeError: 'list' object has no attribute 'split'
```

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._