### PR TITLE
Fix docker daemon startup issue in ppc64le nightly Dashboard tests

### DIFF
--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Tekton Authors
+# Copyright 2021-2026 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -178,12 +178,16 @@ spec:
               volumeMounts:
               - mountPath: /certs/client
                 name: dind-certs
+              - mountPath: /var/lib/docker
+                name: dind-storage
               readinessProbe:
                 periodSeconds: 1
                 exec:
                   command: ['ls', '/certs/client/ca.pem']
             volumes:
             - name: dind-certs
+              emptyDir: {}
+            - name: dind-storage
               emptyDir: {}
           params:
           - name: container-registry


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Docker daemon in the sidecar was failing to start with error:
> failed to mount overlay: invalid argument" storage-driver=overlay2

Add emptyDir mount for `/var/lib/docker` to resolve this. Another alternative considered was changing the storage driver to `vfs` but this is not as performant.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._