### PR TITLE
Fix image pull errors by using fully qualified image names

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
       - name: trigger
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /workspace

--- a/tekton/ci/jobs/tekton-teps-validation.yaml
+++ b/tekton/ci/jobs/tekton-teps-validation.yaml
@@ -20,7 +20,7 @@ spec:
     workingDir: $(workspaces.input.path)
     args: ['table', '--teps-folder', '$(workspaces.input.path)/$(params.teps-folder)']
   - name: teps-table
-    image: alpine/git:latest
+    image: docker.io/alpine/git:latest
     workingDir: $(workspaces.input.path)
     args: ['diff', '--exit-code']
 ---

--- a/tekton/cronjobs/bases/catalog/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/catalog/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/cleanup/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/cleanup/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/configmap/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/configmap/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/folder/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/folder/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/helm/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/helm/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
+++ b/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           initContainers:
           - name: git
-            image: alpine/git
+            image: docker.io/alpine/git
             command:
             - /bin/sh
             args:
@@ -65,7 +65,7 @@ spec:
               name: workspace
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
             - /bin/sh
             args:

--- a/tekton/cronjobs/bases/nightly-tests/trigger-nightly-test.yaml
+++ b/tekton/cronjobs/bases/nightly-tests/trigger-nightly-test.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/peribolos/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/peribolos/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           initContainers:
           - name: git
-            image: alpine/git
+            image: docker.io/alpine/git
             command:
             - /bin/sh
             args:
@@ -66,7 +66,7 @@ spec:
               name: shared-volume
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/bases/tekton-service/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/tekton-service/trigger-resource-cd.yaml
@@ -26,7 +26,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
             emptyDir: {}
           containers:
           - name: trigger
-            image: curlimages/curl
+            image: docker.io/curlimages/curl
             command:
               - /bin/sh
             args:

--- a/tekton/images/alpine-git-nonroot/Dockerfile
+++ b/tekton/images/alpine-git-nonroot/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine/git:2.52.0@sha256:3b7890cb947afd3f71adab55aa6b549ad0f8ddc4b9ed28b027563d73d49d8e11
+FROM docker.io/alpine/git:2.52.0@sha256:3b7890cb947afd3f71adab55aa6b549ad0f8ddc4b9ed28b027563d73d49d8e11
 LABEL maintainer "Tekton Authors <tekton-dev@googlegroups.com>"
 LABEL org.opencontainers.image.source=https://github.com/tektoncd/plumbing
 LABEL org.opencontainers.image.description="Image for Alpine-git Nonroot"

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -94,7 +94,7 @@ spec:
       chmod a+r ${RESOURCES_PATH}/DEPLOYABLE_ALL.yaml
 
   - name: split-yaml-file
-    image: mikefarah/yq
+    image: docker.io/mikefarah/yq
     script: |
       #!/bin/sh
       set -ex

--- a/tekton/resources/cd/helm-template.yaml
+++ b/tekton/resources/cd/helm-template.yaml
@@ -74,7 +74,7 @@ spec:
           -f ${PRE_DEPLOY_RESOURCES}
 
     - name: helm-deploy
-      image: alpine/helm:3.1.2
+      image: docker.io/alpine/helm:3.1.2
       script: |
         #!/bin/sh
         set -ex

--- a/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-p/k8s_cluster_setup.yaml
@@ -35,7 +35,7 @@ spec:
       default: create
   steps:
     - name: ssh
-      image: kroniak/ssh-client
+      image: docker.io/kroniak/ssh-client
       env:
         - name: REMOTE_HOST
           value: $(params.remote-host)

--- a/tekton/resources/nightly-tests/bastion-z/k8s_cluster_setup.yaml
+++ b/tekton/resources/nightly-tests/bastion-z/k8s_cluster_setup.yaml
@@ -34,7 +34,7 @@ spec:
       default: create
   steps:
     - name: ssh
-      image: kroniak/ssh-client
+      image: docker.io/kroniak/ssh-client
       env:
       - name: REMOTE_HOST
         value: $(params.remote-host)

--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -159,7 +159,7 @@ spec:
         echo "$(wc -l $HOME/pr.csv | awk '{ print $1}') PRs in the new release."
         cat $HOME/pr.csv
     - name: release-notes
-      image: stedolan/jq
+      image: docker.io/stedolan/jq
       script: |
         #!/bin/bash
         set -e

--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -162,7 +162,7 @@ spec:
         echo "$(wc -l $HOME/pr.csv | awk '{ print $1}') PRs in the new release."
         cat $HOME/pr.csv
     - name: release-notes
-      image: stedolan/jq
+      image: docker.io/stedolan/jq
       script: |
         #!/bin/bash
         set -e

--- a/tekton/resources/release/base/prerelease_checks.yaml
+++ b/tekton/resources/release/base/prerelease_checks.yaml
@@ -38,7 +38,7 @@ spec:
       description: The workspace where the repo has been cloned
   steps:
     - name: check-git-tag
-      image: alpine/git
+      image: docker.io/alpine/git
       script: |
         echo "Checking git tag"
         # Look for the tag in the list of tags

--- a/tekton/resources/release/base/prerelease_checks_oci.yaml
+++ b/tekton/resources/release/base/prerelease_checks_oci.yaml
@@ -47,7 +47,7 @@ spec:
       optional: false
   steps:
     - name: check-git-tag
-      image: alpine/git
+      image: docker.io/alpine/git
       script: |
         echo "Checking git tag"
         # Look for the tag in the list of tags


### PR DESCRIPTION
Add the explicit `docker.io/` prefix to container images to resolve "ErrImagePull: short name mode is enforcing" errors. This ensures the container runtime can unambiguously identify the registry and prevents failures when short-name resolution is restricted.

Updated images:
- docker.io/alpine/git
- docker.io/curlimages/curl
- docker.io/stedolan/jq
- docker.io/mikefarah/yq
- docker.io/alpine/helm
- docker.io/kroniak/ssh-client

Fixes #3111 3111
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._