### PR TITLE
fix: patch pruner deployment to prevent OOMKilled

### DIFF
--- a/tekton/cd/pruner/overlays/oci-ci-cd/deployment-resources-patch.yaml
+++ b/tekton/cd/pruner/overlays/oci-ci-cd/deployment-resources-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pruner-controller
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+      - name: controller
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 250m
+            memory: 1Gi

--- a/tekton/cd/pruner/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pruner/overlays/oci-ci-cd/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - https://infra.tekton.dev/tekton-releases/pruner/previous/v0.3.3/release.yaml
 patches:
   - path: pruner-config.yaml
+  - path: deployment-resources-patch.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This pull request introduces resource limits and requests for the `tekton-pruner-controller` deployment in the OCI CI/CD overlay, helping to better manage CPU and memory usage. The changes are applied by adding a new patch to the kustomization configuration.

* Added a new patch file (`deployment-resources-patch.yaml`) specifying CPU and memory limits and requests for the `controller` container in the `tekton-pruner-controller` deployment.
* Updated `kustomization.yaml` to include the new `deployment-resources-patch.yaml` in the list of patches, ensuring the resource constraints are applied during deployment.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind misc
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._