### PR TITLE
Short image URLs are not allowed anymore

### DIFF
--- a/prow/control-plane/tune-sysctls_daemonset.yaml
+++ b/prow/control-plane/tune-sysctls_daemonset.yaml
@@ -33,7 +33,7 @@ spec:
                 sysctl -w fs.inotify.max_user_instances=512
                 sleep 10
               done
-          image: alpine:3.6
+          image: docker.io/library/alpine:3.6
           imagePullPolicy: IfNotPresent
           resources: {}
           securityContext:

--- a/tekton/ci/interceptors/github/examples/trigger.yaml
+++ b/tekton/ci/interceptors/github/examples/trigger.yaml
@@ -50,7 +50,7 @@ spec:
                 taskSpec:
                   steps:
                     - name: build-sources
-                      image: ubuntu
+                      image: docker.io/library/ubuntu
                       command:
                         - /bin/bash
                       args: ['-c', 'echo $(tt.params.owner) $(tt.params.repo) $(tt.params.clone_url) $(tt.params.pr) $(tt.params.sha) !!']

--- a/tekton/ci/jobs/e2e-kind.yaml
+++ b/tekton/ci/jobs/e2e-kind.yaml
@@ -37,7 +37,7 @@ spec:
     - name: source
   steps:
     - name: make-artifacts-folder
-      image: alpine:3.15.3
+      image: docker.io/library/alpine:3.15.3
       env:
         - name: ARTIFACTS_FOLDER
           value: "$(workspaces.source.path)/artifacts"
@@ -60,7 +60,7 @@ spec:
           name: cgroup
       args: ["$(params.arguments[*])"]
   sidecars:
-    - image: docker:20.10.11-dind
+    - image: docker.io/library/docker:20.10.11-dind
       name: dind-sidecar
       securityContext:
         privileged: true

--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -21,7 +21,7 @@ spec:
       default: git
   steps:
     - name: find-changed-tasks
-      image: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
+      image: docker.io/library/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
       workingDir: $(workspaces.source.path)
       env:
       - name: GIT_CLONE_DEPTH

--- a/tekton/ci/jobs/tekton-github-tasks-completed.yaml
+++ b/tekton/ci/jobs/tekton-github-tasks-completed.yaml
@@ -17,11 +17,11 @@ spec:
         value: $(params.body)
   steps:
     - name: install-pyyaml
-      image: python:3-alpine
+      image: docker.io/library/python:3-alpine
       script: |
         pip install pyyaml --user
     - name: check-github-tasks-completed
-      image: python:3-alpine
+      image: docker.io/library/python:3-alpine
       script: |
         #!/usr/bin/env python
         import sys

--- a/tekton/ci/jobs/tekton-golang-coverage.yaml
+++ b/tekton/ci/jobs/tekton-golang-coverage.yaml
@@ -150,7 +150,7 @@ spec:
             description: Name of the repo.
         steps:
           - name: split-name
-            image: ubuntu
+            image: docker.io/library/ubuntu
             script: |
               printf '$(params.package)' | awk -F/ '{printf($1)}' | tee /tekton/results/repoOwner
               printf '$(params.package)' | awk -F/ '{printf($2)}' | tee /tekton/results/repoName

--- a/tekton/ci/shared/common-tasks.yaml
+++ b/tekton/ci/shared/common-tasks.yaml
@@ -70,7 +70,7 @@ spec:
       description: The result of the check, "passed" or "failed"
   steps:
     - name: check-name
-      image: alpine
+      image: docker.io/library/alpine
       env:
       - name: GITHUB_COMMAND
         value: $(params.gitHubCommand)

--- a/tekton/cronjobs/README.md
+++ b/tekton/cronjobs/README.md
@@ -208,7 +208,7 @@ spec:
             - name: GIT_REVISION
               value: main
             - name: TARGET_IMAGE
-              value: ghcr.io/tektoncd/plumbing/myimage:latest
+              value: ghcr.io/tektoncd/plumbing/myimage:docker.io/latest
             - name: CONTEXT_PATH
               value: tekton/images/myimage
 ```

--- a/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
+++ b/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
@@ -50,7 +50,7 @@ spec:
               - name: GIT_REVISION
                 value: "main"
           - name: uuid
-            image: python:3.6-alpine3.9
+            image: docker.io/library/python:3.6-alpine3.9
             command:
             - /bin/sh
             args:

--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -51,7 +51,7 @@ spec:
               - name: GIT_REPO
                 value: "github.com/tektoncd/pipeline"
           - name: uuid
-            image: python:3.6-alpine3.9
+            image: docker.io/library/python:3.6-alpine3.9
             command:
             - /bin/sh
             args:

--- a/tekton/mario-bot/mario-github-comment.yaml
+++ b/tekton/mario-bot/mario-github-comment.yaml
@@ -134,7 +134,7 @@ spec:
       - name: pr
       steps:
       - name: setup-comment
-        image: python:3-alpine
+        image: docker.io/library/python:3-alpine
         env:
         - name: PASSED_OR_FAILED
           value: $(params.passedOrFailed)

--- a/tekton/resources/images/docker-multi-arch-template.yaml
+++ b/tekton/resources/images/docker-multi-arch-template.yaml
@@ -117,7 +117,7 @@ spec:
           env:
           - name: DOCKER_TLS_CERTDIR
             value: /certs
-          image: docker:dind
+          image: docker.io/library/docker:dind
           name: server-docker
           readinessProbe:
             exec:

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -164,7 +164,7 @@ spec:
               - mountPath: /certs/client
                 name: dind-certs
             sidecars:
-            - image: docker:dind
+            - image: docker.io/library/docker:dind
               name: server
               args:
                 - --storage-driver=overlay2

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -164,7 +164,7 @@ spec:
               - mountPath: /certs/client
                 name: dind-certs
             sidecars:
-            - image: docker:dind
+            - image: docker.io/library/docker:dind
               name: server
               args:
                 - --storage-driver=overlay2

--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -182,7 +182,7 @@ spec:
         # || true in case no PRs have "release-note-none"
         grep "release-note-none" $HOME/pr.csv > $HOME/pr-no-notes.csv || true
     - name: body
-      image: busybox
+      image: docker.io/library/busybox
       script: |
         #!/bin/sh
         set -e

--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -185,7 +185,7 @@ spec:
         # || true in case no PRs have "release-note-none"
         grep "release-note-none" $HOME/pr.csv > $HOME/pr-no-notes.csv || true
     - name: body
-      image: busybox
+      image: docker.io/library/busybox
       script: |
         #!/bin/sh
         set -e
@@ -366,7 +366,7 @@ spec:
             description: Workspace to verify
         steps:
           - name: check-files
-            image: alpine:3.20
+            image: docker.io/library/alpine:3.20
             script: |
               #!/bin/sh
               set -e

--- a/tekton/resources/release/base/prerelease_checks.yaml
+++ b/tekton/resources/release/base/prerelease_checks.yaml
@@ -59,7 +59,7 @@ spec:
           exit 1
         fi
     - name: check-github-release
-      image: python:3.6-alpine3.9
+      image: docker.io/library/python:3.6-alpine3.9
       script: |
         echo "Checking GitHub release"
         PACKAGE=$(echo ${PACKAGE} | cut -d/ -f2,3)
@@ -71,7 +71,7 @@ spec:
         echo "Release ${VERSION_TAG} already exists for ${PACKAGE}"
         exit 1
     - name: success-confirmation
-      image: alpine
+      image: docker.io/library/alpine
       script: |
         echo "All pre-release checks for ${PACKAGE} @ ${VERSION_TAG} were successful"
         echo "Happy releasing 😺"

--- a/tekton/resources/release/base/prerelease_checks_oci.yaml
+++ b/tekton/resources/release/base/prerelease_checks_oci.yaml
@@ -123,7 +123,7 @@ spec:
         rm -f /oracle/.oci/oci_api_key.pem /oracle/.oci/config
         echo "Release file does not exist. Check passed."
     - name: check-github-release
-      image: python:3.6-alpine3.9
+      image: docker.io/library/python:3.6-alpine3.9
       script: |
         echo "Checking GitHub release"
         PACKAGE=$(echo ${PACKAGE} | cut -d/ -f2,3)
@@ -135,7 +135,7 @@ spec:
         echo "Release ${VERSION_TAG} already exists for ${PACKAGE}"
         exit 1
     - name: success-confirmation
-      image: alpine
+      image: docker.io/library/alpine
       script: |
         echo "All pre-release checks for ${PACKAGE} @ ${VERSION_TAG} were successful"
         echo "Happy releasing 😺"


### PR DESCRIPTION
# Changes

The OCI images for the new version of k8s do not allow for short images anymore, so stop using them.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._