### PR TITLE
Replacing deprecated bundle with remote resolution syntax for PPC64LE

### DIFF
--- a/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
@@ -63,10 +63,16 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
-        - name: git-clone-catalog
+        - name: git-clone
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/catalog

--- a/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
@@ -63,10 +63,16 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
-        - name: git-clone-plumbing
+        - name: git-clone
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-cli
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/cli

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -63,10 +63,16 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
-        - name: git-clone-dashboard
+        - name: git-clone
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/dashboard

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -63,10 +63,16 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
-        - name: git-clone-operator
+        - name: git-clone
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/operator

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -63,10 +63,16 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
-        - name: git-clone-plumbing
+        - name: git-clone
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-pipeline
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/pipeline

--- a/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
@@ -63,10 +63,16 @@ spec:
         - name: remote-port
         - name: remote-user
         tasks:
-        - name: git-clone-plumbing
+        - name: git-clone
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/plumbing
@@ -81,8 +87,14 @@ spec:
         - name: git-clone-triggers
           runAfter: [git-clone-plumbing]
           taskRef:
-            name: git-clone
-            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+            resolver: bundles
+            params:
+              - name: name
+                value: git-clone
+              - name: bundle
+                value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+              - name: kind
+                value: task
           params:
           - name: url
             value: https://github.com/tektoncd/triggers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Signed-off-by: Sanskruti Dongre Sanskruti.Dongre@ibm.com

The PPC64LE Tekton jobs stopped running as support for the deprecated bundle is removed recently. Here is the fix that was proposed

# Changes

```
      - name: git-clone-dashboard
          taskRef:
            name: git-clone
            bundle: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
```

this should be replaced by the remote resolution syntax

```    
    - name: git-clone
       taskRef:
          resolver: bundles
          params:
            - name: name
              value: git-clone
            - name: bundle
              value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
            - name: kind
              value: task
```

/kind bug
