### PR TITLE
Switch Triggers nightlies to ghcr.io

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/triggers-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/triggers-nightly/cronjob.yaml
@@ -14,6 +14,14 @@ spec:
             env:
               - name: PROJECT_NAME
                 value: triggers
+              - name: CR_URI
+                value: ghcr.io
+              - name: CR_PATH
+                value: tektoncd
+              - name: CR_REGIONS
+                value: ""
+              - name: CR_USER
+                value: tekton-robot
           initContainers:
           - name: git
             env:

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -19,10 +19,16 @@
           value: $(tt.params.imageRegistry)
         - name: imageRegistryPath
           value: $(tt.params.imageRegistryPath)
+        - name: imageRegistryUser
+          value: $(tt.params.imageRegistryUser)
+        - name: imageRegistryRegions
+          value: $(tt.params.imageRegistryRegions)
         - name: versionTag
           value: $(tt.params.versionTag)
         - name: serviceAccountPath
           value: release.json
+        - name: serviceAccountImagesPath
+          value: credentials
         workspaces:
           - name: workarea
             volumeClaimTemplate:
@@ -35,3 +41,6 @@
           - name: release-secret
             secret:
               secretName: release-secret
+          - name: release-image-secret
+            secret:
+              secretName: ghcr-creds


### PR DESCRIPTION
# Changes

Publish Triggers nightly release image to ghcr.io

Old images were at:
  `gcr.io/tekton-nightly/github.com/tektoncd/triggers/cmd/<image-name>`

With this change they will now be at:
  `ghcr.io/tektoncd/triggers/<image-name>-<path-hash>`

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._