### PR TITLE
fix(interceptors/github): use constant format string in Errorf calls

### DIFF
--- a/tekton/ci/interceptors/github/pkg/github/issue_comment.go
+++ b/tekton/ci/interceptors/github/pkg/github/issue_comment.go
@@ -22,7 +22,7 @@ type IssueComment struct{}
 func (c *IssueComment) Execute(ctx context.Context, client *github.Client, cfg *pb.Config, req *v1alpha1.InterceptorRequest) (*v1alpha1.InterceptorResponse, error) {
 	event := new(github.IssueCommentEvent)
 	if err := json.Unmarshal([]byte(req.Body), event); err != nil {
-		return nil, Errorf(codes.InvalidArgument, err.Error())
+		return nil, Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if event.GetAction() != "created" {

--- a/tekton/ci/interceptors/github/pkg/github/pull_request.go
+++ b/tekton/ci/interceptors/github/pkg/github/pull_request.go
@@ -26,7 +26,7 @@ type PullRequest struct{}
 func (c *PullRequest) Execute(ctx context.Context, client *github.Client, cfg *pb.Config, req *v1alpha1.InterceptorRequest) (*v1alpha1.InterceptorResponse, error) {
 	event := new(github.PullRequestEvent)
 	if err := json.Unmarshal([]byte(req.Body), event); err != nil {
-		return nil, Errorf(codes.InvalidArgument, err.Error())
+		return nil, Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if cfg.GetPullRequest() == nil {

--- a/tekton/ci/interceptors/github/pkg/github/push.go
+++ b/tekton/ci/interceptors/github/pkg/github/push.go
@@ -21,7 +21,7 @@ type Push struct{}
 func (c *Push) Execute(ctx context.Context, client *github.Client, cfg *pb.Config, req *v1alpha1.InterceptorRequest) (*v1alpha1.InterceptorResponse, error) {
 	event := new(github.PushEvent)
 	if err := json.Unmarshal([]byte(req.Body), event); err != nil {
-		return nil, Errorf(codes.InvalidArgument, err.Error())
+		return nil, Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	if cfg.GetPush() == nil {


### PR DESCRIPTION
# Changes

Fix Go 1.24 vet errors by using constant format strings in Errorf calls.

Go 1.24's stricter vet checks flag non-constant format strings as potential
security issues. This changes `Errorf(codes.InvalidArgument, err.Error())`
to `Errorf(codes.InvalidArgument, "%s", err.Error())` in three files.

This unblocks several dependabot PRs (#3036, #2961, etc.) that were failing
CI due to this issue.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._