### PR TITLE
ci: add fork PR support to /rebase workflow

### DIFF
--- a/.github/workflows/_rebase-command.yaml
+++ b/.github/workflows/_rebase-command.yaml
@@ -7,7 +7,9 @@
 #
 # Security Notes:
 # - Only users with "write" permission can trigger this command (enforced in slash.yml)
+# - Supports fork PRs when "Allow edits from maintainers" is enabled
 # - Uses CHATOPS_TOKEN to push to branches
+# - Uses --force-with-lease for safe force pushing
 # - The rebase is performed on the PR's head branch against its base branch
 #
 # To use this in a repo:
@@ -54,10 +56,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CHATOPS_TOKEN }}
           PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           # Get PR information
           echo "Fetching PR #$PR_NUMBER information..."
-          PR_DATA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json state,headRefName,baseRefName,headRepository,headRepositoryOwner) || {
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,headRefName,baseRefName,headRepository,headRepositoryOwner,maintainerCanModify) || {
             echo "error=true" >> $GITHUB_OUTPUT
             echo "message=Failed to fetch PR information" >> $GITHUB_OUTPUT
             exit 0
@@ -74,17 +78,25 @@ jobs:
           BASE_REF=$(echo "$PR_DATA" | jq -r '.baseRefName')
           HEAD_REPO_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')
           HEAD_REPO_NAME=$(echo "$PR_DATA" | jq -r '.headRepository.name')
+          HEAD_REPO_FULL_NAME="${HEAD_REPO_OWNER}/${HEAD_REPO_NAME}"
 
-          # Check if this is a fork
-          REPO_OWNER="${{ github.repository_owner }}"
+          # Detect fork PRs and check maintainer push access
           if [ "$HEAD_REPO_OWNER" != "$REPO_OWNER" ]; then
-            echo "error=true" >> $GITHUB_OUTPUT
-            echo "message=Cannot rebase PRs from forks. The PR branch must be in the same repository." >> $GITHUB_OUTPUT
-            exit 0
+            MAINTAINER_CAN_MODIFY=$(echo "$PR_DATA" | jq -r '.maintainerCanModify')
+            if [ "$MAINTAINER_CAN_MODIFY" != "true" ]; then
+              echo "error=true" >> $GITHUB_OUTPUT
+              echo "message=Cannot rebase fork PRs unless \"Allow edits from maintainers\" is enabled. Please ask the PR author to enable this option in the PR settings." >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "is_fork=true" >> $GITHUB_OUTPUT
+            echo "Fork PR detected (head: $HEAD_REPO_FULL_NAME). Maintainer push access confirmed."
+          else
+            echo "is_fork=false" >> $GITHUB_OUTPUT
           fi
 
           echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+          echo "head_repo_full_name=$HEAD_REPO_FULL_NAME" >> $GITHUB_OUTPUT
           echo "error=false" >> $GITHUB_OUTPUT
 
           echo "PR #$PR_NUMBER: rebasing '$HEAD_REF' onto '$BASE_REF'"
@@ -105,6 +117,7 @@ jobs:
         with:
           token: ${{ secrets.CHATOPS_TOKEN }}
           fetch-depth: 0
+          repository: ${{ steps.validate.outputs.head_repo_full_name }}
           ref: ${{ steps.validate.outputs.head_ref }}
 
       - name: Perform rebase
@@ -116,6 +129,8 @@ jobs:
           HEAD_REF: ${{ steps.validate.outputs.head_ref }}
           BASE_REF: ${{ steps.validate.outputs.base_ref }}
           PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+          IS_FORK: ${{ steps.validate.outputs.is_fork }}
+          UPSTREAM_REPO: ${{ github.repository }}
         run: |
           set -e
 
@@ -127,20 +142,30 @@ jobs:
             git config user.name "Tekton Bot"
             git config user.email "tekton-bot@users.noreply.github.com"
 
-            # Fetch the base branch
-            echo "Fetching base branch: $BASE_REF..."
-            git fetch origin "$BASE_REF" || {
-              echo "❌ ERROR: Failed to fetch base branch '$BASE_REF'"
-              exit 1
-            }
+            # Set up base branch access
+            if [ "$IS_FORK" = "true" ]; then
+              echo "Fork PR: adding upstream remote for base branch..."
+              git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+              git fetch upstream "$BASE_REF" || {
+                echo "❌ ERROR: Failed to fetch base branch '$BASE_REF' from upstream"
+                exit 1
+              }
+              BASE_REMOTE="upstream"
+            else
+              git fetch origin "$BASE_REF" || {
+                echo "❌ ERROR: Failed to fetch base branch '$BASE_REF'"
+                exit 1
+              }
+              BASE_REMOTE="origin"
+            fi
 
             # Get current HEAD for comparison
             OLD_HEAD=$(git rev-parse HEAD)
             echo "Current HEAD: $OLD_HEAD"
 
             # Perform the rebase
-            echo "Rebasing '$HEAD_REF' onto 'origin/$BASE_REF'..."
-            if ! git rebase "origin/$BASE_REF"; then
+            echo "Rebasing '$HEAD_REF' onto '${BASE_REMOTE}/$BASE_REF'..."
+            if ! git rebase "${BASE_REMOTE}/$BASE_REF"; then
               echo "❌ ERROR: Rebase failed due to conflicts"
               echo ""
               echo "Conflicting files:"
@@ -160,11 +185,15 @@ jobs:
               # Force push the rebased branch
               echo "Force pushing rebased branch..."
               git push --force-with-lease origin "$HEAD_REF" || {
-                echo "❌ ERROR: Failed to push rebased branch. Someone may have pushed new commits."
+                if [ "$IS_FORK" = "true" ]; then
+                  echo "❌ ERROR: Failed to push to fork branch. Ensure 'Allow edits from maintainers' is still enabled and no concurrent pushes occurred."
+                else
+                  echo "❌ ERROR: Failed to push rebased branch. Someone may have pushed new commits."
+                fi
                 exit 1
               }
 
-              COMMIT_COUNT=$(git rev-list --count "origin/$BASE_REF".."$NEW_HEAD")
+              COMMIT_COUNT=$(git rev-list --count "${BASE_REMOTE}/${BASE_REF}".."$NEW_HEAD")
               echo "commits=$COMMIT_COUNT" >> $GITHUB_OUTPUT
               echo "already_up_to_date=false" >> $GITHUB_OUTPUT
             fi
@@ -229,3 +258,4 @@ jobs:
             **Next steps:**
             - Check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details
             - If there are conflicts, you'll need to rebase manually and resolve them
+            ${{ steps.validate.outputs.is_fork == 'true' && '- For fork PRs, ensure "Allow edits from maintainers" is enabled' || '' }}


### PR DESCRIPTION
# Changes

Replace the hard fork rejection ("Cannot rebase PRs from forks") with fork detection and `maintainerCanModify` validation. Fork PRs are now rebased by checking out the fork repo, adding upstream as a remote for the base branch, performing the rebase, and pushing back to the fork with `--force-with-lease`.

This mirrors the fork support already implemented in the `/squash` workflow (`_squash-command.yaml` from PR #3173), using the same pattern:
- Checkout the fork repo directly (`origin` = fork)
- Add upstream remote for the base branch
- Rebase onto `upstream/<base>` instead of `origin/<base>`
- Push to origin (which is the fork)

Fork PRs require the author to enable "Allow edits from maintainers" in the PR settings. If disabled, the workflow posts an actionable error message asking the author to enable it. Same-repo PR behavior is completely unchanged.

**Motivation:** All fork-based contributions (e.g., PRs #9366, #9367, #9368 on tektoncd/pipeline) currently cannot use `/rebase`, forcing manual rebases. This is especially painful when multiple PRs need rebasing after dependency bumps land on `main`.

/kind feature

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._