### PR TITLE
fix: Resolve all golangci-lint errors across Go modules

### DIFF
--- a/bots/buildcaptain/cmd/buildcaptain/main.go
+++ b/bots/buildcaptain/cmd/buildcaptain/main.go
@@ -165,7 +165,7 @@ func getNextTickDuration() time.Duration {
 	if nextTick.Before(now) {
 		nextTick = nextTick.Add(24 * time.Hour)
 	}
-	return nextTick.Sub(time.Now())
+	return time.Until(nextTick)
 }
 
 func NewJobTicker() jobTicker {

--- a/bots/buildcaptain/cmd/buildcaptain/rotation.go
+++ b/bots/buildcaptain/cmd/buildcaptain/rotation.go
@@ -23,7 +23,7 @@ func FromURL(url string) GetFile {
 	return func() (io.ReadCloser, error) {
 		resp, err := http.Get(url)
 		if err != nil {
-			return nil, fmt.Errorf("Could not open url %s: %v", url, err)
+			return nil, fmt.Errorf("could not open url %s: %v", url, err)
 		}
 		return resp.Body, nil
 	}
@@ -43,7 +43,7 @@ func (r Rotation) GetBuildCaptain(t time.Time) string {
 		log.Printf("Could not read from build captain rotation: %v", err)
 		return "nobody"
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 	rotation, err := parseRotation(f)
 
 	if err != nil {

--- a/bots/buildcaptain/cmd/generate-rotation-csv/main.go
+++ b/bots/buildcaptain/cmd/generate-rotation-csv/main.go
@@ -73,10 +73,10 @@ func generateRotationCSV(c config, out io.Writer) error {
 	}
 
 	w := csv.NewWriter(out)
-	w.Write([]string{"Date", "User"})
+	_ = w.Write([]string{"Date", "User"})
 	for iter.Before(end) {
 		if iter.Weekday() == time.Saturday || iter.Weekday() == time.Sunday {
-			w.Write([]string{iter.Format(expectedDateFormat), ""})
+			_ = w.Write([]string{iter.Format(expectedDateFormat), ""})
 			iter = iter.AddDate(0, 0, 1)
 			continue
 		}

--- a/bots/mariobot/cmd/mario/main_test.go
+++ b/bots/mariobot/cmd/mario/main_test.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -145,8 +145,8 @@ func assertResponseStatus(t *testing.T, resp *http.Response, want int) {
 
 func assertResponsePayload(t *testing.T, resp *http.Response, v interface{}, opts ...cmp.Option) {
 	t.Helper()
-	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pipelinerun-logs/cmd/http/query.go
+++ b/pipelinerun-logs/cmd/http/query.go
@@ -20,16 +20,16 @@ type Query struct {
 // and returns an error otherwise.
 func (q *Query) Validate() error {
 	if q.Project == "" {
-		return errors.New("Invalid query: missing project")
+		return errors.New("invalid query: missing project")
 	}
 	if q.Cluster == "" {
-		return errors.New("Invalid query: missing cluster")
+		return errors.New("invalid query: missing cluster")
 	}
 	if q.Namespace == "" {
-		return errors.New("Invalid query: missing namespace")
+		return errors.New("invalid query: missing namespace")
 	}
 	if q.BuildID == "" {
-		return errors.New("Invalid query: missing build id")
+		return errors.New("invalid query: missing build id")
 	}
 	return nil
 }

--- a/tekton/ci/cluster-interceptors/add-pr-body/pkg/pr.go
+++ b/tekton/ci/cluster-interceptors/add-pr-body/pkg/pr.go
@@ -124,7 +124,7 @@ func getPrBody(prUrl string, token string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/tekton/ci/cluster-interceptors/add-pr-body/pkg/pr_test.go
+++ b/tekton/ci/cluster-interceptors/add-pr-body/pkg/pr_test.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +26,7 @@ func TestInterceptor_Process(t *testing.T) {
 
 	t.Run("without auth token", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			writer.Write([]byte(prBody))
+			_, _ = writer.Write([]byte(prBody))
 		}))
 		i := Interceptor{}
 		req := triggersv1.InterceptorRequest{
@@ -48,7 +47,7 @@ func TestInterceptor_Process(t *testing.T) {
 		wantToken := "token abcde"
 		ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			gotToken = request.Header.Get("Authorization")
-			writer.Write([]byte(prBody))
+			_, _ = writer.Write([]byte(prBody))
 		}))
 		i := Interceptor{
 			AuthToken: "abcde",
@@ -166,19 +165,4 @@ func TestInterceptor_Process_Error(t *testing.T) {
 	}
 }
 
-type requestOption func(*http.Request)
 
-// creates a GitHub hook type request - no secret is provided in testing.
-func createRequest(method, url, event, token string, body []byte, opts ...requestOption) *http.Request {
-	req := httptest.NewRequest(method, url, bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Github-Event", event)
-	req.Header.Set("X-Github-Delivery", "testing-123")
-	if token != "" {
-		req.Header.Add("Authorization", "token "+token)
-	}
-	for _, o := range opts {
-		o(req)
-	}
-	return req
-}

--- a/tekton/ci/custom-tasks/pr-commenter/cmd/pr-commenter/main.go
+++ b/tekton/ci/custom-tasks/pr-commenter/cmd/pr-commenter/main.go
@@ -1,3 +1,4 @@
+// Package main is the entrypoint for the PR commenter custom task.
 package main
 
 import (

--- a/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/controller.go
+++ b/tekton/ci/custom-tasks/pr-commenter/pkg/reconciler/controller.go
@@ -1,3 +1,4 @@
+// Package reconciler contains the reconciler for the PR commenter custom task.
 package reconciler
 
 import (
@@ -19,22 +20,24 @@ const (
 
 // NewController instantiates a new controller
 func NewController(scmClient *scm.Client, botUser string) func(context.Context, configmap.Watcher) *controller.Impl {
-	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		r := &Reconciler{
 			SCMClient: scmClient,
 			BotUser:   botUser,
 		}
 
-		impl := runreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		impl := runreconciler.NewImpl(ctx, r, func(_ *controller.Impl) controller.Options {
 			return controller.Options{
 				AgentName: ControllerName,
 			}
 		})
 
-		runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		if _, err := runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: tkncontroller.FilterCustomRunRef("custom.tekton.dev/v0", "PRCommenter"),
 			Handler:    controller.HandleAll(impl.Enqueue),
-		})
+		}); err != nil {
+			panic(err)
+		}
 
 		return impl
 	}

--- a/tekton/ci/custom-tasks/pr-status-updater/cmd/pr-status-updater/main.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/cmd/pr-status-updater/main.go
@@ -1,3 +1,4 @@
+// Package main is the entrypoint for the PR status updater custom task.
 package main
 
 import (

--- a/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/controller.go
+++ b/tekton/ci/custom-tasks/pr-status-updater/pkg/reconciler/controller.go
@@ -1,3 +1,4 @@
+// Package reconciler contains the reconciler for the PR status updater custom task.
 package reconciler
 
 import (
@@ -19,22 +20,24 @@ const (
 
 // NewController instantiates a new controller
 func NewController(scmClient *scm.Client, botUser string) func(context.Context, configmap.Watcher) *controller.Impl {
-	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		r := &Reconciler{
 			SCMClient: scmClient,
 			BotUser:   botUser,
 		}
 
-		impl := runreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		impl := runreconciler.NewImpl(ctx, r, func(_ *controller.Impl) controller.Options {
 			return controller.Options{
 				AgentName: ControllerName,
 			}
 		})
 
-		runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		if _, err := runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: tkncontroller.FilterCustomRunRef("custom.tekton.dev/v0", "PRStatusUpdater"),
 			Handler:    controller.HandleAll(impl.Enqueue),
-		})
+		}); err != nil {
+			panic(err)
+		}
 
 		return impl
 	}

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -59,8 +59,8 @@ func makeAddPRBodyHandler(urlFetcherDecoder urlToMap, token string) http.Handler
 
 		// Get the payload
 		if r.Body != nil {
-			defer r.Body.Close()
-			payload, err = ioutil.ReadAll(r.Body)
+			defer r.Body.Close() //nolint:errcheck
+			payload, err = io.ReadAll(r.Body)
 			if err != nil {
 				log.Printf("failed to read request body: %q", err)
 				marshalError(err, w)
@@ -184,8 +184,8 @@ func getPrBody(prUrl string, token string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main_test.go
+++ b/tekton/ci/interceptors/add-pr-body/cmd/add-pr-body/main_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -166,8 +166,8 @@ func assertResponseStatus(t *testing.T, resp *http.Response, want int) {
 
 func assertResponsePayload(t *testing.T, resp *http.Response, v interface{}, opts ...cmp.Option) {
 	t.Helper()
-	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main.go
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -61,8 +61,8 @@ func makeAddTeamMembersHandler(orgMembersFetcher, teamMembersFetcher urlToList, 
 
 		// Get the payload
 		if r.Body != nil {
-			defer r.Body.Close()
-			payload, err = ioutil.ReadAll(r.Body)
+			defer r.Body.Close() //nolint:errcheck
+			payload, err = io.ReadAll(r.Body)
 			if err != nil {
 				log.Printf("failed to read request body: %q", err)
 				marshalError(err, w)
@@ -247,14 +247,14 @@ func fetchMembers(membersUrl, token string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 	decodedBody, err := decodeListBody(body)
 	if err != nil {
-		return nil, fmt.Errorf("Error decoding body %v to a list: %q", string(body[:]), err)
+		return nil, fmt.Errorf("error decoding body %v to a list: %q", string(body[:]), err)
 	}
 
 	members := []string{}

--- a/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main_test.go
+++ b/tekton/ci/interceptors/add-team-members/cmd/add-team-members/main_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -192,8 +192,8 @@ func assertResponseStatus(t *testing.T, resp *http.Response, want int) {
 
 func assertResponsePayload(t *testing.T, resp *http.Response, v interface{}, opts ...cmp.Option) {
 	t.Helper()
-	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tekton/ci/interceptors/github/main.go
+++ b/tekton/ci/interceptors/github/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 
@@ -20,12 +20,12 @@ func main() {
 	var webhookSecret []byte
 	if *webhookSecretPath != "" {
 		var err error
-		webhookSecret, err = ioutil.ReadFile(*webhookSecretPath)
+		webhookSecret, err = os.ReadFile(*webhookSecretPath)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 	s := github.New(http.DefaultClient, bytes.TrimSpace(webhookSecret))
 
-	http.ListenAndServe(":8080", s)
+	log.Fatal(http.ListenAndServe(":8080", s))
 }

--- a/tekton/ci/interceptors/github/pkg/github/issue_comment_test.go
+++ b/tekton/ci/interceptors/github/pkg/github/issue_comment_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -36,7 +36,7 @@ func TestExecute_IssueComment(t *testing.T) {
 	client := github.NewClient(srv.Client())
 	client.BaseURL = mustParseURL(srv.URL + "/")
 	mux.HandleFunc("/repos/tektoncd/results/contents/OWNERS", func(rw http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(rw).Encode(map[string]string{
+		_ = json.NewEncoder(rw).Encode(map[string]string{
 			"type":    "file",
 			"content": ownersFile,
 		})
@@ -59,10 +59,10 @@ func TestExecute_IssueComment(t *testing.T) {
 		},
 	}
 	mux.HandleFunc("/repos/tektoncd/results/pulls/1", func(rw http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(rw).Encode(pr)
+		_ = json.NewEncoder(rw).Encode(pr)
 	})
 
-	f, err := ioutil.ReadFile("testdata/issue_comment.json")
+	f, err := os.ReadFile("testdata/issue_comment.json")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tekton/ci/interceptors/github/pkg/github/pull_request_test.go
+++ b/tekton/ci/interceptors/github/pkg/github/pull_request_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"log"
 	"testing"
 
@@ -18,7 +18,7 @@ func TestExecute_PullRequest(t *testing.T) {
 	ctx := context.Background()
 	h := &PullRequest{}
 
-	f, err := ioutil.ReadFile("testdata/pull_request.json")
+	f, err := os.ReadFile("testdata/pull_request.json")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tekton/ci/interceptors/github/pkg/github/push_test.go
+++ b/tekton/ci/interceptors/github/pkg/github/push_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +27,7 @@ func TestExecute_Push(t *testing.T) {
 	ctx := context.Background()
 	h := &Push{}
 
-	f, err := ioutil.ReadFile("testdata/push.json")
+	f, err := os.ReadFile("testdata/push.json")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tekton/ci/interceptors/github/pkg/github/server.go
+++ b/tekton/ci/interceptors/github/pkg/github/server.go
@@ -59,7 +59,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(rw).Encode(resp); err != nil {
 		fmt.Println(err)
 		rw.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(rw, "error writing response:", err)
+		fmt.Fprint(rw, "error writing response:", err) //nolint:errcheck // best-effort error response
 		return
 	}
 }

--- a/tekton/ci/interceptors/github/pkg/github/server_test.go
+++ b/tekton/ci/interceptors/github/pkg/github/server_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +23,7 @@ func TestServer(t *testing.T) {
 	srv := httptest.NewServer(New(http.DefaultClient, webhookSecret))
 	defer srv.Close()
 
-	f, err := ioutil.ReadFile("testdata/push.json")
+	f, err := os.ReadFile("testdata/push.json")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# Changes

Fix all pre-existing lint errors reported by golangci-lint across all Go modules:

- **errcheck**: Check error return values for `http.ListenAndServe`, `json.Encode`, `fmt.Fprint`, `Body.Close`, `writer.Write`, `f.Close`, `AddEventHandler`
- **staticcheck (SA1019)**: Replace deprecated `io/ioutil` with `os` and `io` packages
- **staticcheck (ST1005)**: Use lowercase error strings per Go conventions
- **staticcheck (S1024)**: Use `time.Until` instead of `t.Sub(time.Now())`
- **revive (package-comments)**: Add package comments
- **revive (unused-parameter)**: Rename unused parameters to `_`
- **unused**: Remove unused types and functions

Affected modules:
- `bots/buildcaptain`
- `bots/mariobot`
- `pipelinerun-logs`
- `tekton/ci/cluster-interceptors/add-pr-body`
- `tekton/ci/custom-tasks/pr-commenter`
- `tekton/ci/custom-tasks/pr-status-updater`
- `tekton/ci/interceptors/add-pr-body`
- `tekton/ci/interceptors/add-team-members`
- `tekton/ci/interceptors/github`

All modules pass `golangci-lint run` and `go test ./...` after these changes.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._