### PR TITLE
pipeline: deploy v1.14.0 to the dogfooding cluster

### DIFF
--- a/tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/tektoncd/pipeline/releases/download/v1.13.1/release.yaml
+- https://github.com/tektoncd/pipeline/releases/download/v1.14.0/release.yaml
 patches:
 - path: config-defaults.yaml
 - path: config-observability.yaml


### PR DESCRIPTION
# Changes

Bump the OCI dogfooding overlay (`tekton/cd/pipeline/overlays/oci-ci-cd/kustomization.yaml`) from v1.13.1 to **v1.14.0**, following the [release cheat-sheet](https://github.com/tektoncd/pipeline/blob/main/tekton/release-cheat-sheet.md) post-release steps.

/kind misc

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)