### PR TITLE
ci: Use CI summary fan-in check for operator

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -51,11 +51,7 @@ repos:
     - "test"
     - "lint"
   operator:
-    - "build"
-    - "test"
-    - "lint"
-    - "Check generated code"
-    - "Multi-arch build"
+    - "CI summary"
   pipeline:
     - "CI summary"
   plumbing:

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -60,11 +60,7 @@ tide:
             - "lint"
           operator:
             required-contexts:
-            - "build"
-            - "test"
-            - "lint"
-            - "Check generated code"
-            - "Multi-arch build"
+            - "CI summary"
           pipeline:
             required-contexts:
             - "CI summary"


### PR DESCRIPTION
# Changes

Replace 5 individual required checks for `tektoncd/operator` with a single
`CI summary` fan-in check, matching the pattern already used by `pipeline`,
`plumbing`, and `pruner`.

Individual checks removed: `build`, `test`, `lint`, `Check generated code`,
`Multi-arch build`.

Companion PR: https://github.com/tektoncd/operator/pull/3233

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._