### PR TITLE
Add Community Roadmap sync workflow

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -1,0 +1,143 @@
+# .github/workflows/sync-project-status.yml
+#
+# Syncs issues with 'area/roadmap' label from ALL tektoncd repos
+# to the Community Roadmap project (#34).
+#
+# Runs every 6 hours to keep the community roadmap up to date.
+# Status is managed by the project's built-in workflows.
+
+name: Sync Community Roadmap
+
+on:
+  schedule:
+    # Run every 6 hours
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run - log actions without making changes'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  # Community Roadmap v2 (#34)
+  COMMUNITY_PROJECT_ID: "PVT_kwDOAtZbZc4BNrgF"
+
+jobs:
+  sync-community-roadmap:
+    name: Sync Community Roadmap
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.PROJECT_SYNC_APP_ID }}
+          private-key: ${{ secrets.PROJECT_SYNC_PRIVATE_KEY }}
+          owner: tektoncd
+
+      - name: Search for roadmap issues across all repos
+        id: search_issues
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          echo "::group::Searching for roadmap issues"
+          echo "Searching for issues with 'area/roadmap' label in tektoncd org..."
+
+          # Search for all open issues with area/roadmap label
+          gh api -X GET /search/issues \
+            -f q='org:tektoncd label:area/roadmap is:open' \
+            -f per_page=100 \
+            --paginate \
+            --jq '.items' | jq -s 'add // []' > /tmp/roadmap_issues.json
+
+          ISSUE_COUNT=$(jq 'length' /tmp/roadmap_issues.json)
+          echo "Found $ISSUE_COUNT open issues with area/roadmap label"
+          echo "issue_count=$ISSUE_COUNT" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+
+          # Show breakdown by repo
+          echo "::group::Issues by repository"
+          jq -r '.[].repository_url' /tmp/roadmap_issues.json | \
+            sed 's|https://api.github.com/repos/||' | \
+            sort | uniq -c | sort -rn
+          echo "::endgroup::"
+
+      - name: Sync issues to Community Roadmap
+        id: sync_issues
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          echo "::group::Sync configuration"
+          echo "Roadmap issues found: ${{ steps.search_issues.outputs.issue_count }}"
+          echo "Dry run: $DRY_RUN"
+          echo "::endgroup::"
+
+          SYNCED=0
+          ERRORS=0
+
+          echo "::group::Syncing issues to Community Roadmap"
+          # Process each roadmap issue
+          while IFS= read -r issue; do
+            ISSUE_NUMBER=$(echo "$issue" | jq -r '.number')
+            ISSUE_NODE_ID=$(echo "$issue" | jq -r '.node_id')
+            REPO_NAME=$(echo "$issue" | jq -r '.repository_url' | sed 's|https://api.github.com/repos/tektoncd/||')
+            ISSUE_TITLE=$(echo "$issue" | jq -r '.title' | head -c 50)
+
+            echo "SYNC: $REPO_NAME#$ISSUE_NUMBER - ${ISSUE_TITLE}..."
+
+            if [ "$DRY_RUN" != "true" ]; then
+              # Add to community project (idempotent - returns existing item if already present)
+              RESULT=$(gh api graphql -f query='
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {
+                    projectId: $projectId
+                    contentId: $contentId
+                  }) {
+                    item { id }
+                  }
+                }' -f projectId="${{ env.COMMUNITY_PROJECT_ID }}" -f contentId="$ISSUE_NODE_ID" 2>&1)
+
+              if echo "$RESULT" | jq -e '.errors' > /dev/null 2>&1; then
+                echo "::error::$REPO_NAME#$ISSUE_NUMBER: $(echo "$RESULT" | jq -r '.errors[0].message')"
+                ((ERRORS++))
+              else
+                ((SYNCED++))
+              fi
+
+              # Small delay to avoid rate limiting
+              sleep 0.3
+            else
+              ((SYNCED++))
+            fi
+          done < <(jq -c '.[]' /tmp/roadmap_issues.json)
+          echo "::endgroup::"
+
+          echo "::group::Results"
+          echo "Synced: $SYNCED"
+          echo "Errors: $ERRORS"
+          echo "::endgroup::"
+
+          # Set outputs for summary
+          echo "synced=$SYNCED" >> $GITHUB_OUTPUT
+          echo "errors=$ERRORS" >> $GITHUB_OUTPUT
+
+      - name: Job summary
+        run: |
+          echo "## Community Roadmap Sync" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Issues found | ${{ steps.search_issues.outputs.issue_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Synced | ${{ steps.sync_issues.outputs.synced || '0' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Errors | ${{ steps.sync_issues.outputs.errors || '0' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View Community Roadmap](https://github.com/orgs/tektoncd/projects/34)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Community Roadmap sync failed. Check the logs for details."

--- a/docs/community-roadmap-sync.md
+++ b/docs/community-roadmap-sync.md
@@ -1,0 +1,221 @@
+# Community Roadmap Sync
+
+This document describes the automated workflow that syncs issues from all Tekton
+repositories to the [Community Roadmap project](https://github.com/orgs/tektoncd/projects/34).
+
+## Overview
+
+The Community Roadmap provides a unified view of roadmap items across all Tekton
+repositories. Instead of checking individual repo projects, maintainers and
+contributors can see the full picture in one place.
+
+**Project URL:** https://github.com/orgs/tektoncd/projects/34
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Every 6 hours (or manual trigger)                                  │
+│                                                                     │
+│  1. Search: org:tektoncd label:area/roadmap is:open                 │
+│     └─► Finds all issues with 'area/roadmap' label                  │
+│                                                                     │
+│  2. For each issue: add to Community Roadmap                        │
+│     └─► Idempotent: safe to run repeatedly                          │
+│                                                                     │
+│  3. Built-in project workflows handle status changes                │
+│     └─► Issue closed → Done, PR merged → Done, etc.                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Adding Items to the Community Roadmap
+
+To get an issue on the Community Roadmap:
+
+1. Add the `area/roadmap` label to any issue in a tektoncd repository
+2. Wait up to 6 hours for the next sync (or ask a maintainer to trigger manually)
+
+That's it! The workflow will automatically pick it up.
+
+## Status Management
+
+Status is managed by the project's **built-in workflows**, not by this sync workflow.
+
+When you enable these workflows on the project (Settings → Workflows):
+- **Item closed** → Status set to "Done"
+- **Item reopened** → Status set to "In Progress"
+- **PR merged** → Status set to "Done"
+
+Manual status changes can be made directly in the project board.
+
+### Status Options
+
+| Status | Description |
+|--------|-------------|
+| Todo | Planned work, not yet started |
+| In Progress | Actively being worked on |
+| Review | Implementation complete, awaiting review |
+| Done | Completed and closed |
+| Hold | Paused or blocked |
+
+## Workflow Details
+
+**File:** `.github/workflows/sync-project-status.yml`
+
+### Schedule
+
+- Runs automatically every 6 hours (00:00, 06:00, 12:00, 18:00 UTC)
+- Can be triggered manually via GitHub Actions UI
+
+### Manual Trigger
+
+To trigger the workflow manually:
+
+```bash
+# Dry run (no changes, just logs what would happen)
+gh workflow run sync-project-status.yml -f dry_run=true
+
+# Actual sync
+gh workflow run sync-project-status.yml -f dry_run=false
+```
+
+Or use the GitHub UI:
+1. Go to Actions → "Sync Community Roadmap"
+2. Click "Run workflow"
+3. Optionally enable "Dry run" for testing
+
+### Required Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `PROJECT_SYNC_APP_ID` | GitHub App ID |
+| `PROJECT_SYNC_PRIVATE_KEY` | GitHub App private key |
+
+#### GitHub App Setup
+
+1. Create a GitHub App at `https://github.com/organizations/tektoncd/settings/apps/new`
+2. Configure permissions:
+   - **Repository permissions:**
+     - `Discussions: Read` - To add discussions to projects
+     - `Issues: Read` - To search issues across repositories
+     - `Pull requests: Read` - To add PRs to projects
+     - `Metadata: Read` - Required for API access
+   - **Organization permissions:**
+     - `Projects: Read and write` - To add items to organization projects
+3. Install the App on the tektoncd organization
+4. Generate a private key and store it as a secret:
+
+```bash
+gh secret set PROJECT_SYNC_APP_ID --repo tektoncd/plumbing
+gh secret set PROJECT_SYNC_PRIVATE_KEY --repo tektoncd/plumbing < private-key.pem
+```
+
+## Repositories Included
+
+The workflow searches ALL repositories in the `tektoncd` organization. Any repo
+can participate by using the `area/roadmap` label.
+
+Currently contributing repositories include:
+- pipeline
+- triggers
+- cli
+- dashboard
+- operator
+- results
+- chains
+- catalog
+- plumbing
+- community
+- actions
+
+## Troubleshooting
+
+### Issue not appearing in Community Roadmap
+
+1. Verify the issue has the `area/roadmap` label
+2. Verify the issue is **open** (closed issues are not synced)
+3. Check the workflow run logs in GitHub Actions
+4. Trigger a manual sync with `dry_run=false`
+
+### Workflow failing
+
+Check the workflow logs for:
+- Authentication errors → Verify `PROJECT_SYNC_APP_ID` and `PROJECT_SYNC_PRIVATE_KEY` are set correctly
+- Rate limiting → The workflow includes rate limiting, but heavy usage may hit limits
+- API errors → Check GitHub status page
+
+## Appendix: Creating the GitHub App
+
+Step-by-step instructions for creating the GitHub App used by this workflow.
+
+### Step 1: Create the App
+
+1. Go to https://github.com/organizations/tektoncd/settings/apps/new
+2. Fill in the basic information:
+   - **GitHub App name:** `Tekton Community Roadmap Sync`
+   - **Homepage URL:** `https://github.com/tektoncd/plumbing`
+3. Under **Webhook**:
+   - Uncheck "Active" (webhooks are not needed)
+
+### Step 2: Configure Permissions
+
+Set the following permissions:
+
+**Repository permissions:**
+
+| Permission | Access |
+|------------|--------|
+| Discussions | Read-only |
+| Issues | Read-only |
+| Pull requests | Read-only |
+| Metadata | Read-only |
+
+**Organization permissions:**
+
+| Permission | Access |
+|------------|--------|
+| Projects | Read and write |
+
+### Step 3: Set Installation Access
+
+- Select "Only on this account"
+- Click "Create GitHub App"
+
+### Step 4: Install the App
+
+After the App is created:
+
+1. In the App settings, click "Install App" in the left sidebar
+2. Click "Install" next to the `tektoncd` organization
+3. Select "All repositories" (required to search issues across all repos)
+4. Click "Install"
+
+### Step 5: Generate a Private Key
+
+1. Go back to the App's settings page
+2. Scroll down to "Private keys"
+3. Click "Generate a private key"
+4. Save the downloaded `.pem` file securely
+
+### Step 6: Store Secrets in the Repository
+
+Note the **App ID** from the App's settings page (shown near the top).
+
+```bash
+# Store the App ID
+gh secret set PROJECT_SYNC_APP_ID --repo tektoncd/plumbing
+# Enter the App ID when prompted
+
+# Store the private key
+gh secret set PROJECT_SYNC_PRIVATE_KEY --repo tektoncd/plumbing < /path/to/downloaded-private-key.pem
+```
+
+### Step 7: Verify Setup
+
+Trigger a dry run to verify everything is configured correctly:
+
+```bash
+gh workflow run sync-project-status.yml -f dry_run=true --repo tektoncd/plumbing
+```
+
+Check the workflow run in GitHub Actions to ensure it completes successfully.


### PR DESCRIPTION
# Changes

Adds a GitHub Actions workflow that syncs issues with the `area/roadmap` label from all tektoncd repositories to the [Community Roadmap project (#34)](https://github.com/orgs/tektoncd/projects/34).

The workflow:
- Runs every 6 hours (or manual trigger with optional dry-run)
- Searches `org:tektoncd label:area/roadmap is:open` for roadmap issues
- Adds each issue to Community Roadmap (idempotent API call)
- Uses GitHub App authentication (no token expiration)
- Relies on project's built-in workflows for status management

Includes documentation explaining how it works, how to use it, and step-by-step GitHub App setup instructions.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._