### PR TITLE
Fix image pull errors by using fully qualified image names

### DIFF
--- a/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
+++ b/tekton/ci/jobs/tekton-catalog-catlin-lint.yaml
@@ -21,7 +21,7 @@ spec:
       default: git
   steps:
     - name: find-changed-tasks
-      image: docker.io/library/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f
+      image: docker.io/alpine/git:2.52.0@sha256:3b7890cb947afd3f71adab55aa6b549ad0f8ddc4b9ed28b027563d73d49d8e11
       workingDir: $(workspaces.source.path)
       env:
       - name: GIT_CLONE_DEPTH

--- a/tekton/resources/branch-protection/terraform.yaml
+++ b/tekton/resources/branch-protection/terraform.yaml
@@ -31,21 +31,21 @@ spec:
     description: GitHub token for terraform provider authentication
   steps:
   - name: terraform-init
-    image: hashicorp/terraform:1.7
+    image: docker.io/hashicorp/terraform:1.7
     workingDir: $(workspaces.source.path)/$(params.terraformDir)
     script: |
       #!/bin/sh
       set -ex
       terraform init
   - name: terraform-validate
-    image: hashicorp/terraform:1.7
+    image: docker.io/hashicorp/terraform:1.7
     workingDir: $(workspaces.source.path)/$(params.terraformDir)
     script: |
       #!/bin/sh
       set -ex
       terraform validate
   - name: terraform-plan
-    image: hashicorp/terraform:1.7
+    image: docker.io/hashicorp/terraform:1.7
     workingDir: $(workspaces.source.path)/$(params.terraformDir)
     script: |
       #!/bin/sh
@@ -53,7 +53,7 @@ spec:
       export GITHUB_TOKEN=$(cat /etc/github/bot-token)
       terraform plan -out=tfplan
   - name: terraform-execute
-    image: hashicorp/terraform:1.7
+    image: docker.io/hashicorp/terraform:1.7
     workingDir: $(workspaces.source.path)/$(params.terraformDir)
     script: |
       #!/bin/sh


### PR DESCRIPTION
# Changes

Update image references to use fully qualified names to prevent "short name mode is enforcing" errors:

- **tekton/ci/jobs/tekton-catalog-catlin-lint.yaml**: Update alpine/git from the incorrect `docker.io/library/alpine/git:v2.26.2` (which doesn't exist - alpine/git is not a library image) to `docker.io/alpine/git:2.52.0` with a valid digest

- **tekton/resources/branch-protection/terraform.yaml**: Add `docker.io/` prefix to `hashicorp/terraform:1.7` images

This is a follow-up to PR #3112, fixing additional files that were missed.

Fixes the `pull-catalog-catlin-lint` CI job failures that were blocking PRs on tektoncd/catalog (e.g., https://github.com/tektoncd/catalog/pull/1357).

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._