### PR TITLE
feat: add PAC Repository CR for tektoncd/chains

### DIFF
--- a/tekton/cd/dashboard/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/dashboard/overlays/oci-ci-cd/kustomization.yaml
@@ -21,7 +21,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/args/5
-      value: --namespaces=tekton-ci,tekton-nightly,bastion-p,bastion-z,releases-pipeline,releases-operator,releases-pruner
+      value: --namespaces=tekton-ci,tekton-nightly,bastion-p,bastion-z,releases-pipeline,releases-operator,releases-pruner,releases-chains
 - patch: |-
     $patch: delete
     apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/cd/dashboard/overlays/oci-ci-cd/namespaced-rolebindings.yaml
+++ b/tekton/cd/dashboard/overlays/oci-ci-cd/namespaced-rolebindings.yaml
@@ -433,6 +433,78 @@ subjects:
   name: tekton-dashboard
   namespace: tekton-pipelines
 
+# releases-chains namespace (Pipelines-as-Code releases)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-tenant-view-restricted
+  namespace: releases-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-tenant-view-restricted
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-backend-view
+  namespace: releases-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-backend-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-triggers-view
+  namespace: releases-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-aggregate-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-cronjobs-extension
+  namespace: releases-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-cronjobs-extension
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-dashboard-pipelines-view
+  namespace: releases-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-aggregate-view
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+
 # releases-pruner namespace (Pipelines-as-Code releases)
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 - release-rbac.yaml
 - repositories/cli.yaml
 - repositories/pruner.yaml
+- repositories/chains.yaml
 patches:
 - path: pipelines-as-code-configmap.yaml

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
@@ -129,3 +129,35 @@ subjects:
 - kind: ServiceAccount
   name: release
   namespace: releases-pruner
+
+# --- releases-chains ---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release
+  namespace: releases-chains
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-chain-watcher
+  namespace: releases-chains
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["taskruns"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-chain-watcher
+  namespace: releases-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-chain-watcher
+subjects:
+- kind: ServiceAccount
+  name: release
+  namespace: releases-chains

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/chains.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/chains.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Repository CR for tektoncd/chains.
+# PAC matches incoming events (push, incoming webhook) to PipelineRuns
+# defined in the repository's .tekton/ directory.
+# PipelineRuns are executed in the releases-chains namespace.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: releases-chains
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: tektoncd-chains
+  namespace: releases-chains
+spec:
+  url: "https://github.com/tektoncd/chains"
+  settings:
+    # Fetch .tekton/ from the default branch (main), not from the PR branch.
+    # This prevents PR authors from modifying release pipelines — only merged
+    # changes to main take effect.
+    pipelinerun_provenance: "default_branch"
+    policy:
+      # Only chains maintainers and plumbing maintainers can approve
+      # external PRs with /ok-to-test
+      ok_to_test:
+        - chains-maintainers
+        - plumbing-maintainers
+      # Only chains maintainers can trigger CI on their own PRs
+      pull_request:
+        - chains-maintainers
+  incoming:
+    # Patch releases — triggered by .github/workflows/patch-release.yaml
+    - targets:
+        - "release-v*"
+      secret:
+        name: pac-incoming-secret
+      type: webhook-url
+      params:
+        - version
+        - release_as_latest
+    # Nightly builds — triggered by .github/workflows/nightly-builds.yaml
+    - targets:
+        - "main"
+      secret:
+        name: pac-incoming-secret
+      type: webhook-url
+      params:
+        - version_tag


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add Pipelines-as-Code Repository CR for `tektoncd/chains` with:
  - `releases-chains` namespace for PipelineRun execution
  - Release ServiceAccount and RBAC for Tekton Chains signing checks
  - Incoming webhook configuration for patch releases (`release-v*` branches)
  - Dashboard namespace allowlist and RBAC rolebindings

  This enables PAC to run release PipelineRuns defined in `tektoncd/chains`'s  `.tekton/` directory.
  
  Part-of: #58
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!


In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._