### PR TITLE
Fix failing kind cluster start and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing!
 **All contributors must comply with
 [the code of conduct](./code-of-conduct.md).**
 
-* To become an [OWNER](OWNER), see the requirements at [tektoncd/community](https://github.com/tektoncd/community/blob/main/process.md#requirements)
+* To become an [OWNER](OWNERS), see the requirements at [tektoncd/community](https://github.com/tektoncd/community/blob/main/org/README.md#requirements)
 * This repo holds configuration for infrastructure that is used by projects in
   https://github.com/tektoncd.
 * [The README](README.md) describes components of this infrastructure and how to interact
@@ -20,5 +20,5 @@ find info on:
   [commit messages](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)
   and [code](https://github.com/tektoncd/community/blob/main/standards.md#coding-standards)
 * [Processes](https://github.com/tektoncd/community/blob/main/process.md) like
-  [reviews](https://github.com/tektoncd/community/blob/main/process.md#reviews)
-  and [becoming an OWNER](https://github.com/tektoncd/community/blob/main/process.md#owners)
+  [reviews](https://github.com/tektoncd/community/blob/main/process/README.md)
+  and [becoming an OWNER](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,12 +8,12 @@ Tekton in a local cluster.
 
 There are several options available, `minikube`, `kind` and `k3c`
 are good options to run a kubernetes cluster on your laptop.
-If you have go 1.14+ and docker installed, you can use the
+If you have go 1.16+ and docker installed, you can use the
 automated script for `kind`:
 
 ```bash
 # Install Kind if not installed yet
-GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
+go install sigs.k8s.io/kind@v0.27.0
 
 # Delete any pre-existing Tekton cluster
 kind delete cluster --name tekton
@@ -25,7 +25,7 @@ kind delete cluster --name tekton
 If the deployment was successful, you should see a message:
 
 ```bash
-Tekton Dashboard available at http://localhost:9097”
+Tekton Dashboard available at http://localhost:9097
 ```
 
 ## Tekton Based CI
@@ -35,13 +35,16 @@ a service like [smee](https://smee.io) to forward GitHub webhooks
 to the service in your local cluster.
 
 In the following steps we use `smee`. You will need `npm` to install
-the client. You will also need `tkn` installed to run the webhook
-creation task.
+the client. You will need `kustomize` to build the resources and `tkn` installed to run the webhook creation task.
 
 ```bash
 # Install the smee client
 npm install -g smee-client
 ```
+
+Follow the `kustomize` installation guide [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
+
+Follow the `tkn` installation guide [here](https://github.com/tektoncd/cli?tab=readme-ov-file#installing-tkn).
 
 You will use webhooks triggered by your personal fork of the
 `tektoncd/plumbing` repo and forward them the cluster running on
@@ -70,4 +73,4 @@ If you need those for development, you'll need to ensure that:
 - Create the [secret](https://github.com/tektoncd/plumbing/blob/534861ab15eb5787cac51512eaae6ca2101a7573/tekton/resources/ci/github-template.yaml#L121-L123)
   needed by the GitHub update jobs to update status checks.
 
-See also _[CONTRIBUTING.md](CONTRIBUTING.md).
+See also [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/hack/README.md
+++ b/hack/README.md
@@ -23,7 +23,8 @@ This script uses [`kind`](https://kind.sigs.k8s.io/) to create a local K8s clust
 
 - `go`: go 1.14+
 - `kubectl`: Install the K8s CLI *(see [Install tools](https://kubernetes.io/docs/tasks/tools/))*
-- `docker`: Install Docker *(see [Get Docker](https://docs.docker.com/get-docker/))*
+- `podman`: Install Podman *(see [Podman Installation Instructions](https://podman.io/docs/installation))*
+- or `docker`: Install Docker *(see [Get Docker](https://docs.docker.com/get-started/get-docker/))*
 - `kind`: Install `kind` *(see ["quick start" documentation](https://kind.sigs.k8s.io/docs/user/quick-start/))*
 
 #### Usage
@@ -38,7 +39,7 @@ tekton_in_kind.sh [-c cluster-name -p pipeline-version -t triggers-version -d da
 
 The script, after using `kind` to create the K8s cluster, will then use `kubectl` to install the `latest` released versions of Tekton components unless other versions are specified on the optional arguments. Here is a snippet of how the script does this using `kubectl`:
 
-```bash
+```sh
 # Use `-p` arg. value or `latest`
 kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_PIPELINE_VERSION}/release.yaml
 # Use `-t` arg. value or `latest`
@@ -50,25 +51,75 @@ kubectl apply -f https://storage.googleapis.com/tekton-releases/dashboard/previo
 
 > **Note**: The script issues `kind cluster create` which automatically creates a K8s context named `'kind-tekton'` and makes it the current for `kubectl` commands.
 
+> **Note**: The `kind` tool automatically updates the `current-context` for the `kubectl` command. After deleting your local cluster, `kind` unsets the `current-context` and you must manually set it again (e.g., `kubectl config use-context <context-name>`.
+
+> **Note**: This script also builds and deploys a `kind-registry` named `registry:2` to your Podman/Docker image registry and leaves it running on port `5000`. You may manually stop it and delete the image if you do not intend to use the script again. For that see the cleanup section.
+
 #### Cleanup
 
 If you wish to delete the cluster that the script created, use the following command:
 
-```shell
+```sh
 kind delete cluster --name tekton
+```
+
+If you have podman and docker installed and you started the cluster with the podman runtime you need to tell `kind` to use podman when deleting the cluster by setting the `KIND_EXPERIMENTAL_PROVIDER` environment variable otherwise it will default to docker and wont be able to delete it:
+
+```sh
+export KIND_EXPERIMENTAL_PROVIDER=podman 
+kind delete cluster --name tekton
+```
+
+To stop and delete the registry, use the following command:
+
+```sh
+podman stop kind-registry && podman rm kind-registry
+```
+
+If you are using docker, use:
+
+```sh
+docker stop kind-registry && docker rm kind-registry
 ```
 
 The `kind` tool will also use the cluster name from the `KIND_CLUSTER_NAME` environment variable if set.
 
-```shell
+```sh
 export KIND_CLUSTER_NAME=tekton
 kind delete cluster
 Deleting cluster "tekton" ...
 ```
 
-> **Note**: The `kind` tool automatically updates the `current-context` for the `kubectl` command. After deleting your local cluster, `kind` unsets the `current-context` and you must manually set it again (e.g., `kubectl config use-context <context-name>`.
+#### Troubleshooting
 
-> **Note**: This script also builds and deploys a `kind-registry` named `registry:2` to your Docker image registry and leaves it running on port `5000`. You may manually stop it and delete the image if you do not intend to use the script again.
+Podman support for `kind` is in experimental state as described [here](https://github.com/kubernetes-sigs/kind/issues/1778). If you encounter issues you should first check the `kind` [known issues](https://kind.sigs.k8s.io/docs/user/known-issues) section. The next step would be the [closed](https://github.com/kubernetes-sigs/kind/issues?q=is%3Aissue%20state%3Aclosed%20podman) and then [open](https://github.com/kubernetes-sigs/kind/issues?q=is%3Aissue%20state%3Aopen%20podman) issues of the `kind` project on Github.
+
+##### Podman on Fedora 40
+
+If cluster start fails when `kind` tries to join your worker nodes, check the *kubelet* logs in the worker node container:
+
+```sh
+podman exec -it tekton-worker journalctl -u kubelet
+```
+
+If you see this error:
+
+```sh
+# removed timestamp and node name for brevity
+kubelet[510]: E0319 16:49:49.963674     510 manager.go:294] Registration of the raw container factory failed: inotify_init: too many open files
+kubelet[510]: E0319 16:49:49.964127     510 kubelet.go:1632] "Failed to start cAdvisor" err="inotify_init: too many open files"
+systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
+systemd[1]: kubelet.service: Failed with result 'exit-code'.
+```
+
+Increase the resources limits for *inotify*:
+
+```sh
+sudo sysctl fs.inotify.max_user_watches=524288
+sudo sysctl fs.inotify.max_user_instances=512
+```
+
+Read more [here](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
 
 ---
 
@@ -78,7 +129,7 @@ This script creates webhooks triggered by a specified GitHub repository and forw
 
 ### Usage
 
-```shell
+```sh
 tekton_ci.sh -u <github-user> -t <github-token> -o <github-org> -r <github-repo>
 
 Options:


### PR DESCRIPTION
# Changes

When starting the kind cluster using docker with the previous configuration the control-plane kubelet stopped with an error not knowing a feature gate for "EphemeralContainers". This feature is stable since kubernetes 1.24 so this configuration was safely removed.

Closes #2486.

Starting the kind cluster using podman failed when joining the worker-nodes. This is fixed by a minor change on the host. A [troubleshooting](https://github.com/tektoncd/plumbing/pull/2487/files#diff-6a33146cb453cc624d7fa8ebedf1e5f7105e5dc8c835badc012760e18853eb7bR93) section was added to the readme with a link to the fix.

Closes #2522.

Once the kind cluster started using podman the registry could not be connected. This issue was resolved by changing the network mode to "bridge" which is also used in the [guide](https://kind.sigs.k8s.io/docs/user/local-registry/#create-a-cluster-and-registry) on the kind website.

Closes #2523.

If podman and docker runtimes are installed on the host the script does not behave as expected. Starting it using podman will start the registry in podman and the kind cluster in docker. It was updated to always start the registry and the cluster using the same runtime.

Added logs with info about successful and next steps which helps to debug when something fails. Raised the timeouts in the `kubectl wait` command to `600s`, `120s` were not enough.

As of this writing the support for podman in kind is [experimental](https://github.com/kubernetes-sigs/kind/issues/1778). This information was added to the documentation.

Fixed broken links in CONTRIBUTING.md. Updated cluster installation docs in DEVELOPMENT.md to use latest kind and newer go versions, added links to kustomize and tkn installation guides.

/kind bug
/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._