### PR TITLE
fix(github-interceptor): use Error instead of Errorf for non-format strings

### DIFF
--- a/tekton/ci/interceptors/github/pkg/github/issue_comment.go
+++ b/tekton/ci/interceptors/github/pkg/github/issue_comment.go
@@ -22,7 +22,7 @@ type IssueComment struct{}
 func (c *IssueComment) Execute(ctx context.Context, client *github.Client, cfg *pb.Config, req *v1alpha1.InterceptorRequest) (*v1alpha1.InterceptorResponse, error) {
 	event := new(github.IssueCommentEvent)
 	if err := json.Unmarshal([]byte(req.Body), event); err != nil {
-		return nil, Errorf(codes.InvalidArgument, err.Error())
+		return nil, Error(codes.InvalidArgument, err.Error())
 	}
 
 	if event.GetAction() != "created" {

--- a/tekton/ci/interceptors/github/pkg/github/pull_request.go
+++ b/tekton/ci/interceptors/github/pkg/github/pull_request.go
@@ -26,7 +26,7 @@ type PullRequest struct{}
 func (c *PullRequest) Execute(ctx context.Context, client *github.Client, cfg *pb.Config, req *v1alpha1.InterceptorRequest) (*v1alpha1.InterceptorResponse, error) {
 	event := new(github.PullRequestEvent)
 	if err := json.Unmarshal([]byte(req.Body), event); err != nil {
-		return nil, Errorf(codes.InvalidArgument, err.Error())
+		return nil, Error(codes.InvalidArgument, err.Error())
 	}
 
 	if cfg.GetPullRequest() == nil {

--- a/tekton/ci/interceptors/github/pkg/github/push.go
+++ b/tekton/ci/interceptors/github/pkg/github/push.go
@@ -21,7 +21,7 @@ type Push struct{}
 func (c *Push) Execute(ctx context.Context, client *github.Client, cfg *pb.Config, req *v1alpha1.InterceptorRequest) (*v1alpha1.InterceptorResponse, error) {
 	event := new(github.PushEvent)
 	if err := json.Unmarshal([]byte(req.Body), event); err != nil {
-		return nil, Errorf(codes.InvalidArgument, err.Error())
+		return nil, Error(codes.InvalidArgument, err.Error())
 	}
 
 	if cfg.GetPush() == nil {


### PR DESCRIPTION
# Changes

Go 1.24's stricter vet checks flag non-constant format strings passed to printf-like functions. The code was incorrectly using `Errorf` with `err.Error()` as the format string, which could cause issues if the error message contained `%` characters.

This change uses `Error()` instead of `Errorf()` when no format arguments are needed, fixing the lint errors that were blocking dependabot PRs (#2939, #2961, #3036).

Files changed:
- `tekton/ci/interceptors/github/pkg/github/issue_comment.go`
- `tekton/ci/interceptors/github/pkg/github/pull_request.go`
- `tekton/ci/interceptors/github/pkg/github/push.go`

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._