### PR TITLE
chore: upgrade Tekton Pipelines to v1.13.1 on dogfooding

### DIFF
--- a/tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/tektoncd/pipeline/releases/download/v1.13.0/release.yaml
+- https://github.com/tektoncd/pipeline/releases/download/v1.13.1/release.yaml
 patches:
 - path: config-defaults.yaml
 - path: config-observability.yaml


### PR DESCRIPTION
# Changes

Upgrade Tekton Pipelines on the dogfooding cluster from v1.13.0 to v1.13.1.

Key fixes in v1.13.1:
- **Internal container resources are now opt-in** (tektoncd/pipeline#10169) — fixes the `prepare` init container OOM that was failing release PipelineRuns
- **Symlink fix in create-draft-release** (tektoncd/pipeline#10203)

Once deployed, the temporary `default-container-resource-requirements` override in the `config-defaults` ConfigMap can be removed (#3437).

Related: #3437

/kind cleanup

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)