### PR TITLE
tide: require "CI summary" check for tektoncd/catalog

### DIFF
--- a/config/repo-checks.yaml
+++ b/config/repo-checks.yaml
@@ -30,6 +30,8 @@ base_checks:
   - "EasyCLA"
 
 repos:
+  catalog:
+    - "CI summary"
   chains:
     - "CI summary"
   cli:

--- a/prow/control-plane/config.yaml
+++ b/prow/control-plane/config.yaml
@@ -36,6 +36,9 @@ tide:
     orgs:
       tektoncd:
         repos:
+          catalog:
+            required-contexts:
+            - "CI summary"
           chains:
             required-contexts:
             - "CI summary"


### PR DESCRIPTION
# Changes

Add `catalog` to the shared `config/repo-checks.yaml` so Tide requires the new **CI summary** GitHub Actions check before merging PRs in `tektoncd/catalog`.

The catalog CI was recently migrated to a fan-out summary job (tektoncd/catalog#1378), matching the pattern already used by the other tektoncd repos (chains, cli, pipeline, operator, …). This makes **CI summary** a required context for Tide, so the per-matrix-leg checks (which change over time as pipeline versions are bumped) do not need to be enumerated.

The `prow/control-plane/config.yaml` `context_options` block was regenerated via `make generate-tide-contexts` (verified in sync with `make verify-tide-contexts`).

> [!NOTE]
> This should merge **after** tektoncd/catalog#1378 (the CI summary job) lands, so the required context actually exists.

/kind cleanup

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)