### PR TITLE
tekton: update pipeline to v1.10.0 on dogfooding OCI

### DIFF
--- a/tekton/cd/pipeline/overlays/oci-ci-cd/config-observability.yaml
+++ b/tekton/cd/pipeline/overlays/oci-ci-cd/config-observability.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
-  metrics.backend-destination: prometheus
+  metrics-protocol: prometheus

--- a/tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/tektoncd/pipeline/releases/download/v1.9.0/release.yaml
+- https://github.com/tektoncd/pipeline/releases/download/v1.10.0/release.yaml
 patches:
 - path: config-defaults.yaml
 - path: config-observability.yaml


### PR DESCRIPTION
# Changes

Update Tekton Pipelines deployment on the dogfooding OCI cluster from v1.9.0 to v1.10.0.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)