### PR TITLE
Move the Dashboard nightly image to GHCR

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/dashboard-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/dashboard-nightly/cronjob.yaml
@@ -14,6 +14,14 @@ spec:
             env:
               - name: PROJECT_NAME
                 value: dashboard
+              - name: CR_URI
+                value: ghcr.io
+              - name: CR_PATH
+                value: tektoncd/dashboard
+              - name: CR_REGIONS
+                value: ""
+              - name: CR_USER
+                value: tekton-robot
           initContainers:
           - name: git
             env:

--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -21,10 +21,18 @@
           value: $(tt.params.imageRegistry)
         - name: imageRegistryPath
           value: $(tt.params.imageRegistryPath)
+        - name: imageRegistryUser
+          value: $(tt.params.imageRegistryUser)
+        - name: imageRegistryRegions
+          value: $(tt.params.imageRegistryRegions)
         - name: versionTag
           value: $(tt.params.versionTag)
         - name: serviceAccountPath
           value: release.json
+        - name: serviceAccountImagesPath
+          value: credentials
+        - name: koExtraArgs
+          value: ""
         workspaces:
           - name: workarea
             volumeClaimTemplate:
@@ -37,3 +45,6 @@
           - name: release-secret
             secret:
               secretName: release-secret
+          - name: release-images-secret
+            secret:
+              secretName: ghcr-creds


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Related to https://github.com/tektoncd/plumbing/issues/2157 and https://github.com/tektoncd/dashboard/pull/3634

Publish the Dashboard nightly release image to ghcr.io

Old images were at:
  `gcr.io/tekton-nightly/github.com/tektoncd/dashboard/cmd/<image-name>`

With this change they will now be at:
  `ghcr.io/tektoncd/dashboard/<image-name>`

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._