### PR TITLE
fix: add missing kustomization files for terraform branch protection

### DIFF
--- a/tekton/cronjobs/dogfooding/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/kustomization.yaml
@@ -4,5 +4,6 @@ commonAnnotations:
 resources:
 - configmaps
 - images
+- terraform-branch-protection
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tekton/cronjobs/dogfooding/terraform-branch-protection/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/terraform-branch-protection/kustomization.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tektoncd

--- a/tekton/resources/branch-protection/kustomization.yaml
+++ b/tekton/resources/branch-protection/kustomization.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- terraform.yaml
+- terraform-sync.yaml

--- a/tekton/resources/kustomization.yaml
+++ b/tekton/resources/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
 - ci
 - nightly-release
 - nightly-tests
+- branch-protection
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
# Changes

The terraform branch protection resources from PR #3062 were not being deployed because they were not wired into the kustomization hierarchy.

This adds:
- `kustomization.yaml` for `tekton/resources/branch-protection/`
- `kustomization.yaml` for `tekton/cronjobs/dogfooding/terraform-branch-protection/`
- References to these in parent kustomization files

Without this fix, the Task, Pipeline, and CronJob would not be deployed even though the TriggerTemplate was correctly included.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._