### PR TITLE
Add kustomization file for cm

### DIFF
--- a/prow/kustomization.yaml
+++ b/prow/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- rbac.yaml
+- prow.yaml
+- extra.yaml
+- ghproxy.yaml
+- prowjob-schemaless_customresourcedefinition.yaml
+- tune-sysctls_daemonset.yaml
+
+configMapGenerator:
+  - name: config
+    files:
+    - config.yaml
+    options:
+      disableNameSuffixHash: true
+      labels:
+        app: prow
+  - name: plugins
+    files:
+    - plugins.yaml
+    options:
+      disableNameSuffixHash: true
+      labels:
+        app: prow

--- a/prow/rbac.yaml
+++ b/prow/rbac.yaml
@@ -15,35 +15,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: config-map-updater
-  namespace: default
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "list", "patch", "update"]
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: prow-config-bot
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: prow-config-bot-config-map-updater
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: config-map-updater
-subjects:
-- kind: ServiceAccount
-  name: prow-config-bot
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: config-map-updater
   namespace: github-admin
 rules:
 - apiGroups: [""]


### PR DESCRIPTION
# Changes

Add a kustomization file that can be used to deploy prow along with its config maps. I'm replicating the prow setup on OCI, using ArgoCD to sync folders from the plumbing repo. This kustomization file allows to use the kustomize plugin in ArgoCD and avoid the extra process to generate config maps.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._