### PR TITLE
Small fixes to get the CI webhook running

### DIFF
--- a/tekton/cd/add-pr-body-ci/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/add-pr-body-ci/overlays/oci-ci-cd/kustomization.yaml
@@ -3,3 +3,11 @@ kind: Kustomization
 namespace: tekton-ci
 resources:
 - ../../base
+patches:
+  - target:
+      kind: Service
+      name: add-pr-body-interceptor
+    patch: |-
+      - op: replace
+        path: /spec/ports/0/targetPort
+        value: 8082

--- a/tekton/ci/bases/trigger.yaml
+++ b/tekton/ci/bases/trigger.yaml
@@ -43,12 +43,10 @@ spec:
           value:
           - key: add_pr_body.pull_request_url
             expression: "body.issue.pull_request.url"
-    - webhook:
-        objectRef:
-          kind: Service
-          name: add-pr-body
-          apiVersion: v1
-          namespace: tekton-ci
+    - name: "Add PR body"
+      ref:
+        name: "add-pr-body"
+        kind: ClusterInterceptor
     - name: "Add git clone depth"
       ref:
         name: cel

--- a/tekton/ci/cluster-interceptors/add-pr-body/config/interceptor-deployment.yaml
+++ b/tekton/ci/cluster-interceptors/add-pr-body/config/interceptor-deployment.yaml
@@ -46,4 +46,4 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 8082

--- a/tekton/ci/infra/ingress.yaml
+++ b/tekton/ci/infra/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     dns.gardener.cloud/dnsnames: 'webhook.ci.infra.tekton.dev'
     dns.gardener.cloud/ttl: "3600"
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 1M
   name: github-webhook
 spec:
   ingressClassName: nginx


### PR DESCRIPTION

# Changes

* The ingress annotation avoids nginx caching large GitHub payload on disk
* The add-pr-body cluster interceptor requires a different syntax to be used in the trigger
* The service target port for the add-pr-body CI is wrong Fixed it, and also patch it in kustomize until we get a new release with the right port

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._