### PR TITLE
Add OCI configs for prow

### DIFF
--- a/prow/oci/config.yaml
+++ b/prow/oci/config.yaml
@@ -1,0 +1,415 @@
+# Copyright 2019-2024 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+prowjob_namespace: default
+pod_namespace: test-pods
+
+plank:
+  job_url_template: 'https://prow.infra.tekton.dev/view/gs/tekton-prow/{{if or (eq .Spec.Type "presubmit") (eq .Spec.Type "batch")}}pr-logs/pull{{with .Spec.Refs}}/{{.Org}}_{{.Repo}}{{end}}{{else}}logs{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  report_templates:
+    '*': '[Full PR test history](https://prow.infra.tekton.dev/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.infra.tekton.dev/pr?query=is%3Apr%20state%3Aopen%20author%3A{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
+  job_url_prefix_config:
+    '*': https://prow.infra.tekton.dev/view/
+  pod_pending_timeout: 60m
+  pod_unscheduled_timeout: 5m
+  default_decoration_configs:
+    '*':
+      timeout: 2h
+      grace_period: 15s
+      utility_images:
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220628-aa928caf31"
+        initupload: "gcr.io/k8s-prow/initupload:v20220628-aa928caf31"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220628-aa928caf31"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220628-aa928caf31"
+      gcs_configuration:
+        bucket: "tekton-prow"
+        path_strategy: "explicit"
+        default_org: "tektoncd"
+        default_repo: "pipeline"
+      gcs_credentials_secret: "test-account"
+      resources:
+        clonerefs:
+          requests:
+            cpu: 100m
+        initupload:
+          requests:
+            cpu: 100m
+        place_entrypoint:
+          requests:
+            cpu: 100m
+        sidecar:
+          requests:
+            cpu: 100m
+
+branch-protection:
+  orgs:
+    tektoncd:
+      # Protect all branches in tekton
+      # This means all prow jobs with "always_run" set are required
+      # to pass before tide can merge the PR.
+      # Currently this is manually enabled by the tekton org admins,
+      # but it's stated here for documentation and reference purposes.
+      protect: true
+      # Admins can overrule checks
+      enforce_admins: false
+      # Enforce EasyCLA for all repos
+      required_status_checks:
+        contexts:
+        - EasyCLA
+      repos:
+        dashboard:
+          required_status_checks:
+            contexts:
+            - "Build tests"
+            - "E2E tests (k8s-oldest, read-only)"
+            - "E2E tests (k8s-oldest, read-write)"
+            - "E2E tests (k8s-plus-one, read-only)"
+            - "E2E tests (k8s-plus-one, read-write)"
+            - "Unit tests"
+        pipeline:
+          required_status_checks:
+            contexts:
+            - check-pr-has-kind-label
+            - "build"
+            - "test"
+            - "lint"
+            - "Check generated code"
+            - "Multi-arch build"
+            - "e2e-tests / e2e tests (k8s-oldest, alpha)"
+            - "e2e-tests / e2e tests (k8s-oldest, beta)"
+            - "e2e-tests / e2e tests (k8s-oldest, stable)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-three, alpha)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-three, beta)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-three, stable)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-two, alpha)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-two, beta)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-two, stable)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-one, alpha)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-one, beta)"
+            - "e2e-tests / e2e tests (k8s-latest-minus-one, stable)"
+            - "e2e-tests / e2e tests (k8s-latest, alpha)"
+            - "e2e-tests / e2e tests (k8s-latest, beta)"
+            - "e2e-tests / e2e tests (k8s-latest, stable)"
+        operator:
+          required_status_checks:
+            contexts:
+            - check-pr-has-kind-label
+            - "build"
+            - "test"
+            - "lint"
+            - "Check generated code"
+            - "Multi-arch build"
+            - "e2e-tests / e2e tests (k8s-oldest)"
+            - "e2e-tests / e2e tests (k8s-plus-one)"
+        mcp-server:
+          required_status_checks:
+            contexts:
+            - "build"
+            - "test"
+            - "lint"
+        triggers:
+          required_status_checks:
+            contexts:
+            - "lint"
+            - "Tekton Triggers CI"
+        cli:
+          required_status_checks:
+            contexts:
+            - "build"
+            - "test"
+            - "lint"
+            - "Check generated code"
+            - "Multi-arch build"
+            - "e2e-tests / e2e tests (k8s-oldest)"
+            - "e2e-tests / e2e tests (k8s-plus-one)"
+    tektoncd-catalog:
+      # Protect all branches in tektoncd-catalog
+      # This means all prow jobs with "always_run" set are required
+      # to pass before tide can merge the PR.
+      # Currently this is manually enabled by the tekton org admins,
+      # but it's stated here for documentation and reference purposes.
+      protect: true
+      # Admins can overrule checks
+      enforce_admins: false
+      # Enforce EasyCLA for all repos
+      required_status_checks:
+        contexts:
+        - EasyCLA
+
+sinker:
+  resync_period: 1m
+  max_prowjob_age: 48h
+  terminated_pod_ttl: 30m
+  max_pod_age: 3h
+
+tide:
+  sync_period: 2m
+  queries:
+  - repos:
+    - tektoncd-catalog/golang
+    - tektoncd/actions
+    - tektoncd/ahmetb-gen-crd-api-reference-docs
+    - tektoncd/catalog
+    - tektoncd/catlin
+    - tektoncd/chains
+    - tektoncd/cli
+    - tektoncd/community
+    - tektoncd/dashboard
+    - tektoncd/friends
+    - tektoncd/hub
+    - tektoncd/mcp-server
+    - tektoncd/operator
+    - tektoncd/pipeline
+    - tektoncd/plumbing
+    - tektoncd/resolution
+    - tektoncd/results
+    - tektoncd/triggers
+    - tektoncd/website
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/requires-unreleased-pipelines
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
+    - needs-rebase
+  merge_method:
+    tektoncd-catalog/golang: rebase
+    tektoncd/actions: rebase
+    tektoncd/ahmetb-gen-crd-api-reference-docs: rebase
+    tektoncd/catalog: rebase
+    tektoncd/catlin: rebase
+    tektoncd/chains: squash
+    tektoncd/cli: rebase
+    tektoncd/community: rebase
+    tektoncd/dashboard: rebase
+    tektoncd/friends: rebase
+    tektoncd/hub: rebase
+    tektoncd/mcp-server: rebase
+    tektoncd/operator: rebase
+    tektoncd/pipeline: rebase
+    tektoncd/plumbing: rebase
+    tektoncd/resolution: rebase
+    tektoncd/results: rebase
+    tektoncd/triggers: rebase
+    tektoncd/website: rebase
+  target_url: https://prow.infra.tekton.dev/tide
+  priority:
+  - labels: ["kind/flake", "priority/critical-urgent"]
+  - labels: ["kind/failing-test", "priority/critical-urgent"]
+  - labels: ["kind/bug", "priority/critical-urgent"]
+  pr_status_base_urls:
+    '*': https://prow.infra.tekton.dev/pr
+
+deck:
+  spyglass:
+    size_limit: 200000000 # 200MB
+    gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
+    testgrid_config: gs://tekton-prow/testgrid/config
+    testgrid_root: https://testgrid.k8s.io/
+    lenses:
+    - lens:
+        name: metadata
+      required_files:
+      - ^(?:started|finished)\.json$
+      optional_files:
+      - ^(?:podinfo|prowjob)\.json$
+    - lens:
+        name: buildlog
+        config:
+          highlighter:
+            endpoint: http://halogen.default.svc.cluster.local
+            pin: true
+            auto: false
+          highlight_regexes:
+          - Automatic merge failed
+          - cannot convert.+to type
+          - "cannot use.+as.+(type|value)"
+          - Cluster failed to initialize
+          - cluster unreachable
+          - "compilepkg: error"
+          - configuration error
+          - contact Google support
+          - could not apply prowjob annotations
+          - could not find the referenced.+TestGroup
+          - could not write config
+          - "couldn't load prow config:"
+          - curl.+Failed to connect
+          - DATA RACE
+          - dirty working directory
+          - ^E\d{4} \d\d:\d\d:\d\d\.\d+
+          - "(Error|ERROR|error)s?:"
+          - Error.+executing benchmarks
+          - Expected.+got
+          - FAILED. See logs
+          - failed to acquire k8s binaries
+          - failed to solve
+          - (FAIL|Failure \[)\b
+          - fatal error
+          - flag provided but not defined
+          - Full Stack Trace
+          - got.+expected
+          - hash mismatch
+          - Hit an unsupported type
+          - imported but not used
+          - Incompatible changes
+          - incorrect boilerplate
+          - indent-error-flow
+          - INSTALLATION FAILED
+          - is a misspelling
+          - LimitExceeded
+          - "make:.+Error"
+          - Master not detected
+          - Merge conflict
+          - not enough arguments in call
+          - panic\b
+          - Previous (write|read)
+          - Process did not finish before.+timeout
+          - race detected
+          - security token.+invalid
+          - "signal: killed"
+          - Something went wrong
+          - too few arguments
+          - too many errors
+          - "[Tt]imed out"
+          - type.+has no field
+          - unable to start the controlplane
+          - "undefined:"
+          - Unfortunately, an error
+          - unused.+deadcode
+          - "[Uu]nexpected error"
+          - verify.+failed
+          - want.+got
+          - Your cluster may not be fully functional
+          - ^\s+\^$
+          - \[(0;)?31m
+          - "^diff " # [+-]{3}\\s" has too much noise from go test output and set -x
+          - • Failure
+          # This highlights the start of bazel tests/runs to skip go importing noise.
+          - "^INFO: Analyzed \\d+ targets"
+      required_files:
+        - ^.*build-log\.txt$
+    - lens:
+        name: junit
+      required_files:
+        - ^artifacts(/.*/|/)junit.*\.xml$ # https://regex101.com/r/vCSegS/1
+    - lens:
+        name: coverage
+      required_files:
+        - ^artifacts/filtered\.cov$
+      optional_files:
+        - ^artifacts/filtered\.html$
+    - lens:
+        name: podinfo
+        config:
+          runner_configs:
+            "default":
+              pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-a/prow/test-pods/{{ .Name }}/details?project=tekton-releases"
+      required_files:
+        - ^podinfo\.json$
+      optional_files:
+        - ^prowjob\.json$
+    - lens:
+        name: links
+      required_files:
+        - artifacts/.*\.link\.txt
+  tide_update_period: 1s
+
+presets:
+- labels:
+    preset-presubmit-sh: "true"
+  volumeMounts:
+  - name: test-account
+    mountPath: /etc/test-account
+    readOnly: true
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/test-account/service-account.json
+  - name: E2E_CLUSTER_REGION
+    value: us-central1
+  volumes:
+  - name: test-account
+    secret:
+      secretName: test-account
+- labels:
+    preset-postsubmit-sh: "true"
+  volumeMounts:
+  - name: nightly-account
+    mountPath: /etc/nightly-account
+    readOnly: true
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/nightly-account/service-account.json
+  volumes:
+  # this secret/service-account has access to the tekton-nightly project, specifically make it possible to push
+  # images to gcr.io/tekton-nightly 👼
+  - name: nightly-account
+    secret:
+      secretName: nightly-account
+- labels:
+    preset-github-token: "true"
+  volumeMounts:
+  - name: github-token
+    mountPath: /etc/github-token
+    readOnly: true
+  volumes:
+  - name: github-token
+    secret:
+      secretName: oauth-token
+# docker-in-docker (with images/bootstrap) preset
+# NOTE: using this also requires using that image,
+# ensuring you run your test under either the ENTRYPOINT or:
+# /usr/local/bin/runner.sh my-test-command --foo --bar
+# AND setting the following on your PodSpec:
+# securityContext:
+#   privileged: true
+# These settings were taken from kubernetes/test-infra: https://github.com/kubernetes/test-infra/blob/aaf616ee940bcc64f775a77797fc80048df634b4/config/prow/config.yaml#L751
+- labels:
+    preset-dind-enabled: "true"
+  env:
+  - name: DOCKER_IN_DOCKER_ENABLED
+    value: "true"
+  volumes:
+  # kubekins-e2e legacy path
+  - name: docker-graph
+    emptyDir: {}
+  # krte (normal) path
+  - name: docker-root
+    emptyDir: {}
+  volumeMounts:
+  - name: docker-graph
+    mountPath: /docker-graph
+  - name: docker-root
+    mountPath: /var/lib/docker
+# volume mounts for kind
+- labels:
+    preset-kind-volume-mounts: "true"
+  volumeMounts:
+    - mountPath: /lib/modules
+      name: modules
+      readOnly: true
+    - mountPath: /sys/fs/cgroup
+      name: cgroup
+  volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory

--- a/prow/oci/ingress.yaml
+++ b/prow/oci/ingress.yaml
@@ -1,0 +1,46 @@
+# Copyright 2025 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    dns.gardener.cloud/dnsnames: prow.infra.tekton.dev
+    dns.gardener.cloud/ttl: "3600"
+  name: prow
+  namespace: default
+spec:
+  tls:
+  - secretName: prow-tekton-dev-tls
+    hosts:
+    - prow.infra.tekton.dev
+  rules:
+  - host: prow.infra.tekton.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: deck
+            port:
+              number: 80
+        path: /*
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: hook
+            port:
+              number: 8888
+        path: /hook
+        pathType: ImplementationSpecific

--- a/prow/oci/kustomization.yaml
+++ b/prow/oci/kustomization.yaml
@@ -2,18 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- rbac.yaml
-- prow.yaml
-- extra.yaml
-- ghproxy.yaml
-- prowjob-schemaless_customresourcedefinition.yaml
-- tune-sysctls_daemonset.yaml
-- oci
+- ingress.yaml
 
 configMapGenerator:
-  - name: plugins
+  - name: config
     files:
-    - plugins.yaml
+    - config.yaml
     options:
       disableNameSuffixHash: true
       labels:


### PR DESCRIPTION
# Changes

In Oracle cloud the prow domain in prow.infra.tekton.dev. We don't run CI jobs there, they must be migrated to GHA.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._