### PR TITLE
Fix the publish.yaml from the catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 **/.bin
 **/.DS_Store
+
+# Release
+**/source.tar.gz

--- a/tekton/catalog/tasks/publish.yaml
+++ b/tekton/catalog/tasks/publish.yaml
@@ -48,7 +48,7 @@ spec:
         value: "$(workspaces.source.path)/$(params.subfolder)"
       - name: SUBFOLDER
         value: $(params.subfolder)
-      - name: CONTAINER_REGISTY_CREDENTIALS
+      - name: CONTAINER_REGISTRY_CREDENTIALS
         value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
       - name: IMAGE_REGISTRY
         value: "$(params.imageRegistry)"
@@ -69,7 +69,7 @@ spec:
       - name: IMAGES
         value: $(params.images)
       - name: DOCKER_CONFIG
-        value: $(workspaces.output.path)/.docker
+        value: /workspace/.docker
       - name: KO_EXTRA_ARGS
         value: "$(params.koExtraArgs)"
   results:
@@ -83,18 +83,15 @@ spec:
       #!/bin/sh
       set -ex
 
-      # Ensure the DOCKER_CONFIG folder exists
-      mkdir -p ${DOCKER_CONFIG} || true
-
       # Login to IMAGE_REGISTRY. Crane will honour DOCKER_CONFIG.
-      cat ${CONTAINER_REGISTY_CREDENTIALS} | \
-        crane auth login -u _json_key --password-stdin ${IMAGE_REGISTRY}
+      cat ${CONTAINER_REGISTRY_CREDENTIALS} | \
+        crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin ${IMAGE_REGISTRY}
 
       # Auth with account credentials for all regions.
       for region in ${REGIONS}
       do
         HOSTNAME=${region}.${IMAGE_REGISTRY}
-        cat ${CONTAINER_REGISTY_CREDENTIALS} | crane auth login -u _json_key --password-stdin ${HOSTNAME}
+        cat ${CONTAINER_REGISTRY_CREDENTIALS} | crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin ${HOSTNAME}
       done
   - name: create-ko-yaml
     image: docker.io/library/busybox@sha256:c230832bd3b0be59a6c47ed64294f9ce71e91b327957920b6929a0caa8353140


### PR DESCRIPTION
# Changes

Creating .docker in the output workspace fails with permission issues, so using /workspace/.docker instead.

Also, the registry user was missing, which is now fixed.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._