### PR TITLE
Add activeDeadlineSeconds to CronJob templates and manage build-id-ci-nightly via ArgoCD

### DIFF
--- a/tekton/cronjobs/bases/catalog/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/catalog/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "12 * * * *"  # Houly at *:12
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/cleanup/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/cleanup/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "12 * * * *"  # Houly at *:12
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/configmap/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/configmap/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "12 * * * *"  # Houly at *:12
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/folder/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/folder/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "12 * * * *"  # Houly at *:12
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/helm/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/helm/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "12 * * * *"  # Houly at *:12
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
+++ b/tekton/cronjobs/bases/image-build/trigger-image-build.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "0 2 * * *"  # Daily at 2am
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/nightly-tests/trigger-nightly-test.yaml
+++ b/tekton/cronjobs/bases/nightly-tests/trigger-nightly-test.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "0 0 1 * *"
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/peribolos/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/peribolos/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "0 12 * * *"  # Daily at 12 pm
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
+++ b/tekton/cronjobs/bases/release/trigger-with-uuid.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "0 2 * * *"  # Daily at 2am
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/bases/tekton-service/trigger-resource-cd.yaml
+++ b/tekton/cronjobs/bases/tekton-service/trigger-resource-cd.yaml
@@ -19,6 +19,7 @@ spec:
   schedule: "12 * * * *"  # Houly at *:12
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/cronjob.yaml
+++ b/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/cronjob.yaml
@@ -20,6 +20,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       template:
         spec:
           volumes:

--- a/tekton/cronjobs/nightly_oci/releases/kustomization.yaml
+++ b/tekton/cronjobs/nightly_oci/releases/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- build-id-ci-nightly
 - dashboard-nightly
 - triggers-nightly
 - add-pr-body-ci-nightly


### PR DESCRIPTION
# Changes

After the cluster node replacement on 2026-02-11, CRI-O on the new nodes
enforces fully-qualified image names (`short_name_mode = "enforcing"`).
The CronJob pods in the cluster still had old specs with short image names
(e.g. `curlimages/curl` instead of `docker.io/curlimages/curl`), causing
`ImagePullBackOff` on every CronJob trigger pod.

Because all CronJobs use `concurrencyPolicy: Forbid` and the stuck Jobs
never terminate, no new Jobs can be created. **All 28 CronJobs have been
frozen for 7+ days** — nightly tests, nightly releases, cleanup, peribolos,
and catalog publishing are all dead.

The source code already uses fully-qualified image names, but the cluster
was never synced after the node replacement. This PR addresses the two
remaining gaps:

1. **Adds `activeDeadlineSeconds: 300` to all CronJob base templates** —
   these trigger Jobs only run `curl` (and optionally `git ls-remote` +
   a python UUID one-liner in init containers) and should complete in
   seconds. A 5-minute deadline ensures that if a Job gets stuck (image
   pull failure, network issue, etc.), it is automatically cleaned up
   instead of blocking all future runs under `concurrencyPolicy: Forbid`.

2. **Adds `build-id-ci-nightly` to the releases kustomization** — this
   CronJob was manually applied and not managed by ArgoCD. It's currently
   running in the cluster with unqualified image names (`curlimages/curl`,
   `alpine/git`, `python:3.6-alpine3.9`) and will never get synced
   without this fix.

### Manual steps required after merge

Once ArgoCD syncs the new specs, the currently stuck Jobs need to be
deleted so the CronJobs can schedule new ones:

```bash
# Delete all stuck active Jobs in default namespace
kubectl delete jobs -n default -l batch.kubernetes.io/controller-uid \
  --field-selector=status.conditions[0].type!=Complete
```

Alternatively, wait for the `activeDeadlineSeconds` to kick in (5 minutes
from sync) and the Jobs will be cleaned up automatically.

Relates to #3116

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._