### PR TITLE
Add automated-releases namespace to dashboard allowed namespaces

### DIFF
--- a/tekton/cd/dashboard/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/oci-ci-cd/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/args/5
-      value: --namespaces=tekton-ci,tekton-nightly,bastion-p,bastion-z
+      value: --namespaces=tekton-ci,tekton-nightly,bastion-p,bastion-z,automated-releases
 - patch: |-
     $patch: delete
     apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/cd/dashboard/overlays/oci-ci-cd/namespaced-rolebindings.yaml
+++ b/tekton/cd/dashboard/overlays/oci-ci-cd/namespaced-rolebindings.yaml
@@ -217,6 +217,78 @@ subjects:
   name: tekton-dashboard
   namespace: tekton-pipelines
 
+# automated-releases namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-tenant-view-restricted
+  namespace: automated-releases
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-tenant-view-restricted
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-backend-view
+  namespace: automated-releases
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-backend-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-triggers-view
+  namespace: automated-releases
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-aggregate-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-cronjobs-extension
+  namespace: automated-releases
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-cronjobs-extension
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-pipelines-view
+  namespace: automated-releases
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-aggregate-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+
 # bastion-z namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
# Changes

Add the `automated-releases` namespace to the Tekton dashboard configuration:

- Add `automated-releases` to the `--namespaces` argument in the dashboard deployment
- Create the corresponding namespaced RoleBindings for the dashboard service account:
  - `tekton-dashboard-tenant-view-restricted`
  - `tekton-dashboard-backend-view`
  - `tekton-dashboard-triggers-view`
  - `tekton-dashboard-cronjobs-extension`
  - `tekton-dashboard-pipelines-view`

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._