### PR TITLE
Improve Dashboard namespace filtering

### DIFF
--- a/tekton/cd/dashboard/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/oci-ci-cd/kustomization.yaml
@@ -15,6 +15,13 @@ patches:
     - op: replace
       path: /spec/template/spec/containers/0/args/1
       value: --external-logs=https://logs.infra.tekton.dev/logs
+- target:
+    kind: Deployment
+    name: tekton-dashboard
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args/5
+      value: --namespaces=tekton-ci,tekton-nightly,bastion-p,bastion-z
 - patch: |-
     $patch: delete
     apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/cd/dashboard/overlays/oci-ci-cd/restricted-rbac.yaml
+++ b/tekton/cd/dashboard/overlays/oci-ci-cd/restricted-rbac.yaml
@@ -1,33 +1,5 @@
-# New minimal cluster-wide role - just for namespace listing
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: tekton-dashboard-namespace-reader
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
----
-# Cluster-wide binding for namespace listing only
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tekton-dashboard-namespace-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-dashboard-namespace-reader
-subjects:
-- kind: ServiceAccount
-  name: tekton-dashboard
-  namespace: tekton-pipelines
----
 # New role for the potentially sensitive stuff - pods, logs, events
+# It does not include namespaces
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
# Changes

The dashboard accepts a --namespace arg, which, when specified, removes the need for the service account to list namespaces.

Add a new patch to kustomization.yaml to specify the required list of namespaces and drop the role and binding for namespace listing.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._