### PR TITLE
Add release ServiceAccount and RBAC for PAC release namespaces

### DIFF
--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ingress.yaml
 - repositories/pipeline.yaml
 - repositories/operator.yaml
+- release-rbac.yaml
 - repositories/cli.yaml
 patches:
 - path: pipelines-as-code-configmap.yaml

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
@@ -1,0 +1,99 @@
+# ServiceAccount and RBAC for PAC-triggered release pipelines.
+# The wait-for-chains task needs to list/get TaskRuns to check
+# Tekton Chains signing status on publish-images tasks.
+
+# --- releases-operator ---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release
+  namespace: releases-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-chain-watcher
+  namespace: releases-operator
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["taskruns"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-chain-watcher
+  namespace: releases-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-chain-watcher
+subjects:
+- kind: ServiceAccount
+  name: release
+  namespace: releases-operator
+
+# --- releases-pipeline ---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release
+  namespace: releases-pipeline
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-chain-watcher
+  namespace: releases-pipeline
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["taskruns"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-chain-watcher
+  namespace: releases-pipeline
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-chain-watcher
+subjects:
+- kind: ServiceAccount
+  name: release
+  namespace: releases-pipeline
+
+# --- releases-cli ---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release
+  namespace: releases-cli
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-chain-watcher
+  namespace: releases-cli
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["taskruns"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-chain-watcher
+  namespace: releases-cli
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-chain-watcher
+subjects:
+- kind: ServiceAccount
+  name: release
+  namespace: releases-cli


### PR DESCRIPTION
# Changes

Add a dedicated `release` ServiceAccount in each `releases-*` namespace
(`releases-operator`, `releases-pipeline`, `releases-cli`) with RBAC
permissions to get/list TaskRuns.

The `wait-for-chains` task in PAC-triggered release pipelines needs to
query TaskRuns to check Tekton Chains signing status on `publish-images`
tasks. Without this, the task runs as the `default` SA which lacks
permissions, causing it to return `signed="error"` and skipping the
`create-draft-release` task entirely.

Companion PRs to use this SA:
- tektoncd/operator — pending
- tektoncd/pipeline — PR #9671 (will need update)
- tektoncd/cli — PR #2795 (will need update)

/kind feature

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)