### PR TITLE
Fix bash arithmetic exit status in sync-project-status workflow

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -103,15 +103,15 @@ jobs:
 
               if echo "$RESULT" | jq -e '.errors' > /dev/null 2>&1; then
                 echo "::error::$REPO_NAME#$ISSUE_NUMBER: $(echo "$RESULT" | jq -r '.errors[0].message')"
-                ((ERRORS++))
+                ((++ERRORS))
               else
-                ((SYNCED++))
+                ((++SYNCED))
               fi
 
               # Small delay to avoid rate limiting
               sleep 0.3
             else
-              ((SYNCED++))
+              ((++SYNCED))
             fi
           done < <(jq -c '.[]' /tmp/roadmap_issues.json)
           echo "::endgroup::"


### PR DESCRIPTION
# Changes

Fix bash arithmetic causing script failure in `sync-project-status.yml`.

**The Bug:**
```bash
SYNCED=0
((SYNCED++))  # Returns 0 (old value) → exit status 1 → script exits with set -e
```

With postfix increment `((VAR++))`, when VAR=0, it returns the **old value** (0). In bash, `((0))` means exit status 1 (failure). With `set -e` (GitHub Actions default), this exits the script.

The jq "broken pipe" error in the logs was a symptom - the real cause was the while loop exiting unexpectedly, leaving the jq process feeding it with a broken pipe.

**The Fix:**
Use prefix increment `((++VAR))` which returns the **new value** (≥1), so exit status is always 0.

Fixes: https://github.com/tektoncd/plumbing/actions/runs/21625516269

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._