### PR TITLE
feat: set concurrency_limit on tektoncd/pipeline Repository CR

### DIFF
--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/pipeline.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/pipeline.yaml
@@ -28,6 +28,7 @@ metadata:
   name: tektoncd-pipeline
   namespace: releases-pipeline
 spec:
+  concurrency_limit: 2
   url: "https://github.com/tektoncd/pipeline"
   settings:
     # Fetch .tekton/ from the default branch (main), not from the PR branch.


### PR DESCRIPTION
# Changes

Set `concurrency_limit: 2` on the `tektoncd-pipeline` PAC Repository to prevent all release branches from building simultaneously.

Without this, the weekly patch-release cron triggers 7-8 concurrent multi-arch `ko` builds that exhaust `tekton-nodepool` node memory, causing kubelet hangs (see #3428).

With `concurrency_limit: 2`, PAC queues excess PipelineRuns and starts them as running ones complete.

Related: #3428

/kind feature

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)