### PR TITLE
fix: correct release-note rendering (markdown list + dropped first char)

### DIFF
--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -69,8 +69,8 @@ spec:
         # 🎉 [Tag Line - to be done] 🎉
         -->
 
-        -[Docs @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/docs)
-        -[Examples @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/examples)
+        - [Docs @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/docs)
+        - [Examples @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/examples)
 
         ## Installation one-liner
 

--- a/tekton/resources/release/base/github_release.yaml
+++ b/tekton/resources/release/base/github_release.yaml
@@ -171,7 +171,7 @@ spec:
         cat $HOME/pr-notes-tmp.csv | while read pr; do
           PR_NUM=$(echo $pr | cut -d';' -f2)
           PR_RELEASE_NOTES_B64=$(wget -O- https://api.github.com/repos/${PROJECT}/issues/${PR_NUM:1} | \
-            jq .body -r | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | \
+            jq .body -r | tr -d '\r' | awk '/^```release-note/{flag=1;next} /^```/{flag=0} flag' | \
             grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*' | base64 -w0)
           echo "$pr;$PR_RELEASE_NOTES_B64" >> $HOME/pr-notes.csv
           # Avoid rate limiting

--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -76,8 +76,8 @@ spec:
         # 🎉 [Tag Line - to be done] 🎉
         -->
 
-        -[Docs @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/docs)
-        -[Examples @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/examples)
+        - [Docs @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/docs)
+        - [Examples @ ${VERSION}](https://github.com/${PROJECT}/tree/${VERSION}/examples)
 
         ## Installation one-liner
 

--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -187,7 +187,7 @@ spec:
         cat $HOME/pr-notes-tmp.csv | while read pr; do
           PR_NUM=$(echo $pr | cut -d';' -f2)
           PR_RELEASE_NOTES_B64=$(curl -sL https://api.github.com/repos/${PROJECT}/issues/${PR_NUM:1} | \
-            jq .body -r | grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)' | \
+            jq .body -r | tr -d '\r' | awk '/^```release-note/{flag=1;next} /^```/{flag=0} flag' | \
             grep -avP '\W*(Your release note here|action required: your release note here|NONE)\W*' | base64 -w0)
           echo "$pr;$PR_RELEASE_NOTES_B64" >> $HOME/pr-notes.csv
           # Avoid rate limiting


### PR DESCRIPTION
# Changes

Two fixes to the generated draft release notes (`tekton/resources/release/base/github_release.yaml` and `github_release_oci.yaml`):

## 1. Docs/Examples not rendered as a list
The Docs and Examples links were written as `-[Docs @ ...]` / `-[Examples @ ...]` (no space after the dash), so they were not valid markdown list items and rendered as a run-on line. Added the missing space (`- [Docs @ ...]`).

## 2. First character of every release-note description dropped
The release-note extraction used a fixed-width lookbehind:

```
grep -oPz '(?s)(?<=```release-note..)(.+?)(?=```)'
```

The trailing `..` was intended to skip the line break after the fence assuming CRLF (`\r\n`). When the PR body uses LF line endings, `..` matches the newline **plus the first character** of the note, so descriptions rendered as "rrors ..." instead of "Errors ...", "ump ..." instead of "Bump ...", etc.

Replaced the brittle regex with an awk extraction that captures the lines strictly between the ```release-note fences after normalising line endings, preserving the full description regardless of CRLF/LF.

Both observed in the tektoncd/pipeline v1.14.0 draft release notes.

/kind bug

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)