### PR TITLE
Add import blocks for release-v* branch protections

### DIFF
--- a/terraform/branch-protection/imports.tf
+++ b/terraform/branch-protection/imports.tf
@@ -72,3 +72,63 @@ import {
   to = github_branch_protection.main["plumbing"]
   id = "plumbing:main"
 }
+
+# Import existing release branch protections (release-v*)
+# These were created in the first terraform-branch-protection pipeline run.
+#
+# After successful import, these blocks can be removed.
+
+import {
+  to = github_branch_protection.releases["dashboard"]
+  id = "dashboard:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["pipeline"]
+  id = "pipeline:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["operator"]
+  id = "operator:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["mcp-server"]
+  id = "mcp-server:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["triggers"]
+  id = "triggers:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["cli"]
+  id = "cli:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["pruner"]
+  id = "pruner:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["chains"]
+  id = "chains:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["hub"]
+  id = "hub:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["results"]
+  id = "results:release-v*"
+}
+
+import {
+  to = github_branch_protection.releases["plumbing"]
+  id = "plumbing:release-v*"
+}


### PR DESCRIPTION
# Changes

Add import blocks for release-v* branch protections that were created in the
first terraform-branch-protection pipeline run.

The previous PR (#3091) added import blocks for `main` branch protections,
but the `release-v*` protections were created during the first pipeline run
and now also need imports.

This fixes the "Name already protected: release-v*" errors.

**Imports added for all 11 repos:**
- dashboard, pipeline, operator, mcp-server, triggers
- cli, pruner, chains, hub, results, plumbing

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._