### PR TITLE
Remove dependabot config for images that have been removed from repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -205,19 +205,6 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/tekton/images/skopeo"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "ok-to-test"
-      - "dependencies"
-      - "release-note-none"
-      - "kind/misc"
-    groups:
-      all:
-        patterns:
-          - "*"
-  - package-ecosystem: "docker"
     directory: "/tekton/images/alpine-git-nonroot"
     schedule:
       interval: "weekly"
@@ -297,19 +284,6 @@ updates:
           - "*"
   - package-ecosystem: "docker"
     directory: "/tekton/images/tkn"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "ok-to-test"
-      - "dependencies"
-      - "release-note-none"
-      - "kind/misc"
-    groups:
-      all:
-        patterns:
-          - "*"
-  - package-ecosystem: "docker"
-    directory: "/tekton/images/openssh-server"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
The `skopeo` and `openssh-server` images were removed in https://github.com/tektoncd/plumbing/pull/2064 and https://github.com/tektoncd/plumbing/pull/2065

Cleanup the dependabot config as these are no longer needed.
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._