### PR TITLE
ci: update pipeline branch protection for unified CI summary check

### DIFF
--- a/terraform/branch-protection/locals.tf
+++ b/terraform/branch-protection/locals.tf
@@ -45,12 +45,7 @@ locals {
       "Unit tests",
     ]
     pipeline = [
-      "build",
-      "test",
-      "lint",
-      "Check generated code",
-      "Multi-arch build",
-      "e2e tests",
+      "CI summary",
     ]
     operator = [
       "build",

--- a/terraform/branch-protection/main.tf
+++ b/terraform/branch-protection/main.tf
@@ -19,11 +19,11 @@ resource "github_branch_protection" "main" {
   repository_id = each.key
   pattern       = "main"
 
-  enforce_admins                   = var.enforce_admins
-  require_signed_commits           = var.require_signed_commits
-  required_linear_history          = var.required_linear_history
-  allows_deletions                 = var.allow_deletions
-  allows_force_pushes              = var.allow_force_pushes
+  enforce_admins                  = var.enforce_admins
+  require_signed_commits          = var.require_signed_commits
+  required_linear_history         = var.required_linear_history
+  allows_deletions                = var.allow_deletions
+  allows_force_pushes             = var.allow_force_pushes
   require_conversation_resolution = var.require_conversation_resolution
 
   required_status_checks {
@@ -57,11 +57,11 @@ resource "github_branch_protection" "releases" {
 
   required_status_checks {
     strict = true
-    # Use subset of checks for release branches (build + test minimum)
+    # Use subset of checks for release branches (build + test minimum, or unified CI summary)
     contexts = concat(
       local.base_status_checks,
       [for check in lookup(local.repo_specific_checks, each.key, []) :
-        check if can(regex("^(build|test|lint)$", check))
+        check if can(regex("^(build|test|lint|CI summary)$", check))
       ]
     )
   }


### PR DESCRIPTION
# Changes

Replace the 6 individual pipeline CI status checks (`build`, `test`, `lint`,
`Check generated code`, `Multi-arch build`, `e2e tests`) with the single
unified `CI summary` fan-in job introduced in tektoncd/pipeline#9394.

Also updates the release branch protection regex filter to include `CI summary`
so the unified check is required on release branches as well.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)