### PR TITLE
fix: Persist Terraform state for branch protection

### DIFF
--- a/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/kustomization.yaml
+++ b/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/kustomization.yaml
@@ -16,3 +16,4 @@ kind: Kustomization
 namespace: default
 resources:
 - cronjob.yaml
+- rbac.yaml

--- a/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/rbac.yaml
+++ b/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/rbac.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RBAC for Terraform Kubernetes backend.
+# The backend stores state in Secret "tfstate-branch-protection"
+# and uses Lease "lock-tfstate-branch-protection" for locking.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: terraform-state
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch", "delete"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "create", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: terraform-state
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+roleRef:
+  kind: Role
+  name: terraform-state
+  apiGroup: rbac.authorization.k8s.io

--- a/tekton/resources/branch-protection/terraform.yaml
+++ b/tekton/resources/branch-protection/terraform.yaml
@@ -36,7 +36,9 @@ spec:
     script: |
       #!/bin/sh
       set -ex
-      terraform init
+      # -input=false prevents interactive prompts in CI
+      # -migrate-state handles backend transitions (no-op when backend is unchanged)
+      terraform init -input=false -migrate-state
   - name: terraform-validate
     image: docker.io/hashicorp/terraform:1.7
     workingDir: $(workspaces.source.path)/$(params.terraformDir)

--- a/terraform/branch-protection/versions.tf
+++ b/terraform/branch-protection/versions.tf
@@ -15,6 +15,16 @@
 terraform {
   required_version = ">= 1.5"
 
+  # Store state in a Kubernetes Secret so it persists across ephemeral
+  # Tekton TaskRun pods. Without this, every run would start with empty
+  # state, import all resources, and destroy+recreate them — leaving
+  # repos unprotected during the ~3 minute window.
+  backend "kubernetes" {
+    secret_suffix     = "branch-protection"
+    namespace         = "default"
+    in_cluster_config = true
+  }
+
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
# Changes

The `terraform-branch-protection` Task runs in ephemeral pods with no
backend configured. Every nightly run starts with empty state, imports
all 20 branch protections, and **destroys + recreates them all** — leaving
a ~3 minute window where all tektoncd repos are unprotected.

This adds a Kubernetes backend to persist state in a Secret
(`tfstate-branch-protection`), so subsequent runs are no-ops when
nothing changed.

- Add `backend "kubernetes"` to `versions.tf`
- Add RBAC (Role + RoleBinding) for state Secret and lock Lease access
- Use `terraform init -migrate-state -input=false` for the transition

/kind bug

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)