### PR TITLE
Pin actions/create-github-app-token to full SHA

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.PROJECT_SYNC_APP_ID }}
           private-key: ${{ secrets.PROJECT_SYNC_PRIVATE_KEY }}


### PR DESCRIPTION
# Changes

Pin `actions/create-github-app-token` to full commit SHA to comply with tektoncd's organization security policy for GitHub Actions.

The workflow `sync-project-status.yml` was failing at startup because the action was referenced by tag (`@v2`) instead of a full commit SHA. This violates the organization's policy which restricts actions to those "owned by tektoncd, created by GitHub, verified in the GitHub Marketplace, or matching specific approved patterns" and requires pinning to full-length commit SHAs.

Fixes: https://github.com/tektoncd/plumbing/actions/runs/21620091400

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._