### PR TITLE
fix: follow redirects to download manifest

### DIFF
--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -97,7 +97,7 @@ spec:
         REKOR_ATTESTATION_IMAGES=\$(rekor-cli get --uuid "\$REKOR_UUID" --format json | jq -r .Attestation | jq -r '.subject[]|.name + ":${VERSION}@sha256:" + .digest.sha256')
 
         # Download the release file
-        curl "\$RELEASE_FILE" > release.yaml
+        curl -L "\$RELEASE_FILE" > release.yaml
 
         # For each image in the attestation, match it to the release file
         for image in \$REKOR_ATTESTATION_IMAGES; do


### PR DESCRIPTION
# Changes

This pull request introduces an update to the `curl` command to use the `-L` flag, enabling automatic following of redirects when downloading the release file in `github_release.yaml`.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._