### PR TITLE
Fix coverage job

### DIFF
--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -156,6 +156,10 @@ spec:
               printf '$(params.package)' | awk -F/ '{printf($2)}' | tee /tekton/results/repoName
     - name: clone-coverage-upload
       runAfter: ['split-full-repo-name']
+      when:  # implicit dependency on the check tasks
+      - input: $(tasks.check-name-matches.results.check)
+        operator: in
+        values: ["passed"]
       workspaces:
         - name: source
         - name: credentials


### PR DESCRIPTION
# Changes

When issuing a `/test` command, the job checks if the CI job name matches, if not the coverage task does not need to run.
Today however the pipeline attempts to run the coverage task and fails because of missing results.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._