### PR TITLE
results: temporarily disable on dogfooding cluster

### DIFF
--- a/tekton/cd/results/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/results/overlays/oci-ci-cd/kustomization.yaml
@@ -7,3 +7,5 @@ kind: Kustomization
 patches:
 - path: service.yaml
 - path: patch-postgres-image.yaml
+# TEMPORARY: Results is broken (postgres image gone), disable it. See patch header.
+- path: patch-disable-results.yaml

--- a/tekton/cd/results/overlays/oci-ci-cd/patch-disable-results.yaml
+++ b/tekton/cd/results/overlays/oci-ci-cd/patch-disable-results.yaml
@@ -1,0 +1,48 @@
+# TEMPORARY: Tekton Results is disabled on the dogfooding cluster.
+#
+# The upstream postgres image (docker.io/bitnami/postgresql) is no longer
+# pullable since Bitnami deprecated their free Docker Hub catalog, so the
+# results-postgres StatefulSet is stuck in ImageInspectError and the api,
+# watcher and retention-policy-agent are in CrashLoopBackOff.
+#
+# While broken, the watcher could re-add the results.tekton.dev/pipelinerun
+# finalizer to PipelineRuns without ever removing it, leaving them stuck in
+# Terminating forever (which previously caused a large PipelineRun/PVC pileup).
+#
+# Scaling everything to 0 stops the crashloops and prevents the finalizer
+# pileup. Manifests and the postgres PVC are kept intact so this is a trivial
+# revert once Results is fixed (see tracking issue).
+#
+# TODO(results): remove this patch once the postgres image / Results deployment
+# is fixed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api
+  namespace: tekton-pipelines
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-watcher
+  namespace: tekton-pipelines
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-retention-policy-agent
+  namespace: tekton-pipelines
+spec:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tekton-results-postgres
+  namespace: tekton-pipelines
+spec:
+  replicas: 0


### PR DESCRIPTION
## What

Temporarily disable Tekton Results on the `oci-ci-cd` dogfooding cluster by scaling all its workloads (api, watcher, retention-policy-agent, postgres) to `replicas: 0` via a kustomize patch.

## Why

Results has been broken for 45+ days (see #3427):

- `tekton-results-postgres-0` is in `ImageInspectError` — the pinned `docker.io/bitnami/postgresql` image is no longer pullable since Bitnami deprecated their free Docker Hub catalog.
- api / watcher / retention-policy-agent are all in `CrashLoopBackOff` (no DB).
- While broken, the watcher leaves the `results.tekton.dev/pipelinerun` finalizer on PipelineRuns without removing it, trapping completed runs in `Terminating` forever. This caused a large PipelineRun/PVC pileup (~33 stuck runs since February, ~1.5 TB of orphaned PVCs cleaned up on 2026-06-08).

## How

A new `patch-disable-results.yaml` sets `replicas: 0` on the three Deployments and the postgres StatefulSet. Manifests and the postgres PVC are kept intact, so re-enabling later is a trivial revert of this patch.

```
Deployment  tekton-results-api                     replicas=0
Deployment  tekton-results-retention-policy-agent  replicas=0
Deployment  tekton-results-watcher                 replicas=0
StatefulSet tekton-results-postgres                replicas=0
```

Verified with `kubectl kustomize tekton/cd/results/overlays/oci-ci-cd`.

## Follow-up

Proper fix tracked in #3427: replace the unavailable Bitnami postgres image (bitnamilegacy / official postgres / CloudNativePG), then revert this patch and verify the watcher removes finalizers cleanly.

Refs #3427