### PR TITLE
fix(cherry-pick): fetch PR ref to access fork commits

### DIFF
--- a/.github/workflows/_cherry-pick-command.yaml
+++ b/.github/workflows/_cherry-pick-command.yaml
@@ -203,6 +203,15 @@ jobs:
             COMMIT_COUNT=$(echo "$COMMITS" | wc -l)
             echo "Found $COMMIT_COUNT commit(s) to cherry-pick"
 
+            # Fetch the PR commits - they may be from a fork and not available locally
+            # GitHub makes PR commits available via refs/pull/<number>/head
+            echo "Fetching PR ref to make fork commits available locally..."
+            git fetch origin "pull/$PR_NUMBER/head" 2>&1 || ERROR="Failed to fetch PR commits from refs/pull/$PR_NUMBER/head"
+            if [[ "$ERROR" != "" ]]; then
+              echo "❌ ERROR: $ERROR"
+              exit 1
+            fi
+
             # Cherry-pick each commit in order
             CURRENT=0
             for COMMIT in $COMMITS; do


### PR DESCRIPTION
# Changes

The cherry-pick workflow was failing when trying to cherry-pick commits from PRs that originated from forks. The commit SHAs from the PR exist in the contributor's fork but are not available in the main repository checkout.

This fix fetches the PR ref (`refs/pull/<number>/head`) before attempting to cherry-pick, which makes the commits from forks available locally.

**Root cause**: When a PR is submitted from a fork, the original commit SHAs (e.g., `3b1c471fc748fb0d06bee0279b3deb7b18ffb1a2`) only exist in the fork repository. The workflow was using `gh pr view --json commits` to get these SHAs, but they weren't available after `actions/checkout` because that only fetches the main repo.

**Fix**: Fetch `refs/pull/$PR_NUMBER/head` which GitHub makes available for all PRs, including those from forks.

Fixes: tektoncd/pipeline#9386 (cherry-pick failure comment)

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) - N/A, internal workflow fix
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)