### PR TITLE
chore: update dashboard required checks to CI summary

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -41,12 +41,7 @@ repos:
     - "e2e-tests / e2e tests (k8s-oldest)"
     - "e2e-tests / e2e tests (k8s-plus-one)"
   dashboard:
-    - "Build tests"
-    - "E2E tests (k8s-oldest, read-only)"
-    - "E2E tests (k8s-oldest, read-write)"
-    - "E2E tests (k8s-plus-one, read-only)"
-    - "E2E tests (k8s-plus-one, read-write)"
-    - "Unit tests"
+    - "CI summary"
   mcp-server:
     - "CI summary"
   operator:

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -50,12 +50,7 @@ tide:
             - "e2e-tests / e2e tests (k8s-plus-one)"
           dashboard:
             required-contexts:
-            - "Build tests"
-            - "E2E tests (k8s-oldest, read-only)"
-            - "E2E tests (k8s-oldest, read-write)"
-            - "E2E tests (k8s-plus-one, read-only)"
-            - "E2E tests (k8s-plus-one, read-write)"
-            - "Unit tests"
+            - "CI summary"
           mcp-server:
             required-contexts:
             - "CI summary"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace the 6 individual dashboard checks (`Build tests`, `E2E tests` variants,
`Unit tests`) with the single `CI summary` fan-in check in both
`config/repo-checks.yaml` and `prow/control-plane/config.yaml` (regenerated via
`hack/generate-tide-contexts.py`).

This corresponds to tektoncd/dashboard#4779 which adds the `ci-summary` fan-in
job to the dashboard CI workflow.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._