### PR TITLE
ci: update triggers required checks to use CI summary fan-in

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -64,5 +64,4 @@ repos:
     - "CI summary"
   results: []
   triggers:
-    - "lint"
-    - "Tekton Triggers CI"
+    - "CI summary"

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -76,8 +76,7 @@ tide:
             - "CI summary"
           triggers:
             required-contexts:
-            - "lint"
-            - "Tekton Triggers CI"
+            - "CI summary"
   # END GENERATED context_options
   queries:
   - repos:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace the individual `lint` and `Tekton Triggers CI` required checks
for tektoncd/triggers with the unified `CI summary` fan-in job, matching
the pattern already used by tektoncd/pipeline and tektoncd/plumbing.

See: https://github.com/tektoncd/triggers/pull/1956

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._