### PR TITLE
Fix path of Triggers images published to ghcr.io

### DIFF
--- a/tekton/cronjobs/dogfooding/releases/triggers-nightly/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/releases/triggers-nightly/cronjob.yaml
@@ -17,7 +17,7 @@ spec:
               - name: CR_URI
                 value: ghcr.io
               - name: CR_PATH
-                value: tektoncd
+                value: tektoncd/triggers
               - name: CR_REGIONS
                 value: ""
               - name: CR_USER

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -29,6 +29,8 @@
           value: release.json
         - name: serviceAccountImagesPath
           value: credentials
+        - name: koExtraArgs
+          value: ""
         workspaces:
           - name: workarea
             volumeClaimTemplate:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Follow-up to https://github.com/tektoncd/plumbing/pull/2206

For example, instead of:
`ghcr.io/tektoncd/github.com/tektoncd/triggers/cmd/webhook:v20240926-96723b346e`

ensure image is published at:

`ghcr.io/tektoncd/triggers/webhook-dd1edc925ee1772a9f76e2c1bc291ef6:v20240926-96723b346e`

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._