### PR TITLE
images: update ko from google/ko 0.15.4 to ko-build/ko 0.18.1

### DIFF
--- a/tekton/images/kind-e2e/Dockerfile
+++ b/tekton/images/kind-e2e/Dockerfile
@@ -22,14 +22,14 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 WORKDIR /kind
 
-ARG KO_VERSION=0.15.4
+ARG KO_VERSION=0.18.1
 
 # common util tools
 RUN apk add --no-cache \
   bash curl docker git jq openssl build-base
 
 # Install ko
-RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
+RUN curl -L https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 
 # Install kubectl and make sure it's available in the PATH.

--- a/tekton/images/kind/Dockerfile
+++ b/tekton/images/kind/Dockerfile
@@ -22,13 +22,13 @@ LABEL org.opencontainers.image.licenses=Apache-2.0
 
 WORKDIR /kind
 
-ARG KO_VERSION=0.15.4
+ARG KO_VERSION=0.18.1
 
 RUN apk add --no-cache \
   bash curl docker git jq openssl
 
 # Install ko
-RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
+RUN curl -L https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 
 # Install kubectl and make sure it's available in the PATH.

--- a/tekton/images/test-runner/Dockerfile
+++ b/tekton/images/test-runner/Dockerfile
@@ -161,8 +161,8 @@ RUN apt update && apt install -y uuid-runtime  # for uuidgen
 RUN apt update && apt install -y rubygems  # for mdl
 
 # Install ko
-ARG KO_VERSION=0.15.4
-RUN curl -L https://github.com/google/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
+ARG KO_VERSION=0.18.1
+RUN curl -L https://github.com/ko-build/ko/releases/download/v${KO_VERSION}/ko_${KO_VERSION}_Linux_x86_64.tar.gz > ko_${KO_VERSION}.tar.gz
 RUN tar -C /usr/local/bin -xzf ko_${KO_VERSION}.tar.gz
 
 # Extra tools through go install


### PR DESCRIPTION
## Changes

The ko project moved from `github.com/google/ko` to `github.com/ko-build/ko`.
The old `google/ko` releases are no longer being published, causing image
builds to fail when downloading the ko binary.

Update all three Dockerfiles that install ko:
- `tekton/images/kind-e2e`
- `tekton/images/kind`
- `tekton/images/test-runner`

Bumps ko from 0.15.4 to 0.18.1.

/kind bug

## Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)