### PR TITLE
fix: Update MetalLB to v0.13.10 and fix /etc/hosts permission in setup-kind.sh

### DIFF
--- a/tekton/images/kind-e2e/setup-kind.sh
+++ b/tekton/images/kind-e2e/setup-kind.sh
@@ -215,8 +215,7 @@ kind create cluster --config kind.yaml
 #############################################################
 echo '--- Setup metallb'
 
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
 network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)
@@ -274,7 +273,7 @@ docker network connect "kind" "$REGISTRY_NAME"
 
 # Make the $REGISTRY_NAME -> 127.0.0.1, to tell `ko` to publish to
 # local reigstry, even when pushing $REGISTRY_NAME:$REGISTRY_PORT/some/image
-echo "127.0.0.1 $REGISTRY_NAME" | tee -a /etc/hosts
+echo "127.0.0.1 $REGISTRY_NAME" | sudo tee -a /etc/hosts
 
 # Create a registry-credentials secret and attach it to the list of service accounts in the namespace.
 function sa_ips() {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Replace the two v0.9.3 apply lines with a single v0.13.10 `metallb-native.yaml` manifest.

MetalLB v0.9.3 manifests (`namespace.yaml` + `metallb.yaml`) use `PodSecurityPolicy`, which was removed in Kubernetes 1.25. This causes `setup-kind.sh` to fail on any cluster running Kubernetes >= 1.25.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._