### PR TITLE
change: add explicit secrets definition for workflow_call

### DIFF
--- a/.github/workflows/_chatops_retest.yml
+++ b/.github/workflows/_chatops_retest.yml
@@ -23,6 +23,10 @@
 name: Rerun Failed Actions
 on:
   workflow_call:
+    secrets:
+      CHATOPS_TOKEN:
+        description: 'The GitHub token used for chatops operations'
+        required: true
 
 jobs:
   retest:


### PR DESCRIPTION
# Changes

This PR explicitly defines the required secrets schema for the reusable `_chatops_retest.yml` workflow under the `on.workflow_call.secrets` configuration.

### Why this is needed
Currently, the workflow expects `secrets.CHATOPS_TOKEN` within its jobs but does not declare it as an input in the `workflow_call` trigger. This triggers security/audit validation warnings (such as from `zizmor`) regarding unrestricted secret inheritance (`secrets: inherit`) in calling repositories. Explicitly declaring the secret unblocks precise pass-through mapping from the calling side.

Cross-referencing: part of the hardening efforts to unblock tektoncd/dashboard#5071.

/kind cleanup

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)