### PR TITLE
Remove retries field from Tekton pipeline templates for ppc64le

### DIFF
--- a/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
@@ -149,7 +149,6 @@ spec:
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
-          retries: 2
           params:
           - name: package
             value: github.com/tektoncd/cli

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -196,7 +196,6 @@ spec:
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
-          retries: 2
         finally:
         - name: delete-k8s-cluster
           taskRef:

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -151,7 +151,6 @@ spec:
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
-          retries: 2
         finally:
         - name: delete-k8s-cluster
           taskRef:

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -139,7 +139,6 @@ spec:
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
-          retries: 2
           params:
           - name: package
             value: github.com/tektoncd/pipeline
@@ -161,7 +160,6 @@ spec:
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
-          retries: 2
           params:
           - name: package
             value: github.com/tektoncd/pipeline

--- a/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
@@ -149,7 +149,6 @@ spec:
           - name: source-code
             workspace: shared-workspace
             subPath: source-code
-          retries: 2
           params:
           - name: package
             value: github.com/tektoncd/triggers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Signed-off-by: Valen Mascarenhas [Valen.Mascarenhas@ibm.com](mailto:Valen.Mascarenhas@ibm.com)

This PR removes the retries: 2 field from all relevant Tekton pipeline templates for ppc64le arch,. The change ensures tasks are not retried automatically on failure

# Changes

1. Removed retries: 2 field from task definitions in Tekton YAML files.



# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._