### PR TITLE
Fix add-pr-body interceptor

### DIFF
--- a/tekton/ci/cluster-interceptors/add-pr-body/cmd/interceptor/main.go
+++ b/tekton/ci/cluster-interceptors/add-pr-body/cmd/interceptor/main.go
@@ -49,7 +49,7 @@ func main() {
 	s := server.Server{
 		Logger: logger,
 	}
-	s.RegisterInterceptor("addPrBody", pkg.Interceptor{
+	s.RegisterInterceptor("add-pr-body", pkg.Interceptor{
 		AuthToken: getGitHubAuth(authSecretEnvVar),
 	})
 	mux := http.NewServeMux()


### PR DESCRIPTION
# Changes

The interceptor was registered with path addPrBody which includes capital letters, which will never match:

```
ii, ok := is.interceptors[strings.TrimPrefix(strings.ToLower(r.URL.Path), "/")]
```

Use the path already configured in the CR instead.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._