### PR TITLE
chore: add tekton.dev/auto-cleanup-pvc annotation to all PipelineRun templates

### DIFF
--- a/tekton/ci/repos/catalog/base/template.yaml
+++ b/tekton/ci/repos/catalog/base/template.yaml
@@ -13,6 +13,7 @@
         annotations:
           tekton.dev/gitRevision: "$(tt.params.gitRevision)"
           tekton.dev/gitURL: "$(tt.params.gitRepository)"
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         serviceAccountName: tekton-ci-jobs
         pipelineRef:

--- a/tekton/ci/repos/community/template.yaml
+++ b/tekton/ci/repos/community/template.yaml
@@ -14,6 +14,7 @@
       annotations:
         tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       serviceAccountName: tekton-ci-jobs
       workspaces:
@@ -57,6 +58,7 @@
       annotations:
         tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       serviceAccountName: tekton-ci-jobs
       workspaces:

--- a/tekton/ci/repos/shared/doc-reviews/template.yaml
+++ b/tekton/ci/repos/shared/doc-reviews/template.yaml
@@ -15,6 +15,7 @@
       annotations:
         tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       serviceAccountName: tekton-ci-jobs
       timeout: 10m

--- a/tekton/ci/repos/website/template.yaml
+++ b/tekton/ci/repos/website/template.yaml
@@ -14,6 +14,7 @@
       annotations:
         tekton.dev/gitRevision: "$(tt.params.gitRevision)"
         tekton.dev/gitURL: "$(tt.params.gitRepository)"
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       serviceAccountName: tekton-ci-jobs
       workspaces:

--- a/tekton/mario-bot/mario-github-comment.yaml
+++ b/tekton/mario-bot/mario-github-comment.yaml
@@ -51,6 +51,8 @@ spec:
     kind: PipelineRun
     metadata:
       generateName: mario-comment-github-
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineSpec:
         tasks:

--- a/tekton/mario-bot/mario-image-build-trigger.yaml
+++ b/tekton/mario-bot/mario-image-build-trigger.yaml
@@ -148,6 +148,8 @@ spec:
       generateName: build-and-push-
       labels:
         mario.bot/pull-request-id: $(tt.params.pullRequestID)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       serviceAccountName: mario-releaser
       pipelineSpec:

--- a/tekton/resources/cd/configmap-template.yaml
+++ b/tekton/resources/cd/configmap-template.yaml
@@ -169,6 +169,8 @@ spec:
     kind: PipelineRun
     metadata:
       generateName: deploy-configmap-$(tt.params.configMapDescription)-
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: deploy-configmap

--- a/tekton/resources/cd/folder-template.yaml
+++ b/tekton/resources/cd/folder-template.yaml
@@ -215,6 +215,8 @@ spec:
     kind: PipelineRun
     metadata:
       generateName: deploy-resources-$(tt.params.folderDescription)-
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: deploy-from-folder

--- a/tekton/resources/cd/peribolos-template.yaml
+++ b/tekton/resources/cd/peribolos-template.yaml
@@ -13,6 +13,8 @@ spec:
       kind: PipelineRun
       metadata:
         generateName: peribolos-run-
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           name: peribolos-sync  # Defined in the org-permissions folder

--- a/tekton/resources/cd/tekton-template.yaml
+++ b/tekton/resources/cd/tekton-template.yaml
@@ -48,6 +48,8 @@ spec:
     kind: PipelineRun
     metadata:
       generateName: deploy-$(tt.params.tektonProject)-release-$(tt.params.targetCluster)-
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: install-tekton-release

--- a/tekton/resources/cd/terraform-branch-protection-template.yaml
+++ b/tekton/resources/cd/terraform-branch-protection-template.yaml
@@ -33,6 +33,8 @@ spec:
       labels:
         tekton.dev/pipeline: terraform-branch-protection-sync
         pipelinesascode.tekton.dev/event-type: push
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: terraform-branch-protection-sync

--- a/tekton/resources/images/docker-multi-arch-template.yaml
+++ b/tekton/resources/images/docker-multi-arch-template.yaml
@@ -163,6 +163,8 @@ spec:
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         plumbing.tekton.dev/image: $(tt.params.imageName)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: docker-multi-arch-build-and-push

--- a/tekton/resources/images/ko-multi-arch-template.yaml
+++ b/tekton/resources/images/ko-multi-arch-template.yaml
@@ -114,6 +114,8 @@ spec:
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         plumbing.tekton.dev/image: $(tt.params.imageName)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: ko-multi-arch-build-and-push

--- a/tekton/resources/images/single-arch-template.yaml
+++ b/tekton/resources/images/single-arch-template.yaml
@@ -118,6 +118,8 @@ spec:
       labels:
         prow.k8s.io/build-id: $(tt.params.buildUUID)
         plumbing.tekton.dev/image: $(tt.params.imageName)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       pipelineRef:
         name: single-arch-build-and-push

--- a/tekton/resources/nightly-release/overlays/add-pr-body-ci/template.yaml
+++ b/tekton/resources/nightly-release/overlays/add-pr-body-ci/template.yaml
@@ -7,6 +7,8 @@
         generateName: add-pr-body-ci-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           resolver: git

--- a/tekton/resources/nightly-release/overlays/add-team-members/template.yaml
+++ b/tekton/resources/nightly-release/overlays/add-team-members/template.yaml
@@ -7,6 +7,8 @@
         generateName: add-team-members-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           resolver: git

--- a/tekton/resources/nightly-release/overlays/build-id-ci/template.yaml
+++ b/tekton/resources/nightly-release/overlays/build-id-ci/template.yaml
@@ -7,6 +7,8 @@
         generateName: build-id-ci-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           resolver: git

--- a/tekton/resources/nightly-release/overlays/chains/template.yaml
+++ b/tekton/resources/nightly-release/overlays/chains/template.yaml
@@ -7,6 +7,8 @@
         generateName: chains-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           name: chains-release

--- a/tekton/resources/nightly-release/overlays/dashboard/template.yaml
+++ b/tekton/resources/nightly-release/overlays/dashboard/template.yaml
@@ -7,6 +7,8 @@
         generateName: dashboard-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         timeouts:
           pipeline: "1h30m"

--- a/tekton/resources/nightly-release/overlays/operator/template.yaml
+++ b/tekton/resources/nightly-release/overlays/operator/template.yaml
@@ -7,6 +7,8 @@
         generateName: operator-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           name: operator-release

--- a/tekton/resources/nightly-release/overlays/pipeline/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pipeline/template.yaml
@@ -7,6 +7,8 @@
         generateName: pipeline-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           name: pipeline-release

--- a/tekton/resources/nightly-release/overlays/pr-commenter/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pr-commenter/template.yaml
@@ -7,6 +7,8 @@
         generateName: pr-commenter-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           resolver: git

--- a/tekton/resources/nightly-release/overlays/pr-status-updater/template.yaml
+++ b/tekton/resources/nightly-release/overlays/pr-status-updater/template.yaml
@@ -7,6 +7,8 @@
         generateName: pr-status-updater-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           resolver: git

--- a/tekton/resources/nightly-release/overlays/triggers/template.yaml
+++ b/tekton/resources/nightly-release/overlays/triggers/template.yaml
@@ -7,6 +7,8 @@
         generateName: triggers-release-nightly-
         labels:
           tekton.dev/kind: release
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           name: triggers-release

--- a/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-ppc64le-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-catalog-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 3h
       workspaces:

--- a/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/catalog-deploy-test-s390x-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-catalog-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 2h
       workspaces:

--- a/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-ppc64le-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-cli-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 3h
       workspaces:

--- a/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/cli-deploy-test-s390x-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-cli-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 2h
       workspaces:

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-ppc64le-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-dashboard-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 3h
       workspaces:

--- a/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/dashboard-deploy-test-s390x-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-dashboard-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 2h
       workspaces:

--- a/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-ppc64le-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-operator-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 3h
       workspaces:

--- a/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/operator-deploy-test-s390x-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-operator-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 2h
       workspaces:

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-ppc64le-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 3h
       workspaces:

--- a/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/pipeline-deploy-test-s390x-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-pipeline-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 2h
       workspaces:

--- a/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-ppc64le-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-triggers-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 3h
       workspaces:

--- a/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
+++ b/tekton/resources/nightly-tests/triggers-deploy-test-s390x-template.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       generateName: tekton-triggers-$(tt.params.targetArch)-nightly-run-
       namespace: $(tt.params.namespace)
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       timeout: 2h
       workspaces:

--- a/tekton/resources/org-permissions/peribolos-run.yaml
+++ b/tekton/resources/org-permissions/peribolos-run.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   generateName: peribolos-run-
+  annotations:
+    tekton.dev/auto-cleanup-pvc: "true"
 spec:
   pipelineRef:
     name: peribolos-sync

--- a/tekton/resources/org-permissions/peribolos-trigger.yaml
+++ b/tekton/resources/org-permissions/peribolos-trigger.yaml
@@ -25,6 +25,8 @@ spec:
       kind: PipelineRun
       metadata:
         generateName: peribolos-run-
+        annotations:
+          tekton.dev/auto-cleanup-pvc: "true"
       spec:
         pipelineRef:
           name: peribolos-sync

--- a/tekton/resources/release/release-logs/release-logs-triggers.yaml
+++ b/tekton/resources/release/release-logs/release-logs-triggers.yaml
@@ -96,6 +96,8 @@ spec:
     kind: PipelineRun
     metadata:
       generateName: save-release-logs-
+      annotations:
+        tekton.dev/auto-cleanup-pvc: "true"
     spec:
       serviceAccountName: tekton-logs
       pipelineRef:


### PR DESCRIPTION
# Changes

Add the `tekton.dev/auto-cleanup-pvc: "true"` annotation to all 39
TriggerTemplate and PipelineRun files that use `volumeClaimTemplate`
workspaces.

This annotation (available since Tekton Pipelines v1.12.0, which is
deployed on the dogfooding cluster) ensures PVCs are automatically
deleted on PipelineRun completion instead of accumulating until the
pruner eventually deletes the PipelineRun.

On OCI/OKE, every `volumeClaimTemplate` workspace creates a **50 GiB**
block volume (OCI minimum), regardless of the requested size. The
dogfooding cluster currently has 220 PVCs (215 orphaned) consuming
significant block storage.

**Note:** PAC-based PipelineRuns in other repos (e.g.,
`tektoncd/operator/.tekton/`) also use `volumeClaimTemplate` but are not
controlled by plumbing TriggerTemplates. Those repos need the annotation
added in their respective `.tekton/` directories separately.

Closes #3377

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)