### PR TITLE
Remove hub from branch protection (archived repo)

### DIFF
--- a/terraform/branch-protection/imports.tf
+++ b/terraform/branch-protection/imports.tf
@@ -30,3 +30,21 @@ import {
   to       = github_branch_protection.releases[each.key]
   id       = "${each.key}:release-v*"
 }
+
+# hub repository was archived — remove from Terraform state
+# without attempting to destroy the resources (API calls would fail on archived repos)
+removed {
+  from = github_branch_protection.main["hub"]
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = github_branch_protection.releases["hub"]
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/branch-protection/locals.tf
+++ b/terraform/branch-protection/locals.tf
@@ -24,7 +24,6 @@ locals {
     "cli",
     "pruner",
     "chains",
-    "hub",
     "results",
     "plumbing",
   ]


### PR DESCRIPTION
# Changes

The hub repository has been archived, so this PR removes it from the branch protection terraform configuration.

**Changes:**
- Removed `"hub"` from the `tektoncd_repos` list in `terraform/branch-protection/locals.tf`
- Added `removed` blocks in `terraform/branch-protection/imports.tf` to safely detach the existing branch protection resources from Terraform state without attempting to destroy them (API calls would fail on archived repos)

/kind cleanup

# Submitter Checklist

- [x] Includes docs (if user facing) - N/A, infrastructure change
- [x] Commit messages follow commit message best practices