### PR TITLE
Update slash command workflow with CHATOPS_TOKEN

### DIFF
--- a/.github/workflows/_slash.yml
+++ b/.github/workflows/_slash.yml
@@ -29,10 +29,13 @@
 # jobs:
 #   check_comments:
 #     uses: tektoncd/plumbing/.github/actions/_slash.yml@main
-
 name: Slash Command Routing
 on:
   workflow_call:
+    secrets:
+      CHATOPS_TOKEN:
+        description: 'The GitHub token used for chatops operations'
+        required: true
 
 jobs:
   check_comments:


### PR DESCRIPTION
# Changes

This PR explicitly defines the required secrets schema for the reusable `_slash.yml` workflow under the `on.workflow_call.secrets` configuration.

### Why this is needed
The workflow utilizes `secrets.CHATOPS_TOKEN` to authenticate the slash command dispatch steps, but did not formally declare it under its `workflow_call` interface. This omission triggers security and audit tool warnings (like `zizmor`) regarding unrestricted secret inheritance (`secrets: inherit`) in repositories using this infrastructure. Explicitly defining the input secret allows calling pipelines to map it directly and securely.

Cross-referencing: part of the hardening efforts to unblock tektoncd/dashboard#5071.

/kind cleanup

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)