### PR TITLE
Skip sync-community-roadmap workflow in forks

### DIFF
--- a/.github/workflows/sync-project-status.yml
+++ b/.github/workflows/sync-project-status.yml
@@ -27,6 +27,8 @@ env:
 jobs:
   sync-community-roadmap:
     name: Sync Community Roadmap
+    # Only run in the upstream repo, not in forks (secrets won't be available)
+    if: github.repository == 'tektoncd/plumbing'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Changes

The sync-project-status workflow requires secrets (`PROJECT_SYNC_APP_ID`
and `PROJECT_SYNC_PRIVATE_KEY`) that are only available in the upstream
tektoncd/plumbing repository. When this workflow runs in forks, it fails
with "appId option is required" because the secrets don't exist.

This PR adds an `if` condition to skip the job when running in forks,
preventing unnecessary failures for anyone who forks the repository.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._