### PR TITLE
Update cli required checks to use CI summary fan-in

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -33,13 +33,7 @@ repos:
   chains:
     - "CI summary"
   cli:
-    - "build"
-    - "test"
-    - "lint"
-    - "Check generated code"
-    - "Multi-arch build"
-    - "e2e-tests / e2e tests (k8s-oldest)"
-    - "e2e-tests / e2e tests (k8s-plus-one)"
+    - "CI summary"
   dashboard:
     - "CI summary"
   mcp-server:

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -41,13 +41,7 @@ tide:
             - "CI summary"
           cli:
             required-contexts:
-            - "build"
-            - "test"
-            - "lint"
-            - "Check generated code"
-            - "Multi-arch build"
-            - "e2e-tests / e2e tests (k8s-oldest)"
-            - "e2e-tests / e2e tests (k8s-plus-one)"
+            - "CI summary"
           dashboard:
             required-contexts:
             - "CI summary"


### PR DESCRIPTION
# Changes

Replace the 7 individual required checks for tektoncd/cli with
the single `CI summary` fan-in check, matching the pattern already
used by tektoncd/pipeline, tektoncd/plumbing and tektoncd/pruner.

Corresponding PR: https://github.com/tektoncd/cli/pull/2741

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._