### PR TITLE
Update Go versions in ko-gcloud and pipelinerun-logs Dockerfiles to 1.25.0

### DIFF
--- a/pipelinerun-logs/Dockerfile
+++ b/pipelinerun-logs/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine3.16
+FROM golang:1.25.0-alpine
 WORKDIR /go/src/pipelinerun-logs
 COPY . .
 RUN go build -o ./pipelinerun-logs ./cmd/http

--- a/tekton/images/ko-gcloud/Dockerfile
+++ b/tekton/images/ko-gcloud/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.24.1
+ARG GO_VERSION=1.25.0
 FROM ghcr.io/ko-build/ko:v0.18.1@sha256:1ef724b37bccd9dcb153c8a8205ada3149644fd5b37398e808c85d5b84de7ca1 AS ko
 FROM golang:1.25.7-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS build
 LABEL description="Build container"


### PR DESCRIPTION
# Changes

Update Go versions in two Dockerfiles to 1.25.0:

- **ko-gcloud**: `ARG GO_VERSION` from 1.24.1 → 1.25.0 (used to install Go in the final cloud-sdk stage)
- **pipelinerun-logs**: base image from `golang:1.20.4-alpine3.16` → `golang:1.25.0-alpine` (was very stale at 1.20.4)

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._