### PR TITLE
chore: improve tekton_ci.sh with fixes and enhancements

### DIFF
--- a/hack/tekton_ci.sh
+++ b/hack/tekton_ci.sh
@@ -1,22 +1,68 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-declare GITHUB_USER GITHUB_TOKEN GITHUB_ORG GITHUB_REPO
+declare GITHUB_USER GITHUB_TOKEN GITHUB_ORG GITHUB_REPO GITHUB_SECRET
 
 # This script deploys Tekton CI on a local kind cluster
 # It create GitHub webhook and deploys Tekton CI pipeline and tasks
 
-USAGE="Usage:  tekton_ci.sh -u <github-user> -t <github-token> -o <github-org> -r <github-repo>
+USAGE="Usage:  tekton_ci.sh -u <github-user> -t <github-token> -o <github-org> -r <github-repo> [-s <github-secret>]
 
 Options:
  -u <github-user>         Your GitHub username
  -t <github-token>        Your GitHub token
  -o <github-org>          The org or user where your fork is hosted
  -r <github-repo>         The name of the fork, typically \"plumbing\"
+ -s <github-secret>       GitHub webhook secret (optional, will be generated if not provided)
 "
 
+# Function to check if required tools are available
+check_dependencies() {
+  local missing_tools=()
+  
+  for tool in kubectl kustomize smee tkn ko; do
+    if ! command -v "$tool" &> /dev/null; then
+      missing_tools+=("$tool")
+    fi
+  done
+  
+  # Check for container runtime (docker or podman)
+  if ! command -v docker &> /dev/null && ! command -v podman &> /dev/null; then
+    missing_tools+=("docker or podman")
+  fi
+  
+  if [ ${#missing_tools[@]} -ne 0 ]; then
+    echo "Error: Missing required tools: ${missing_tools[*]}"
+    echo "Please install these tools before running this script."
+    exit 1
+  fi
+}
+
+# Function to generate a random secret
+generate_secret() {
+  openssl rand -hex 20
+}
+
+# Function to cleanup background processes
+cleanup() {
+  echo "Cleaning up background processes..."
+  if [[ -n "$KUBECTL_PID" ]]; then
+    kill "$KUBECTL_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$SMEE_PID" ]]; then
+    kill "$SMEE_PID" 2>/dev/null || true
+  fi
+  rm -f ./el-tekton-ci-pf.log ./smee.log
+}
+
+# Set up cleanup trap
+trap cleanup EXIT
+
+# Check dependencies first
+check_dependencies
+
 # Read command line options
-while getopts ":u:t:o:r:" opt; do
+while getopts ":u:t:o:r:s:" opt; do
   case ${opt} in
     u )
       GITHUB_USER=$OPTARG
@@ -29,6 +75,9 @@ while getopts ":u:t:o:r:" opt; do
       ;;
     r )
       GITHUB_REPO=$OPTARG
+      ;;
+    s )
+      GITHUB_SECRET=$OPTARG
       ;;
     \? )
       echo "Invalid option: $OPTARG" 1>&2
@@ -51,31 +100,146 @@ if [ -z "$GITHUB_USER" ] || [ -z "$GITHUB_TOKEN" ] || [ -z "$GITHUB_ORG" ] || [ 
   exit 1
 fi
 
+# Generate GitHub secret if not provided
+if [ -z "$GITHUB_SECRET" ]; then
+  GITHUB_SECRET=$(generate_secret)
+  echo "Generated GitHub webhook secret: $GITHUB_SECRET"
+fi
+
+echo "Deploying Tekton CI resources..."
 
 # Deploy plumbing resources. Run from the root of your local clone
 # The sed command injects your fork GitHub org in the CEL filters
-kustomize build tekton/ci | \
-  sed -E 's/tektoncd(\/p[^i]+|\(|\/'\'')/'$GITHUB_ORG'\1/g' | \
-  kubectl create -f -
+if ! kustomize build tekton/ci | \
+  sed -E "s/tektoncd(\/p[^i]+|\(|\/')/$GITHUB_ORG\1/g" | \
+  kubectl create -f -; then
+  echo "Error: Failed to deploy plumbing resources"
+  exit 1
+fi
+
+# Install build-id cluster interceptor (required by CI resources)
+echo "Installing build-id cluster interceptor..."
+
+# Set environment variables for ko
+export KO_DOCKER_REPO=ghcr.io/${GITHUB_ORG}/${GITHUB_REPO}
+
+# login to ghcr.io (GitHub Container Registry) to allow ko to push the built container image there
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u "${GITHUB_USER}" --password-stdin
+
+# create a secret to allow the cluster to pull the image when deploying
+kubectl create secret docker-registry ghcr-creds \
+  --docker-server=ghcr.io \
+  --docker-username="$GITHUB_USER" \
+  --docker-password="$GITHUB_TOKEN" \
+  --namespace=tekton-ci
+
+# Change to the build-id directory since ko needs to be run from where go.mod is located
+pushd tekton/ci/cluster-interceptors/build-id > /dev/null
+
+# Create service account and add image pull secret
+kubectl apply -f config/100-serviceaccount.yaml --namespace=tekton-ci
+
+# add the secret to the service account
+kubectl patch serviceaccount build-id-bot \
+  --namespace tekton-ci \
+  --patch '{"imagePullSecrets": [{"name": "ghcr-creds"}]}'
+
+# Apply build-id cluster interceptor configuration directly
+echo "Building and applying build-id cluster interceptor..."
+if ! ko apply -f config/ -- --namespace=tekton-ci; then
+  echo "Error: Failed to install build-id cluster interceptor"
+  popd > /dev/null
+  exit 1
+fi
+
+popd > /dev/null
+
+echo "Creating secrets..."
 
 # Create the secret used by the GitHub interceptor
-kubectl create secret generic ci-webhook -n tektonci --from-literal=secret=$GITHUB_SECRET
+if ! kubectl create secret generic ci-webhook -n tekton-ci --from-literal=secret="$GITHUB_SECRET"; then
+  echo "Error: Failed to create ci-webhook secret"
+  exit 1
+fi
+
+echo "Waiting for pods to be ready..."
 
 # Wait until all pods are ready
-kubectl wait -n tektonci --for=condition=ready pods --all --timeout=120s
+if ! kubectl wait -n tekton-ci --for=condition=ready pods --all --timeout=120s; then
+  echo "Error: Pods failed to become ready within timeout"
+  exit 1
+fi
+
+echo "Setting up port forwarding and smee..."
 
 # Expose the event listener via Smee
-kubectl port-forward service/el-tekton-ci-webhook -n tektonci 9999:8080 &> ./el-tekton-ci-webhook-pf.log &
-smee --target http://127.0.0.1:9999/ &> ./smee.log &
+kubectl port-forward service/el-tekton-ci -n tekton-ci 9999:8080 &> ./el-tekton-ci-pf.log &
+KUBECTL_PID=$!
 
-# Wait smee target ready
+smee --target http://127.0.0.1:9999/ &> ./smee.log &
+SMEE_PID=$!
+
+# Wait smee target ready and extract URL more robustly
+echo "Waiting for smee to start..."
 sleep 5
+
+# Wait for smee log to contain the URL
+for i in {1..10}; do
+  if [[ -f "./smee.log" ]] && grep -q "https://smee.io/" "./smee.log"; then
+    break
+  fi
+  sleep 2
+done
+
+if [[ ! -f "./smee.log" ]] || ! grep -q "https://smee.io/" "./smee.log"; then
+  echo "Error: Failed to get smee URL from log"
+  exit 1
+fi
+
 SMEE_TARGET=$(tail -1 ./smee.log | cut -d'/' -f3-)
 
-# Install a Task to create the webhook, create a secret used by it
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/triggers/main/docs/getting-started/create-webhook.yaml
+if [[ -z "$SMEE_TARGET" ]]; then
+  echo "Error: Failed to extract smee target URL"
+  exit 1
+fi
 
-kubectl create secret generic github --from-literal=token=$GITHUB_TOKEN --from-literal=secret=$GITHUB_SECRET
+echo "Smee target: $SMEE_TARGET"
+
+echo "Installing webhook creation task..."
+
+# Install a Task to create the webhook, create a secret used by it
+if ! kubectl apply -f https://raw.githubusercontent.com/tektoncd/triggers/main/docs/getting-started/create-webhook.yaml; then
+  echo "Error: Failed to install webhook creation task"
+  exit 1
+fi
+
+if ! kubectl create secret generic github --from-literal=token="$GITHUB_TOKEN" --from-literal=secret="$GITHUB_SECRET"; then
+  echo "Error: Failed to create github secret"
+  exit 1
+fi
+
+echo "Creating webhook in GitHub repository..."
 
 # Setup the webhook in your fork that points to the smee service
-tkn task start create-webhook -p ExternalDomain=$SMEE_TARGET -p GitHubUser=$GITHUB_USER -p GitHubRepo=$GITHUB_REPO -p GitHubOrg=$GITHUB_ORG -p GitHubSecretName=github -p GitHubAccessTokenKey=token -p GitHubSecretStringKey=secret
+if ! tkn task start create-webhook \
+  -p ExternalDomain="$SMEE_TARGET" \
+  -p GitHubUser="$GITHUB_USER" \
+  -p GitHubRepo="$GITHUB_REPO" \
+  -p GitHubOrg="$GITHUB_ORG" \
+  -p GitHubDomain="github.com" \
+  -p WebhookEvents='[\"push\",\"pull_request\"]' \
+  -p GitHubSecretName=github \
+  -p GitHubAccessTokenKey=token \
+  -p GitHubSecretStringKey=secret; then
+  echo "Error: Failed to create webhook"
+  exit 1
+fi
+
+echo "Tekton CI deployment completed successfully!"
+echo "GitHub webhook secret: $GITHUB_SECRET"
+echo "Smee URL: https://$SMEE_TARGET"
+echo ""
+echo "Background processes are running. Press Ctrl+C to stop them."
+
+# Keep the script running to maintain the port-forward and smee processes
+wait

--- a/tekton/ci/infra/0001_rbac.yaml
+++ b/tekton/ci/infra/0001_rbac.yaml
@@ -85,16 +85,39 @@ rules:
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-interceptor-access
+rules:
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["interceptors"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-ci-jobs-triggers-tekton-ci-workspace-listener
 subjects:
 - kind: ServiceAccount
   name: tekton-ci-workspace-listener
+  namespace: tekton-ci
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: tekton-ci-jobs-triggers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-interceptor-access-tekton-ci-workspace-listener
+subjects:
+- kind: ServiceAccount
+  name: tekton-ci-workspace-listener
+  namespace: tekton-ci
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-interceptor-access
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR refactors the `hack/tekton_ci.sh` script to make Tekton CI setup on a local Kind cluster error free, reliable  and automated. Includes a combination of fixes and improvements as listed below:

**Issues Fixed:**
- **GITHUB_SECRET undefined**: Added auto-generation with `openssl rand -hex 20` and optional `-s` parameter
- **Namespace inconsistency**: Fixed all references to use namespace `tekton-ci` consistently. There were issues since at some locations namespace was defaulted or incorrectly used as `tektonci`
- **Missing RBAC**: - Added missing `ClusterRole` for `tekton-interceptor-access` with proper `ClusterRoleBinding` for event listener service account
- **Missing build-id interceptor installation**:  Installation automation for build-id interceptor was missing, which resulted in hooks not triggering any events. This is fixed and fully automated now

**Improvements**
- Added error checking for every critical command with descriptive messages
- Implemented proper cleanup with signal traps for background processes
- Added robust smee URL extraction with retry logic
- Enabled non-interactive webhook creation using `tkn task start`
- Documents the need and process to create github Personal Access Tokens to access repos and package registry

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._