### PR TITLE
Refactor terraform imports to use for_each

### DIFF
--- a/terraform/branch-protection/imports.tf
+++ b/terraform/branch-protection/imports.tf
@@ -12,123 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Import existing main branch protections into Terraform state
+# Import existing branch protections into Terraform state
 # These protections already exist on GitHub and need to be imported
 # so Terraform can manage them going forward.
 #
+# Uses for_each to dynamically import based on tektoncd_repos list.
 # After successful import, these blocks can be removed.
 
 import {
-  to = github_branch_protection.main["dashboard"]
-  id = "dashboard:main"
+  for_each = toset(local.tektoncd_repos)
+  to       = github_branch_protection.main[each.key]
+  id       = "${each.key}:main"
 }
 
 import {
-  to = github_branch_protection.main["pipeline"]
-  id = "pipeline:main"
-}
-
-import {
-  to = github_branch_protection.main["operator"]
-  id = "operator:main"
-}
-
-import {
-  to = github_branch_protection.main["mcp-server"]
-  id = "mcp-server:main"
-}
-
-import {
-  to = github_branch_protection.main["triggers"]
-  id = "triggers:main"
-}
-
-import {
-  to = github_branch_protection.main["cli"]
-  id = "cli:main"
-}
-
-import {
-  to = github_branch_protection.main["pruner"]
-  id = "pruner:main"
-}
-
-import {
-  to = github_branch_protection.main["chains"]
-  id = "chains:main"
-}
-
-import {
-  to = github_branch_protection.main["hub"]
-  id = "hub:main"
-}
-
-import {
-  to = github_branch_protection.main["results"]
-  id = "results:main"
-}
-
-import {
-  to = github_branch_protection.main["plumbing"]
-  id = "plumbing:main"
-}
-
-# Import existing release branch protections (release-v*)
-# These were created in the first terraform-branch-protection pipeline run.
-#
-# After successful import, these blocks can be removed.
-
-import {
-  to = github_branch_protection.releases["dashboard"]
-  id = "dashboard:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["pipeline"]
-  id = "pipeline:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["operator"]
-  id = "operator:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["mcp-server"]
-  id = "mcp-server:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["triggers"]
-  id = "triggers:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["cli"]
-  id = "cli:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["pruner"]
-  id = "pruner:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["chains"]
-  id = "chains:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["hub"]
-  id = "hub:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["results"]
-  id = "results:release-v*"
-}
-
-import {
-  to = github_branch_protection.releases["plumbing"]
-  id = "plumbing:release-v*"
+  for_each = toset(local.tektoncd_repos)
+  to       = github_branch_protection.releases[each.key]
+  id       = "${each.key}:release-v*"
 }


### PR DESCRIPTION
# Changes

Refactor terraform import blocks to use dynamic `for_each` loops based on
the `tektoncd_repos` list in `locals.tf`.

**Before:** 11 individual import blocks for main branches only (~75 lines)
**After:** 2 dynamic import blocks for main + release-v* branches (~20 lines)

**Benefits:**
- Automatically stays in sync with `tektoncd_repos` list
- Adds missing `release-v*` branch protection imports
- Makes it easier to add new repos in the future
- Cleaner, more maintainable code

Requires Terraform >= 1.5 (already specified in `versions.tf`).

This supersedes PR #3092 which added manual import blocks for release-v*.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._