### PR TITLE
Reapply "Switch CI/CD jobs to ghcr.io images"

### DIFF
--- a/bots/mariobot/README.md
+++ b/bots/mariobot/README.md
@@ -26,7 +26,7 @@ This will respond with a JSON body something like this:
   "gitRepository": "github.com/tektoncd/plumbing",
   "gitRevision": "pull/20/head",
   "contextPath": "tekton/images/tkn",
-  "targetImage": "gcr.io/tekton-releases/dogfooding/tkn:mario",
+  "targetImage": "ghcr.io/tektoncd/plumbing/tkn:mario",
   "pullRequestID": "20"
 }
 ```

--- a/docs/kind-e2e.md
+++ b/docs/kind-e2e.md
@@ -91,7 +91,7 @@ This ensures that specific nodes are used for your `kind` job. These nodes have 
 and 16gb RAM, with local SSD-backed ephemeral storage. We have determined that this
 configuration is the optimal one for `kind`. 
 
-The image used in your container should be `gcr.io/tekton-releases/dogfooding/test-runner:v20220812-35d6c29808@sha256:b9010d2fe3d1da99c1735ad291271ca8ed56c8e0f3a16d4b0de7a1096fcf5a08`
+The image used in your container should be `ghcr.io/tektoncd/plumbing/test-runner:v20220812-35d6c29808@sha256:b9010d2fe3d1da99c1735ad291271ca8ed56c8e0f3a16d4b0de7a1096fcf5a08`
 or newer. You can use `:latest`, but we'd recommend against that.
 
 The `args` for your job's container should look like this:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -364,7 +364,7 @@ presubmits:
     trigger: "(?m)^/test pull-dogfooding-mario-test,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:mario
+      - image: ghcr.io/tektoncd/plumbing/test-runner:mario
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -412,7 +412,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-catlin-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -438,7 +438,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-catlin-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -464,7 +464,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-catlin-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -492,7 +492,7 @@ presubmits:
       clone_uri: "https://github.com/tektoncd/catlin.git"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+        - image: ghcr.io/tektoncd/plumbing/coverage:latest
           imagePullPolicy: Always
           command:
           - "/coverage"
@@ -515,7 +515,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-build-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -548,7 +548,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-unit-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -581,7 +581,7 @@ presubmits:
       trigger: "(?m)^/test (all|pull-tekton-chains-integration-tests),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
           - /usr/local/bin/entrypoint.sh
@@ -616,7 +616,7 @@ presubmits:
       clone_uri: "https://github.com/tektoncd/chains.git"
       spec:
         containers:
-        - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+        - image: ghcr.io/tektoncd/plumbing/coverage:latest
           imagePullPolicy: Always
           command:
           - "/coverage"
@@ -647,7 +647,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -680,7 +680,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-build-cross-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -713,7 +713,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-cli-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -756,7 +756,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -793,7 +793,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -819,7 +819,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-dashboard-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -855,7 +855,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -892,7 +892,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -918,7 +918,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -945,7 +945,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-experimental-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -972,7 +972,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -998,7 +998,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1024,7 +1024,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-hub-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1051,7 +1051,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1084,7 +1084,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-operator-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1127,7 +1127,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1165,7 +1165,7 @@ presubmits:
     clone_uri: "https://github.com/tektoncd/operator.git"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1195,7 +1195,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1228,7 +1228,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1263,7 +1263,7 @@ presubmits:
     clone_uri: "https://github.com/tektoncd/pipeline.git"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1302,7 +1302,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1348,7 +1348,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1406,7 +1406,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-        - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+        - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
           imagePullPolicy: Always
           command:
             - /usr/local/bin/entrypoint.sh
@@ -1443,7 +1443,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1469,7 +1469,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-catalog-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1505,7 +1505,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -1542,7 +1542,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+      - image: ghcr.io/tektoncd/plumbing/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1568,7 +1568,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+      - image: ghcr.io/tektoncd/plumbing/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1596,7 +1596,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-resolution-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
+      - image: ghcr.io/tektoncd/plumbing/test-runner@sha256:5e5c4b04b7e7459f306eb0b8424495652b034b4b06a9e9ea7b0fe22282fd11af # golang 1.19
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1625,7 +1625,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-results-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1651,7 +1651,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-results-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1696,7 +1696,7 @@ presubmits:
           value: "true"
           effect: NoSchedule
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1727,7 +1727,7 @@ presubmits:
     clone_uri: "https://github.com/tektoncd/results.git"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1750,7 +1750,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1776,7 +1776,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-triggers-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1802,7 +1802,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-triggers-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1830,7 +1830,7 @@ presubmits:
     clone_uri: "https://github.com/tektoncd/triggers.git"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1853,7 +1853,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-gen-crd-api-reference-docs-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+      - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
         imagePullPolicy: Always
         command:
         - /usr/local/bin/entrypoint.sh
@@ -1905,7 +1905,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1920,7 +1920,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1936,7 +1936,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1951,7 +1951,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1973,7 +1973,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -1988,7 +1988,7 @@ postsubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/tekton-releases/dogfooding/coverage:latest
+      - image: ghcr.io/tektoncd/plumbing/coverage:latest
         imagePullPolicy: Always
         command:
         - "/coverage"
@@ -2019,7 +2019,7 @@ periodics:
         value: "true"
         effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+    - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
       imagePullPolicy: Always
       command:
         - /usr/local/bin/entrypoint.sh
@@ -2071,7 +2071,7 @@ periodics:
       value: "true"
       effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+    - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
       imagePullPolicy: Always
       securityContext:
         privileged: true
@@ -2123,7 +2123,7 @@ periodics:
         value: "true"
         effect: NoSchedule
     containers:
-    - image: gcr.io/tekton-releases/dogfooding/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
+    - image: ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356 # go 1.22, kind 0.23, ko 0.15.4, go-license 1.0
       imagePullPolicy: Always
       command:
         - /usr/local/bin/entrypoint.sh

--- a/tekton/ci/cluster-interceptors/add-pr-body/tekton/publish.yaml
+++ b/tekton/ci/cluster-interceptors/add-pr-body/tekton/publish.yaml
@@ -93,7 +93,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
+    image: ghcr.io/tektoncd/plumbing/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -142,7 +142,7 @@ spec:
       ko resolve --platform=${PLATFORMS} --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
 
   - name: koparse
-    image: gcr.io/tekton-releases/dogfooding/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
+    image: ghcr.io/tektoncd/plumbing/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
     script: |
       set -ex
 

--- a/tekton/ci/cluster-interceptors/build-id/tekton/publish.yaml
+++ b/tekton/ci/cluster-interceptors/build-id/tekton/publish.yaml
@@ -93,7 +93,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:latest
+    image: ghcr.io/tektoncd/plumbing/ko:latest
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -142,7 +142,7 @@ spec:
       ko resolve --platform=${PLATFORMS} --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
 
   - name: koparse
-    image: gcr.io/tekton-releases/dogfooding/koparse:latest
+    image: ghcr.io/tektoncd/plumbing/koparse:latest
     script: |
       set -ex
 

--- a/tekton/ci/custom-tasks/pr-commenter/tekton/publish.yaml
+++ b/tekton/ci/custom-tasks/pr-commenter/tekton/publish.yaml
@@ -93,7 +93,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
+    image: ghcr.io/tektoncd/plumbing/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -143,7 +143,7 @@ spec:
       ko resolve --platform=${PLATFORMS} --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
 
   - name: koparse
-    image: gcr.io/tekton-releases/dogfooding/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
+    image: ghcr.io/tektoncd/plumbing/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
     script: |
       set -ex
 

--- a/tekton/ci/custom-tasks/pr-status-updater/tekton/publish.yaml
+++ b/tekton/ci/custom-tasks/pr-status-updater/tekton/publish.yaml
@@ -91,7 +91,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
+    image: ghcr.io/tektoncd/plumbing/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -141,7 +141,7 @@ spec:
       ko resolve --platform=${PLATFORMS} --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
 
   - name: koparse
-    image: gcr.io/tekton-releases/dogfooding/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
+    image: ghcr.io/tektoncd/plumbing/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
     script: |
       set -ex
 

--- a/tekton/ci/interceptors/add-pr-body/tekton/publish.yaml
+++ b/tekton/ci/interceptors/add-pr-body/tekton/publish.yaml
@@ -93,7 +93,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
+    image: ghcr.io/tektoncd/plumbing/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -143,7 +143,7 @@ spec:
       ko resolve --platform=${PLATFORMS} --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yaml
 
   - name: koparse
-    image: gcr.io/tekton-releases/dogfooding/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
+    image: ghcr.io/tektoncd/plumbing/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
     script: |
       set -ex
 

--- a/tekton/ci/interceptors/add-team-members/tekton/publish.yaml
+++ b/tekton/ci/interceptors/add-team-members/tekton/publish.yaml
@@ -93,7 +93,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
+    image: ghcr.io/tektoncd/plumbing/ko:v20240926-3daa55a03e@sha256:393155dbdd7c8d920925b202c88e4846f46a70c1e1dc218b0ea5e2d7e388b576
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
@@ -143,7 +143,7 @@ spec:
       ko resolve --platform=${PLATFORMS} --preserve-import-paths -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.notags.yam.
 
   - name: koparse
-    image: gcr.io/tekton-releases/dogfooding/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
+    image: ghcr.io/tektoncd/plumbing/koparse:v20240910-ec3cf3c749@sha256:5e8a522fc1e587fc00b69a6d73e0bfdf7a29ca143537a5542eb224680d2dbf2f
     script: |
       set -ex
 

--- a/tekton/ci/jobs/e2e-kind.yaml
+++ b/tekton/ci/jobs/e2e-kind.yaml
@@ -46,7 +46,7 @@ spec:
         set -ex
         mkdir -p "$ARTIFACTS_FOLDER"
         echo "Created folder $ARTIFACTS_FOLDER"
-    - image: gcr.io/tekton-releases/dogfooding/kind-e2e:latest
+    - image: ghcr.io/tektoncd/plumbing/kind-e2e:latest
       imagePullPolicy: Always
       workingDir: $(workspaces.source.path)
       name: kind

--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -40,7 +40,7 @@ spec:
         done
         echo -n $final_tests > changed-files.txt
     - name: lint-catalog
-      image: gcr.io/tekton-releases/dogfooding/catlin:latest
+      image: ghcr.io/tektoncd/plumbing/catlin:latest
       workingDir: $(workspaces.source.path)
       script: |
         set +e

--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -39,7 +39,7 @@ spec:
       description: The file within workspace that contains the GitHub token.
     - name: sourcePath
       description: Location where the git repo will be installed.
-  image: gcr.io/tekton-releases/dogfooding/coverage:latest
+  image: ghcr.io/tektoncd/plumbing/coverage:latest
   env:
     - name: PULL_PULL_SHA
       value: $(params.gitRevision)

--- a/tekton/ci/jobs/tekton-teps-validation.yaml
+++ b/tekton/ci/jobs/tekton-teps-validation.yaml
@@ -13,10 +13,10 @@ spec:
     - name: input
   steps:
   - name: teps-validate
-    image: gcr.io/tekton-releases/dogfooding/teps:latest
+    image: ghcr.io/tektoncd/plumbing/teps:latest
     args: ['validate', '--teps-folder', '$(workspaces.input.path)/$(params.teps-folder)']
   - name: teps-table-refresh
-    image: gcr.io/tekton-releases/dogfooding/teps:latest
+    image: ghcr.io/tektoncd/plumbing/teps:latest
     workingDir: $(workspaces.input.path)
     args: ['table', '--teps-folder', '$(workspaces.input.path)/$(params.teps-folder)']
   - name: teps-table

--- a/tekton/ci/shared/common-tasks.yaml
+++ b/tekton/ci/shared/common-tasks.yaml
@@ -27,7 +27,7 @@ spec:
       type: array
   steps:
     - name: check-files-changed
-      image: gcr.io/tekton-releases/dogfooding/test-runner@sha256:d6a49b0d6822f4db7ede60d3f6bb41c1278079ad7c631fcaf00a609a977d0ac0 # golang 1.18.7
+      image: ghcr.io/tektoncd/plumbing/test-runner@sha256:d6a49b0d6822f4db7ede60d3f6bb41c1278079ad7c631fcaf00a609a977d0ac0 # golang 1.18.7
       env:
       - name: GIT_CLONE_DEPTH
         value: $(params.gitCloneDepth)

--- a/tekton/ci/shared/gubernator-metadata.yaml
+++ b/tekton/ci/shared/gubernator-metadata.yaml
@@ -79,7 +79,7 @@ spec:
         value: $(params.pullRequestNumber)
   steps:
     - name: write-data
-      image: gcr.io/tekton-releases/dogfooding/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
+      image: ghcr.io/tektoncd/plumbing/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
       workingDir: $(workspaces.shared.path)
       script: |
         #!/usr/bin/env sh
@@ -172,7 +172,7 @@ spec:
         value: $(params.jobStatus)
   steps:
     - name: write-data
-      image: gcr.io/tekton-releases/dogfooding/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
+      image: ghcr.io/tektoncd/plumbing/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
       workingDir: $(workspaces.shared.path)
       script: |
         #!/usr/bin/env sh

--- a/tekton/cronjobs/README.md
+++ b/tekton/cronjobs/README.md
@@ -208,7 +208,7 @@ spec:
             - name: GIT_REVISION
               value: main
             - name: TARGET_IMAGE
-              value: gcr.io/tekton-releases/dogfooding/myimage:latest
+              value: ghcr.io/tektoncd/plumbing/myimage:latest
             - name: CONTEXT_PATH
               value: tekton/images/myimage
 ```

--- a/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/alpine-git-nonroot-nightly/README.md
@@ -1,3 +1,3 @@
 Cron Job to build an alpine container image with `git` installed and a
 non-root user set up.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest](gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest](ghcr.io/tektoncd/plumbing/alpine-git-nonroot:latest).

--- a/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/buildx-gcloud-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `docker buildx` and `gcloud` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest](gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/buildx-gcloud:latest](ghcr.io/tektoncd/plumbing/buildx-gcloud:latest).

--- a/tekton/cronjobs/dogfooding/images/catlin-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/catlin-nightly/README.md
@@ -1,1 +1,1 @@
-Cron Job to build a container image with `catlin` installed. The image is published daily to `gcr.io/tekton-releases/dogfooding/catlin:latest`.
+Cron Job to build a container image with `catlin` installed. The image is published daily to `ghcr.io/tektoncd/plumbing/catlin:latest`.

--- a/tekton/cronjobs/dogfooding/images/coverage-image-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/coverage-image-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `coverage` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/coverage:latest](gcr.io/tekton-releases/dogfooding/coverage:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/coverage:latest](ghcr.io/tektoncd/plumbing/coverage:latest).

--- a/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/go-rest-api-test-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `go-rest-api-test` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest](gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/go-rest-api-test:latest](ghcr.io/tektoncd/plumbing/go-rest-api-test:latest).

--- a/tekton/cronjobs/dogfooding/images/hub-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/hub-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `hub` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/hub:latest](gcr.io/tekton-releases/dogfooding/hub:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/hub:latest](ghcr.io/tektoncd/plumbing/hub:latest).

--- a/tekton/cronjobs/dogfooding/images/ko-gcloud-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/ko-gcloud-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `ko` and `gcloud` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/ko:gcloud-latest](gcr.io/tekton-releases/dogfooding/ko-gcloud:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/ko:gcloud-latest](ghcr.io/tektoncd/plumbing/ko-gcloud:latest).

--- a/tekton/cronjobs/dogfooding/images/ko-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/ko-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `ko` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/ko:latest](gcr.io/tekton-releases/dogfooding/ko:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/ko:latest](ghcr.io/tektoncd/plumbing/ko:latest).

--- a/tekton/cronjobs/dogfooding/images/koparse-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/koparse-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `koparse` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/tkn:latest](gcr.io/tekton-releases/dogfooding/koparse:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/tkn:latest](ghcr.io/tektoncd/plumbing/koparse:latest).

--- a/tekton/cronjobs/dogfooding/images/kubectl-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/kubectl-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `kubectl` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/kubectl:latest](gcr.io/tekton-releases/dogfooding/kubectl:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/kubectl:latest](ghcr.io/tektoncd/plumbing/kubectl:latest).

--- a/tekton/cronjobs/dogfooding/images/pipeline-test-runner-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/pipeline-test-runner-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build the `test-runner` container image used for CI/CD.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/test-runner:latest](gcr.io/tekton-releases/dogfooding/test-runner:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/test-runner:latest](ghcr.io/tektoncd/plumbing/test-runner:latest).

--- a/tekton/cronjobs/dogfooding/images/teps-community-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/teps-community-nightly/README.md
@@ -1,4 +1,4 @@
 # Teps image
 
 Cron Job to build a container with the "teps.py" tool from the tektoncd/community repo.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/teps:latest](gcr.io/tekton-releases/dogfooding/teps:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/teps:latest](ghcr.io/tektoncd/plumbing/teps:latest).

--- a/tekton/cronjobs/dogfooding/images/tkn-nightly/README.md
+++ b/tekton/cronjobs/dogfooding/images/tkn-nightly/README.md
@@ -1,2 +1,2 @@
 Cron Job to build a container image with `tkn` installed.
-The image is published daily to [gcr.io/tekton-releases/dogfooding/tkn:latest](gcr.io/tekton-releases/dogfooding/tkn:latest).
+The image is published daily to [ghcr.io/tektoncd/plumbing/tkn:latest](ghcr.io/tektoncd/plumbing/tkn:latest).

--- a/tekton/resources/cd/install-tekton-release.yaml
+++ b/tekton/resources/cd/install-tekton-release.yaml
@@ -57,7 +57,7 @@ spec:
         value: $(workspaces.resources.path)/plumbing/tekton/cd
   steps:
   - name: deploy-tekton-project
-    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+    image: ghcr.io/tektoncd/plumbing/ko-gcloud:latest
     script: |
       #!/usr/bin/env bash
       set -exo pipefail
@@ -92,7 +92,7 @@ spec:
       kubectl apply --kubeconfig $KUBECONFIG $APPLY_MODE
 
   - name: wait-until-pods-and-crds
-    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+    image: ghcr.io/tektoncd/plumbing/ko-gcloud:latest
     script: |
       #!/usr/bin/env bash
       set -exo pipefail
@@ -108,7 +108,7 @@ spec:
         kubectl wait --for condition=established --timeout=60s crd -l app.kubernetes.io/part-of=$APPLICATION
       fi
   - name: deploy-extra-manifest
-    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+    image: ghcr.io/tektoncd/plumbing/ko-gcloud:latest
     script: |
       #!/usr/bin/env bash
       set -exo pipefail

--- a/tekton/resources/images/docker-multi-arch-template.yaml
+++ b/tekton/resources/images/docker-multi-arch-template.yaml
@@ -78,7 +78,7 @@ spec:
             value: $(params.tags)
           - name: IMAGE_URL
             value: $(params.imageUrl)
-          image: gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest
+          image: ghcr.io/tektoncd/plumbing/buildx-gcloud:latest
           name: build-image-multi-arch
           script: |
             #!/usr/bin/env sh

--- a/tekton/resources/images/ko-multi-arch-template.yaml
+++ b/tekton/resources/images/ko-multi-arch-template.yaml
@@ -72,7 +72,7 @@ spec:
             value: $(params.tags)
           - name: CONTEXT_PATH
             value: $(params.contextPath)
-          image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+          image: ghcr.io/tektoncd/plumbing/ko-gcloud:latest
           name: build-image-multi-arch
           script: |
             #!/usr/bin/env sh

--- a/tekton/resources/nightly-tests/base/deploy_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/base/deploy_tekton_component.yaml
@@ -18,7 +18,7 @@ spec:
     mountPath: /root/.kube
   steps:
   - name: deploy
-    image: gcr.io/tekton-releases/dogfooding/kubectl:latest
+    image: ghcr.io/tektoncd/plumbing/kubectl:latest
     env:
     - name: KUBECONFIG
       value: $(workspaces.k8s-shared.path)/config

--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
@@ -25,7 +25,7 @@ spec:
     description: workspace with source code for tekton component
   steps:
   - name: run-e2e-tests
-    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    image: ghcr.io/tektoncd/plumbing/test-runner:latest
     workingDir: $(workspaces.source-code.path)/src/$(params.package)
     env:
     - name: REPO_ROOT_DIR

--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_component.yaml
@@ -34,7 +34,7 @@ spec:
     description: target architecture for tests (s390x, ppc64le, arm64)
   steps:
   - name: run-e2e-tests
-    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    image: ghcr.io/tektoncd/plumbing/test-runner:latest
     workingDir: $(workspaces.source-code.path)/src/$(params.package)
     env:
     - name: REPO_ROOT_DIR

--- a/tekton/resources/nightly-tests/bastion-z/cleanup_tekton.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/cleanup_tekton.yaml
@@ -20,7 +20,7 @@ spec:
     mountPath: /workspace
   steps:
   - name: cleanup-resources
-    image: gcr.io/tekton-releases/dogfooding/kubectl:latest
+    image: ghcr.io/tektoncd/plumbing/kubectl:latest
     env:
     - name: KUBECONFIG
       value: $(workspaces.k8s-shared.path)/config
@@ -34,7 +34,7 @@ spec:
         kubectl delete --ignore-not-found=true ${res}.tekton.dev --all || return true
       done
   - name: uninstall-tekton-project
-    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    image: ghcr.io/tektoncd/plumbing/test-runner:latest
     workingDir: /workspace/src/$(params.package)
     env:
     - name: KUBECONFIG

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_cli.yaml
@@ -25,7 +25,7 @@ spec:
     description: workspace with source code for tekton component
   steps:
   - name: run-e2e-tests
-    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    image: ghcr.io/tektoncd/plumbing/test-runner:latest
     workingDir: $(workspaces.source-code.path)/src/$(params.package)
     env:
     - name: REPO_ROOT_DIR

--- a/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/test_tekton_component.yaml
@@ -33,7 +33,7 @@ spec:
     description: workspace with source code for tekton component
   steps:
   - name: run-e2e-tests
-    image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+    image: ghcr.io/tektoncd/plumbing/test-runner:latest
     workingDir: $(workspaces.source-code.path)/src/$(params.package)
     env:
     - name: REPO_ROOT_DIR

--- a/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
@@ -124,7 +124,7 @@ spec:
               description: workspace with source code for tekton component
             steps:
             - name: run-e2e-tests
-              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              image: ghcr.io/tektoncd/plumbing/test-runner:latest
               workingDir: $(workspaces.source-code.path)/src/github.com/tektoncd/catalog
               env:
               - name: KUBECONFIG

--- a/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
@@ -124,7 +124,7 @@ spec:
               description: workspace with source code for tekton component
             steps:
             - name: run-e2e-tests
-              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              image: ghcr.io/tektoncd/plumbing/test-runner:latest
               workingDir: $(workspaces.source-code.path)/src/github.com/tektoncd/catalog
               env:
               - name: KUBECONFIG

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -116,7 +116,7 @@ spec:
               description: workspace with source code for tekton component
             steps:
             - name: run-e2e-tests
-              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              image: ghcr.io/tektoncd/plumbing/test-runner:latest
               workingDir: $(workspaces.source-code.path)/src/github.com/tektoncd/dashboard
               env:
               # Connect to the sidecar over TCP, with TLS.

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -116,7 +116,7 @@ spec:
               description: workspace with source code for tekton component
             steps:
             - name: run-e2e-tests
-              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              image: ghcr.io/tektoncd/plumbing/test-runner:latest
               workingDir: $(workspaces.source-code.path)/src/github.com/tektoncd/dashboard
               env:
               # Connect to the sidecar over TCP, with TLS.

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -115,7 +115,7 @@ spec:
               description: workspace with source code for tekton component
             steps:
             - name: run-e2e-tests
-              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              image: ghcr.io/tektoncd/plumbing/test-runner:latest
               workingDir: $(workspaces.source-code.path)/src/github.com/tektoncd/operator
               env:
               - name: GOPATH

--- a/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
@@ -115,7 +115,7 @@ spec:
               description: workspace with source code for tekton component
             steps:
             - name: run-e2e-tests
-              image: gcr.io/tekton-releases/dogfooding/test-runner:latest
+              image: ghcr.io/tektoncd/plumbing/test-runner:latest
               workingDir: $(workspaces.source-code.path)/src/github.com/tektoncd/operator
               env:
               - name: GOPATH

--- a/tekton/resources/release/release-logs/save-release-logs.yaml
+++ b/tekton/resources/release/release-logs/save-release-logs.yaml
@@ -34,7 +34,7 @@ spec:
         value: $(params.namespace)
   steps:
   - name: write-data
-    image: gcr.io/tekton-releases/dogfooding/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
+    image: ghcr.io/tektoncd/plumbing/tkn:v20230113-3deba3be3c@sha256:f977259288f8961d5e7ed966584f272431edadfda3bd0a30022ad9416ebde47e
     workingDir: $(workspaces.shared.path)
     script: |
       #!/usr/bin/env sh


### PR DESCRIPTION
# Changes

This reverts commit b18b17efee73753999a5a1d2e760657c48e899e5.

I made a more specific script which crane-copies images that are used right now in plumbing:
```
grin gcr.io/tekton-releases/dogfooding | grep 'image: gcr.io' | cut -d':' -f3- | awk '{ print $1}' | sort -u | grep ':' | while read aa; do image=$(basename $aa); crane cp ${aa} ghcr.io/tektoncd/plumbing/${image}; done
```

And I verified that this now works:
```
➜ podman pull ghcr.io/tektoncd/plumbing/test-runner:v20240701-65c50ec2ee@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356
Trying to pull ghcr.io/tektoncd/plumbing/test-runner@sha256:3041dfd469504cd36d3119a0f8057061f9e401eccb7d46462bdfeffdb8948356...
Getting image source signatures
Copying blob sha256:86bd4bee5e76706775a3ff03d90633e8562717d4b59ab0e40a8fd39b2bb16448
(...)
95a686135a8782c17106e5c6fd1f840129560b79604203425e8bce7cafa2caa1
```

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._