### PR TITLE
fix: fully-qualify postgres image for Results on OKE/CRI-O

### DIFF
--- a/tekton/cd/results/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/results/overlays/oci-ci-cd/kustomization.yaml
@@ -6,3 +6,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
 - path: service.yaml
+- path: patch-postgres-image.yaml

--- a/tekton/cd/results/overlays/oci-ci-cd/patch-postgres-image.yaml
+++ b/tekton/cd/results/overlays/oci-ci-cd/patch-postgres-image.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tekton-results-postgres
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+        - name: postgres
+          image: docker.io/bitnami/postgresql@sha256:ac8dd0d6512c4c5fb146c16b1c5f05862bd5f600d73348506ab4252587e7fcc6


### PR DESCRIPTION
# Changes

CRI-O with short name enforcement on the OKE dogfooding cluster rejects
bare `bitnami/postgresql` images with `ImageInspectError`. This adds a
kustomize patch in the OCI overlay to use the fully-qualified
`docker.io/bitnami/postgresql` image reference.

The `tekton-results-postgres` StatefulSet (and consequently the API,
watcher, and retention-policy-agent) has been broken for ~19 days
because of this.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)