### PR TITLE
Replace obsolete bundle refs with bundle resolver

### DIFF
--- a/tekton/ci/jobs/tekton-yamllint.yaml
+++ b/tekton/ci/jobs/tekton-yamllint.yaml
@@ -25,8 +25,14 @@ spec:
   tasks:
   - name: git-clone
     taskRef:
-      name: git-clone
-      bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+      resolver: bundles
+      params:
+      - name: bundle
+        value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+      - name: name
+        value: git-clone
+      - name: kind
+        value: task
     params:
       - name: url
         value: $(params.gitRepository)
@@ -66,8 +72,14 @@ spec:
         operator: in
         values: ["passed"]              # In cases triggered not by specific github comments
     taskRef:
-      name: yaml-lint
-      bundle: ghcr.io/tektoncd/catalog/upstream/tasks/yaml-lint:0.1
+      resolver: bundles
+      params:
+      - name: bundle
+        value: ghcr.io/tektoncd/catalog/upstream/tasks/yaml-lint:0.1
+      - name: name
+        value: yaml-lint
+      - name: kind
+        value: task
     params:
     - name: args
       value: ["$(params.args[*])"]

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -197,8 +197,14 @@ spec:
           - name: data
             value: '{"pull-request-id": "$(params.pullRequestID)", "build-pipelinerun": "$(context.pipelineRun.name)", "git-url": "https://$(params.gitRepository)", "git-revision": "$(params.gitRevision)", "target-image": "$(params.targetImage)", "status": "$(tasks.clone-and-build.status)"}'
           taskRef:
-            name: cloudevent
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/cloudevent:0.1
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/cloudevent:0.1
+            - name: name
+              value: cloudevent
+            - name: kind
+              value: task
       params:
       - name: pullRequestID
         value: $(tt.params.pullRequestID)

--- a/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-catalog
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/catalog

--- a/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-catalog
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/catalog

--- a/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-plumbing
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-cli
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/cli

--- a/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-plumbing
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-cli
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/cli

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-dashboard
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/dashboard

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-dashboard
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/dashboard

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-operator
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/operator

--- a/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-operator
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/operator

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-plumbing
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-pipeline
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/pipeline

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-plumbing
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-pipeline
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/pipeline

--- a/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-plumbing
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-triggers
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/triggers

--- a/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
@@ -65,8 +65,14 @@ spec:
         tasks:
         - name: git-clone-plumbing
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-triggers
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+            - name: bundle
+              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            - name: name
+              value: git-clone
+            - name: kind
+              value: task
           params:
           - name: url
             value: https://github.com/tektoncd/triggers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Update usage of the no longer supported `bundle:` field in `taskRef`. Instead replace it with the bundles remote resolver.
/kind misc

`bundle:` refs are no longer supported by the latest Pipelines releases and this is causing the config sync to dogfooding to fail, e.g.:
`2025-05-22T12:31:32.027419345Z Error from server (BadRequest): error when creating "target.yaml": admission webhook "[validation.webhook.pipeline.tekton.dev](http://validation.webhook.pipeline.tekton.dev/)" denied the request: validation failed: must not set the field(s): spec.tasks[0].taskRef.bundle, spec.tasks[3].taskRef.bundle`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._