### PR TITLE
fix: Add list verb to terraform-state Role for secrets

### DIFF
--- a/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/rbac.yaml
+++ b/tekton/cronjobs/dogfooding/terraform-branch-protection/tektoncd/rbac.yaml
@@ -22,7 +22,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "create", "update", "patch", "delete"]
+  verbs: ["list", "get", "create", "update", "patch", "delete"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "create", "update", "delete"]


### PR DESCRIPTION
# Changes

Follow-up to #3151. The Terraform Kubernetes backend calls `list` on secrets
to discover existing workspaces during `terraform init`. Without it, the
init step fails with:

```
Error: Failed to get existing workspaces: secrets is forbidden:
User "system:serviceaccount:default:default" cannot list resource
"secrets" in API group "" in the namespace "default"
```

Adds the missing `list` verb to the `terraform-state` Role.

/kind bug

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)