### PR TITLE
Remove chains prow-based integration tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -584,39 +584,6 @@ presubmits:
             limits:
               cpu: 4000m
               memory: 8Gi
-    - name: pull-tekton-chains-integration-tests
-      labels:
-        preset-presubmit-sh: "true"
-      agent: kubernetes
-      always_run: true
-      decorate: true
-      rerun_command: "/test pull-tekton-chains-integration-tests"
-      trigger: "(?m)^/test (all|pull-tekton-chains-integration-tests),?(\\s+|$)"
-      spec:
-        containers:
-        - image: ghcr.io/tektoncd/plumbing/test-runner:v20250108-44b28c7784@sha256:93b108a47e11ccda5c981c7acf3238be5d1c6962a52149a4234227954e3dbdeb # go 1.23, kind 0.23, ko 0.15.4, go-license 1.0
-          imagePullPolicy: Always
-          command:
-          - /usr/local/bin/entrypoint.sh
-          args:
-          - "--scenario=kubernetes_execute_bazel"
-          - "--clean"
-          - "--job=$(JOB_NAME)"
-          - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
-          - "--root=/go/src"
-          - "--service-account=/etc/test-account/service-account.json"
-          - "--upload=gs://tekton-prow/pr-logs"
-          - "--" # end bootstrap args, scenario args below
-          - "--" # end kubernetes_execute_bazel flags (consider following flags as text)
-          - "./test/presubmit-tests.sh"
-          - "--integration-tests"
-          resources:
-            requests:
-              cpu: 2000m
-              memory: 4Gi
-            limits:
-              cpu: 4000m
-              memory: 8Gi
     - name: pull-tekton-chains-go-coverage
       labels:
         preset-github-token: "true"


### PR DESCRIPTION
# Changes

Chains E2E tests are covered via GitHub actions in a matrix against various versions of Tekton pipeline and K8s.

AFAIK the same tests are executed in the prow-based integration tests, only for fixed pipeline/k8s versions. I propose to remove it since it consumes infra resources and do not provide better coverage.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

FYI @tektoncd/chains-maintainers WDYT?