### PR TITLE
ci: Add CI summary as required check for tektoncd/results

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -52,6 +52,7 @@ repos:
     - "CI summary"
   pruner:
     - "CI summary"
-  results: []
+  results:
+    - "CI summary"
   triggers:
     - "CI summary"

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -66,6 +66,9 @@ tide:
           pruner:
             required-contexts:
             - "CI summary"
+          results:
+            required-contexts:
+            - "CI summary"
           triggers:
             required-contexts:
             - "CI summary"


### PR DESCRIPTION
# Changes

Update `repo-checks.yaml` to require the `CI summary` fan-in check for
`tektoncd/results`, replacing the empty check list. Regenerate Tide
`context_options` accordingly.

This pairs with tektoncd/results#1225 which adds the CI summary fan-in job.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)