### PR TITLE
fix(prow): update prow command help url

### DIFF
--- a/prow/control-plane/plugins.yaml
+++ b/prow/control-plane/plugins.yaml
@@ -18,7 +18,7 @@ approve:
   - tektoncd-catalog
   require_self_approval: true
   ignore_review_state: false
-  commandHelpLink: https://prow.tekton.dev/command-help
+  commandHelpLink: https://prow.infra.tekton.dev/command-help
 
 plugins:
   tektoncd:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the link used in Prow's command help comment to point to `prow.infra.tekton.dev` instead of `prow.tekton.dev`

There are a few other instances of `prow.tekton.dev` but this is the only instance I've confirmed is incorrect. I've confirmed `prow.tekton.dev` is still accepting connections so it's unclear to me if/where it is still the right URL.

1. In [the Prow docs' Ingress section](https://github.com/tektoncd/plumbing/blob/fix-prow-links/docs/prow.md#L106), it's states the below. I think this needs to be updated to be `-f prow/control-plane/ingress.yaml` and also it appears the ingress is configured to `prow.infra.tekton.dev`, but I need confirmation.
```bash
# Apply the ingress resource, configured to use `prow.tekton.dev`
kubectl apply -f prow/ingress.yaml
```
2. The same docs also state "Then you can update https://prow.tekton.dev to point at the Cluster ingress address.", which I think is likely incorrect as well
3. Lastly, the [Deck deployment](https://github.com/tektoncd/plumbing/blob/fix-prow-links/prow/control-plane/prow.yaml#L271) uses the arg `--redirect-http-to=prow.tekton.dev`. I can't find documentation on this arg and `http://prow.infra.tekton` redirects to `https://prow.infra.tekton.dev` so I'm not sure how this is used or if it is incorrect


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._