### PR TITLE
prow: disable all plugins for tektoncd/pipelines-as-code

### DIFF
--- a/prow/control-plane/plugins.yaml
+++ b/prow/control-plane/plugins.yaml
@@ -66,6 +66,8 @@ plugins:
       - verify-owners
       - wip
       - yuks
+  tektoncd/pipelines-as-code:
+    plugins: []
   tektoncd/pipeline:
     plugins:
       - release-note


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

# Changes

Disable all prow plugins for `tektoncd/pipelines-as-code` by setting an
empty plugins list at the repo level, which overrides the org-wide
`tektoncd` plugin configuration.

`pipelines-as-code` is moving to use Pipelines-as-Code (itself) for
CI/CD, replacing prow. This is the first step before migrating other
repositories.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._