### PR TITLE
Prevent sourcing of tekton_in_kind.sh Issue: 3038

### DIFF
--- a/hack/tekton_in_kind.sh
+++ b/hack/tekton_in_kind.sh
@@ -16,6 +16,13 @@ declare TEKTON_PIPELINE_VERSION TEKTON_TRIGGERS_VERSION TEKTON_DASHBOARD_VERSION
 # - If a kind cluster named "tekton" already exists this will fail
 # - Local access to the dashboard requires port 9097 to be locally available
 
+# if script is ran with source, i.e. `. tekton_in_kind.sh` - a warning is displayed 
+# and suggested to run it in it's own shell process. 
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+  echo "This script is not intended to be sourced. Please run it as ./tekton_in_kind.sh"
+  return 1
+fi
+
 get_latest_release() {
   curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
     grep '"tag_name":' |                                            # Get tag line


### PR DESCRIPTION
The tekton_in_kind.sh script can currently be sourced without error, which may lead to unexpected behavior such as early returns, partially executed logic, or confusing failures for users who expect it to run as a standalone entrypoint.

Adding an explicit guard to detect sourcing and fail fast provides clearer feedback and avoids subtle misuse. Alternatives such as documenting correct usage or relying on downstream failures were considered, but enforcing correct invocation in the script itself is more robust and user-friendly. This change has no impact on valid usage and leaves room for future refactoring if sourcing support is ever intentionally added. Addressing issue https://github.com/tektoncd/plumbing/issues/3038

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR prevents tekton_in_kind.sh from being sourced by mistake by
explicitly detecting when the script is sourced and failing fast with a
clear error message.

Sourcing this script can lead to confusing behavior (such as unexpected
return statements or partially executed logic), since it is designed
to be run as a standalone executable. By enforcing correct invocation,
the script becomes safer and more user-friendly, addressing the problem
described in https://github.com/tektoncd/plumbing/issues/3038


/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._