### PR TITLE
Move inactive approvers to alumni

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,19 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- abayer
 - afrittoli
 - AlanGreene
 - anithapriyanatarajan
-- bobcatfish
-- chitrangpatel
-- dibyom
-- jeromeJu
-- jerop
 - savitaashture
 - vdemeester
-- wlynch
 
 # Alumni ❤️
 # - nikhil-thomas
 # - dlorenc
+# - bobcatfish
+# - chitrangpatel
+# - jeromeJu
+# - jerop
+# - wlynch
+# - abayer
+# - dibyom


### PR DESCRIPTION
# Changes

Move bobcatfish, chitrangpatel, jeromeJu, jerop, wlynch, abayer, and dibyom to alumni status. All have zero plumbing-specific contributions in the last 12 months, confirmed by both GitHub API and [Tekton DevStats](https://tekton.devstats.cd.foundation/).

Active approvers remaining:
- **vdemeester**: 315 devstats contributions, 56 reviews
- **afrittoli**: 105 devstats contributions, 12 reviews
- **AlanGreene**: 91 devstats contributions, 12 reviews
- **anithapriyanatarajan**: 42 devstats contributions, 6 reviews
- **savitaashture**: low but present

Per the [contributor ladder inactivity policy](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#inactivity), >4 months of no contributions warrants moving to emeritus. Plumbing uses the [simpler process](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#maintainer) for maintainer changes.

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)