### PR TITLE
Skip missing clustertask e2e suite for Tekton CLI

### DIFF
--- a/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/test_tekton_cli.yaml
@@ -48,6 +48,11 @@ spec:
       source $(workspaces.source-code.path)/$(params.plumbing-path)/scripts/library.sh
       go build -o tkn $(params.package)/cmd/tkn
       for testsuite in clustertask eventlistener pipeline pipelinerun plugin task; do
-        header "Running Go $(params.tags) ${testsuite} tests"
-        report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite}
+        if [[ -d "$(params.tests-path)/${testsuite}" ]]; then
+          header "Running Go $(params.tags) ${testsuite} tests"
+          report_go_test -v -count=1 -tags=$(params.tags) -timeout=$(params.timeout) $(params.tests-path)/${testsuite}
+        else
+          echo "Skipping Go $(params.tags) ${testsuite} tests: $(params.tests-path)/${testsuite} does not exist"
+        fi
       done
+


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

CI for the Tekton CLI currently attempts to run the `clustertask` Go e2e test suite unconditionally, but `test/e2e/clustertask` directory no longer exists in the tektoncd/cli repository, which causes CI failures with: `stat ./test/e2e/clustertask: directory not found`

This issue is reproducible in current CI and resolved by guarding the test invocation.

This change updates the `test-e2e-tekton-cli` Task to skip e2e test suites whose directories are absent, aligning plumbing CI with the current Tekton CLI repo layout. No behavior is changed for existing e2e test suites.


/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._