### PR TITLE
feat(branch-protection): add e2e tests to pipeline required checks

### DIFF
--- a/terraform/branch-protection/locals.tf
+++ b/terraform/branch-protection/locals.tf
@@ -50,6 +50,7 @@ locals {
       "lint",
       "Check generated code",
       "Multi-arch build",
+      "e2e tests",
     ]
     operator = [
       "build",


### PR DESCRIPTION
## Changes

Add the `e2e tests` status check to the required checks for the
tektoncd/pipeline repository branch protection.

This check comes from the `e2e-summary` job in pipeline's
`.github/workflows/ci.yaml` which aggregates all e2e test results
before allowing merge.

## Why

The e2e tests are critical for validating pipeline changes work
correctly in a real Kubernetes environment. Making this check
required ensures PRs cannot be merged if e2e tests are failing.

## Verification

- Confirmed the check name `e2e tests` by examining the
  [ci.yaml workflow](https://github.com/tektoncd/pipeline/blob/main/.github/workflows/ci.yaml#L148)
  in tektoncd/pipeline