### PR TITLE
fix: link ghcr-chains-auth secret to release ServiceAccounts

### DIFF
--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
@@ -9,6 +9,8 @@ kind: ServiceAccount
 metadata:
   name: release
   namespace: releases-operator
+secrets:
+- name: ghcr-chains-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -41,6 +43,8 @@ kind: ServiceAccount
 metadata:
   name: release
   namespace: releases-pipeline
+secrets:
+- name: ghcr-chains-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -73,6 +77,8 @@ kind: ServiceAccount
 metadata:
   name: release
   namespace: releases-cli
+secrets:
+- name: ghcr-chains-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -105,6 +111,8 @@ kind: ServiceAccount
 metadata:
   name: release
   namespace: releases-pruner
+secrets:
+- name: ghcr-chains-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -137,6 +145,8 @@ kind: ServiceAccount
 metadata:
   name: release
   namespace: releases-chains
+secrets:
+- name: ghcr-chains-auth
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
# Changes

Tekton Chains reads OCI registry credentials from the TaskRun's
ServiceAccount secrets. The `release` ServiceAccounts in all release
namespaces were missing the `ghcr-chains-auth` secret reference,
causing Chains to fail with `UNAUTHORIZED` errors when pushing
signature blobs to `ghcr.io`.

This adds `secrets: [{name: ghcr-chains-auth}]` to all five release
SAs: operator, pipeline, cli, pruner, and chains.

**Error observed** (reported by @AlanGreene in `releases-pruner`):
```
POST https://ghcr.io/v2/tektoncd/pruner/controller-.../blobs/uploads/:
UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
```

**Note:** The `ghcr-chains-auth` secret must also exist in each namespace.
Currently present in: `releases-pruner`, `releases-pipeline`, `releases-cli`.
Missing from: `releases-operator`, `releases-chains` — to be added via
tektoncd/infra terraform (`ghcr_chains_auth_namespaces`).

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)