### PR TITLE
prow: exclude pipelines-as-code from org-level plugins

### DIFF
--- a/prow/control-plane/plugins.yaml
+++ b/prow/control-plane/plugins.yaml
@@ -22,6 +22,8 @@ approve:
 
 plugins:
   tektoncd:
+    excluded_repos:
+      - pipelines-as-code
     plugins:
       - approve
       - assign
@@ -66,8 +68,6 @@ plugins:
       - verify-owners
       - wip
       - yuks
-  tektoncd/pipelines-as-code:
-    plugins: []
   tektoncd/pipeline:
     plugins:
       - release-note


### PR DESCRIPTION
# Changes

Setting repo-level `plugins: []` for `tektoncd/pipelines-as-code` doesn't
override org-level plugins — prow merges them additively. This is why prow
was still commenting on [pipelines-as-code PRs](https://github.com/tektoncd/pipelines-as-code/pull/4#issuecomment-4037677110)
despite the previous change in 6c47a66e0f0b.

Use the `excluded_repos` field on the org-level `tektoncd` entry instead,
which properly prevents all org-wide plugins (approve, lgtm, assign, etc.)
from firing on `pipelines-as-code`.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._