### PR TITLE
Fix broken pipe error in sync-project-status workflow

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -85,7 +85,7 @@ jobs:
             ISSUE_NUMBER=$(echo "$issue" | jq -r '.number')
             ISSUE_NODE_ID=$(echo "$issue" | jq -r '.node_id')
             REPO_NAME=$(echo "$issue" | jq -r '.repository_url' | sed 's|https://api.github.com/repos/tektoncd/||')
-            ISSUE_TITLE=$(echo "$issue" | jq -r '.title' | head -c 50)
+            ISSUE_TITLE=$(echo "$issue" | jq -r '.title[0:50]')
 
             echo "SYNC: $REPO_NAME#$ISSUE_NUMBER - ${ISSUE_TITLE}..."
 


### PR DESCRIPTION
# Changes

Fix broken pipe error in `sync-project-status.yml` workflow.

The script was failing with `jq: error: writing output failed: Broken pipe` because:
```bash
ISSUE_TITLE=$(echo "$issue" | jq -r '.title' | head -c 50)
```

When `head -c 50` reads enough bytes, it closes its input, causing jq to fail when writing to the closed pipe. With bash's `-e` flag (default in GitHub Actions), this exits the script with error code 1.

**Fix:** Use jq's built-in string slicing (`.title[0:50]`) instead of piping to `head`.

Fixes: https://github.com/tektoncd/plumbing/actions/runs/21624192113

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._