### PR TITLE
fix(ci): Handle grep no-match in detect-changes image filter

### DIFF
--- a/hack/detect-changes.sh
+++ b/hack/detect-changes.sh
@@ -101,7 +101,7 @@ if echo "$CHANGED" | grep -qE "^(\.github/workflows/ci\.yaml|tekton/images/gener
 fi
 
 # Filter to only images with changes
-CHANGED_DIRS=$(echo "$CHANGED" | grep "^tekton/images/" | cut -d/ -f3 | sort -u)
+CHANGED_DIRS=$(echo "$CHANGED" | { grep "^tekton/images/" || true; } | cut -d/ -f3 | sort -u)
 if [[ -n "$CHANGED_DIRS" ]]; then
   FILTER=$(echo "$CHANGED_DIRS" | jq -R . | jq -sc '.')
   FILTERED=$(echo "$ALL_IMAGES" | jq -c --argjson dirs "$FILTER" \


### PR DESCRIPTION
# Changes

The `detect-changes.sh` script fails when no files under `tekton/images/`
are changed. The `grep "^tekton/images/"` command returns exit code 1 on
no match, which combined with `set -euo pipefail` causes the entire
script to abort.

This was triggered by https://github.com/tektoncd/plumbing/actions/runs/22177706794/job/64130582140
where only terraform/branch-protection files changed — no image files.

Fix: wrap the grep in `{ grep ... || true; }` so the pipeline
succeeds even when grep finds no matches.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._