### PR TITLE
feat: add reusable go-coverage workflow for standardization

### DIFF
--- a/.github/workflows/_go-coverage.yml
+++ b/.github/workflows/_go-coverage.yml
@@ -1,0 +1,90 @@
+# Reusable Go Coverage Workflow
+#
+# This workflow generates Go test coverage reports and posts them as PR comments.
+# It runs on pull requests, pushes to the main branch, scheduled intervals, and manual triggers.
+#
+# To use this in a repo:
+#
+# name: Go coverage
+# on:
+#   pull_request:
+#     branches: ["main"]
+#   push:
+#     branches: ["main"]
+#   schedule:
+#     - cron: '14 3 2 */2 *'
+#   workflow_dispatch:
+#
+# jobs:
+#   go-coverage:
+#     name: Go coverage
+#     uses: tektoncd/plumbing/.github/workflows/_go-coverage.yml@main
+#     secrets:
+#       CHATOPS_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
+
+name: Reusable Go Coverage
+
+on:
+  workflow_call:
+    inputs:
+      go-test-flags:
+        description: 'Go test flags for coverage generation'
+        required: false
+        type: string
+        default: '-cover -coverprofile=coverage.txt ./...'
+    secrets:
+      CHATOPS_TOKEN:
+        description: 'GitHub token for posting PR comments'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  go-coverage:
+    name: Go coverage
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c  # v6.1.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Generate coverage
+        run: |
+          go test ${{ inputs.go-test-flags }} || true
+          echo "Generated coverage profile"
+
+      - name: Archive coverage results
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: code-coverage
+          path: coverage.txt
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
+        continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
+        with:
+          token: ${{ secrets.CHATOPS_TOKEN }}
+          coverage-artifact-name: "code-coverage"
+          coverage-file-name: "coverage.txt"

--- a/.github/workflows/_slash.yml
+++ b/.github/workflows/_slash.yml
@@ -20,7 +20,7 @@
 # When a command is recognised, the rocket and eyes emojis are added
 #
 # To use this in a repo:
-# 
+#
 # name: Slash Command Routing
 # on:
 #   issue_comment:
@@ -28,7 +28,7 @@
 #
 # jobs:
 #   check_comments:
-#     uses: tektoncd/plumbing/.github/actions/_slash.yml@main
+#     uses: tektoncd/plumbing/.github/workflows/_slash.yml@main
 
 name: Slash Command Routing
 on:


### PR DESCRIPTION
# Changes

This PR creates a reusable `_go-coverage.yml` workflow in plumbing to standardize Go coverage reporting across all tektoncd repositories (addresses #3003).

**What's included:**
- New reusable workflow `.github/workflows/_go-coverage.yml` that generates Go test coverage reports and posts them as PR comments
- Uses standard Go modules checkout (no GOPATH structure required)
- Configurable `go-test-flags` input for custom test flags
- Requires `CHATOPS_TOKEN` secret for posting PR comments
- Includes security hardening, concurrency control, and comprehensive usage documentation
- Fix: Corrected typo in `_slash.yml` documentation (`.github/actions/_slash.yml` → `.github/workflows/_slash.yml`)

**Benefits:**
- Single source of truth for go-coverage implementation across all tektoncd repos
- Easier to maintain and update (change once in plumbing, propagates everywhere)
- Consistent coverage reporting across all tektoncd repositories
- Reduces code duplication

**Next steps after merge:**
- Migrate 7 existing repos to use this reusable workflow (operator, pruner, pipeline, results, chains, triggers, catlin)
- Add workflow to 4 repos that don't have coverage yet (cli, plumbing, hub, mcp-server)

/kind feature

# Submitter Checklist

- [x] Includes docs (comprehensive inline documentation in workflow file)
- [x] Commit messages follow commit message best practices

Closes #3003