### PR TITLE
chore: update mcp-server required checks to CI summary

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -47,9 +47,7 @@ repos:
     - "E2E tests (k8s-plus-one, read-write)"
     - "Unit tests"
   mcp-server:
-    - "build"
-    - "test"
-    - "lint"
+    - "CI summary"
   operator:
     - "build"
     - "test"

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -55,9 +55,7 @@ tide:
             - "Unit tests"
           mcp-server:
             required-contexts:
-            - "build"
-            - "test"
-            - "lint"
+            - "CI summary"
           operator:
             required-contexts:
             - "build"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace the individual required checks (`build`, `test`, `lint`) with the single `CI summary` fan-in check for `tektoncd/mcp-server`.

This corresponds to https://github.com/tektoncd/mcp-server/pull/101 which adds the `ci-summary` fan-in job to the CI workflow.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._