### PR TITLE
Add branch protection for tektoncd-catalog repos

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -50,3 +50,15 @@ repos:
     - "CI summary"
   triggers:
     - "CI summary"
+
+# tektoncd-catalog org repos
+# Full list of required checks per repo (no shared base_checks,
+# since not all catalog repos use Prow/Tide).
+catalog_repos:
+  golang:
+    - "EasyCLA"
+    - "tide"
+    - "CI summary"
+  git-clone:
+    - "EasyCLA"
+    - "CI summary"

--- a/terraform/branch-protection/locals.tf
+++ b/terraform/branch-protection/locals.tf
@@ -36,4 +36,10 @@ locals {
       lookup(local.repo_specific_checks, repo, [])
     )
   }
+
+  # tektoncd-catalog org repos
+  # Each repo defines its full list of required checks (no shared base_checks,
+  # since not all catalog repos use Prow/Tide).
+  catalog_repos_config = try(local.repo_checks.catalog_repos, {})
+  catalog_repos        = keys(local.catalog_repos_config)
 }

--- a/terraform/branch-protection/main.tf
+++ b/terraform/branch-protection/main.tf
@@ -72,3 +72,24 @@ resource "github_branch_protection" "releases" {
     required_approving_review_count = var.required_approving_review_count_releases
   }
 }
+
+# Main branch protection for tektoncd-catalog repositories
+resource "github_branch_protection" "catalog_main" {
+  provider = github.catalog
+  for_each = toset(local.catalog_repos)
+
+  repository_id = each.key
+  pattern       = "main"
+
+  enforce_admins                  = var.enforce_admins
+  require_signed_commits          = var.require_signed_commits
+  required_linear_history         = var.required_linear_history
+  allows_deletions                = var.allow_deletions
+  allows_force_pushes             = var.allow_force_pushes
+  require_conversation_resolution = var.require_conversation_resolution
+
+  required_status_checks {
+    strict   = false
+    contexts = local.catalog_repos_config[each.key]
+  }
+}

--- a/terraform/branch-protection/outputs.tf
+++ b/terraform/branch-protection/outputs.tf
@@ -32,3 +32,16 @@ output "release_branch_protections" {
     repo => github_branch_protection.releases[repo].id
   }
 }
+
+output "catalog_protected_repos" {
+  description = "List of tektoncd-catalog repositories with branch protection applied"
+  value       = local.catalog_repos
+}
+
+output "catalog_main_branch_protections" {
+  description = "tektoncd-catalog main branch protection resource IDs"
+  value = {
+    for repo in local.catalog_repos :
+    repo => github_branch_protection.catalog_main[repo].id
+  }
+}

--- a/terraform/branch-protection/versions.tf
+++ b/terraform/branch-protection/versions.tf
@@ -36,3 +36,8 @@ terraform {
 provider "github" {
   owner = "tektoncd"
 }
+
+provider "github" {
+  alias = "catalog"
+  owner = "tektoncd-catalog"
+}


### PR DESCRIPTION
# Changes

Add branch protection rules for `tektoncd-catalog/golang` and
`tektoncd-catalog/git-clone` repositories via Terraform.

- **golang**: requires `EasyCLA`, `tide`, and `CI summary` checks
- **git-clone**: requires `EasyCLA` and `CI summary` checks (no tide/prow)

A second GitHub provider alias (`github.catalog`) is added to manage
resources in the `tektoncd-catalog` org separately from `tektoncd`.

Each catalog repo defines its full list of required checks (no shared
`base_checks`), since not all catalog repos use Prow/Tide.

**Note:** The Terraform automation's GitHub token needs access to the
`tektoncd-catalog` org for this to work.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._