### PR TITLE
ci: Enable Tide from-branch-protection context policy

### DIFF
--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -26,6 +26,12 @@ sinker:
 
 tide:
   sync_period: 2m
+  context_options:
+    # Derive required/optional contexts from GitHub branch protection
+    # rules (managed via Terraform in terraform/branch-protection/).
+    # This allows conditional/skipped GitHub Actions jobs to not block
+    # Tide from merging PRs.
+    from-branch-protection: true
   queries:
   - repos:
     - tektoncd-catalog/golang


### PR DESCRIPTION
# Changes

Enable `from-branch-protection: true` in the Tide `context_options`
configuration so that Tide derives required/optional status contexts
from GitHub branch protection rules (managed via Terraform in
`terraform/branch-protection/`).

This fixes a problem where conditional/skipped GitHub Actions jobs
(e.g. jobs that only run when certain files change) block Tide from
merging PRs, because Tide treats unknown contexts as required by
default.

With this change, only the checks listed in branch protection
(e.g. `tide`, `EasyCLA`, `CI summary` for `tektoncd/pipeline`) are
required — any other status context (including skipped conditional
jobs) is treated as optional.

See for example https://github.com/tektoncd/pipeline/pull/9390.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)