### PR TITLE
Replace deprecated Dashboard extension displayname field

### DIFF
--- a/tekton/cd/dashboard/overlays/dogfooding/extensions.yaml
+++ b/tekton/cd/dashboard/overlays/dogfooding/extensions.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   apiVersion: batch/v1
   name: cronjobs
-  displayname: k8s cronjobs
+  displayName: k8s cronjobs
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
`displayname` is deprecated as of Dashboard v0.49 and removed in v0.54.  I have updated `dogfooding` to v0.53 which is the latest release that supports both. Once this PR is merged I will deploy the latest release (v0.60).

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._