### PR TITLE
Fix subpath capitalisation

### DIFF
--- a/tekton/catalog/pipelines/release.yaml
+++ b/tekton/catalog/pipelines/release.yaml
@@ -76,7 +76,7 @@ spec:
       workspaces:
         - name: output
           workspace: workarea
-          subpath: git
+          subPath: git
       params:
         - name: url
           value: https://$(params.package)
@@ -101,7 +101,7 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git/$(params.subfolder)
+          subPath: git/$(params.subfolder)
     - name: build
       runAfter: [git-clone]
       when:
@@ -121,7 +121,7 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git/$(params.subfolder)
+          subPath: git/$(params.subfolder)
     - name: publish-images
       runAfter: [build, unit-tests]
       taskRef:
@@ -163,10 +163,10 @@ spec:
       workspaces:
         - name: source
           workspace: workarea
-          subpath: git
+          subPath: git
         - name: output
           workspace: workarea
-          subpath: bucket
+          subPath: bucket
         - name: release-secret
           workspace: release-images-secret
     - name: publish-to-bucket
@@ -185,7 +185,7 @@ spec:
           workspace: release-secret
         - name: source
           workspace: workarea
-          subpath: bucket
+          subPath: bucket
       params:
         - name: location
           value: $(params.releaseBucket)/previous/$(params.versionTag)
@@ -213,7 +213,7 @@ spec:
           workspace: release-secret
         - name: source
           workspace: workarea
-          subpath: bucket
+          subPath: bucket
       params:
         - name: location
           value: $(params.releaseBucket)/latest


### PR DESCRIPTION
# Changes

The latest Tekton is picky on capitalisation(as it should)
Fixing the incorrect `subpath` to `subPath`

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._