### PR TITLE
fix: clean up GitHub release title and add optional draft param

### DIFF
--- a/tekton/resources/release/README.md
+++ b/tekton/resources/release/README.md
@@ -55,6 +55,15 @@ a release tag line.
 Parameters are: `package`, `release-name`, `release-tag`, `previous-release-tag`
 , `git-revision`, `bucket` and `rekor-uuid`.
 
+The OCI variant ([release-draft-oci](./base/github_release_oci.yaml)) also
+accepts an optional `draft` parameter (default `"true"`, matching the
+existing behavior above). Set it to `"false"` to publish the release
+directly instead of creating a draft pre-release — useful for routine
+releases (e.g. patch releases) that don't need manual curation. Either way,
+the release title is always set to a clean `Tekton <Project> release
+<version>` (with the release name quoted alongside it, only when one is
+given), instead of being left blank for the release manager to fill in.
+
 An example using `tkn`. Start defining a few environment variables, obtain the
 REKOR_UUID and then run the pipeline:
 

--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -37,8 +37,8 @@ spec:
     default: "release"
   - name: draft
     description: |
-      Whether to create the GitHub release as a draft pre-release for manual
-      review (the default, preserving existing behavior). Set to "false" to
+      Whether to create the GitHub release as a draft for manual review
+      (the default, preserving existing behavior). Set to "false" to
       publish the release directly instead.
     default: "true"
   workspaces:
@@ -88,9 +88,12 @@ spec:
         fi
         printf '%s' "${TITLE}" > $HOME/release-title.txt
 
+        # The title above is already set on the release itself via
+        # `gh release create --title`, and GitHub renders it prominently
+        # above the description — repeating it as the first line of the
+        # body here would just be redundant, so the body starts straight
+        # into the content instead.
         cat <<EOF | tee $HOME/release.md
-        ${TITLE}
-
         <!-- For major releases, add a tag line
         # 🎉 [Tag Line - to be done] 🎉
         -->
@@ -330,7 +333,7 @@ spec:
           # "Latest" can pass --latest afterwards with `gh release edit`.
           STATE_FLAGS="--latest=false"
         else
-          STATE_FLAGS="--draft --prerelease"
+          STATE_FLAGS="--draft"
         fi
 
         gh release create "${VERSION}" \
@@ -365,8 +368,8 @@ spec:
     description: The Rekor UUID associated to the attestation
   - name: draft
     description: |
-      Whether to create the GitHub release as a draft pre-release for manual
-      review (the default, preserving existing behavior). Set to "false" to
+      Whether to create the GitHub release as a draft for manual review
+      (the default, preserving existing behavior). Set to "false" to
       publish the release directly instead.
     default: "true"
   workspaces:

--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -35,6 +35,12 @@ spec:
   - name: release-subpath
     description: Subpath within workspace for release artifacts
     default: "release"
+  - name: draft
+    description: |
+      Whether to create the GitHub release as a draft pre-release for manual
+      review (the default, preserving existing behavior). Set to "false" to
+      publish the release directly instead.
+    default: "true"
   workspaces:
   - name: shared
     description: contains the cloned repo and the release files
@@ -59,6 +65,8 @@ spec:
         value: $(params.git-revision)
       - name: REKOR_UUID
         value: $(params.rekor-uuid)
+      - name: DRAFT
+        value: $(params.draft)
   steps:
     - name: header
       image: docker.io/library/alpine:3.21
@@ -69,8 +77,19 @@ spec:
         BQ="\`" # Backquote
 
         TEKTON_PROJECT_CAPITALIZED=$(echo "$TEKTON_PROJECT" | awk '{ print toupper(substr($0,1,1)) substr($0,2) }')
+
+        # Only append the quoted release name when one was actually given.
+        # Otherwise this would show up as a redundant, empty/duplicated
+        # suffix, e.g. `Tekton Foo release v0.1.2 "Release v0.1.2"`.
+        if [ -n "${RELEASE_NAME}" ]; then
+          TITLE="Tekton ${TEKTON_PROJECT_CAPITALIZED} release ${VERSION} \"${RELEASE_NAME}\""
+        else
+          TITLE="Tekton ${TEKTON_PROJECT_CAPITALIZED} release ${VERSION}"
+        fi
+        printf '%s' "${TITLE}" > $HOME/release-title.txt
+
         cat <<EOF | tee $HOME/release.md
-        Tekton ${TEKTON_PROJECT_CAPITALIZED} release ${VERSION} "${RELEASE_NAME}"
+        ${TITLE}
 
         <!-- For major releases, add a tag line
         # 🎉 [Tag Line - to be done] 🎉
@@ -295,6 +314,7 @@ spec:
 
         RELEASE_PATH="$(workspaces.shared.path)/$(params.release-subpath)"
         TEKTON_PROJECT=$(basename $PROJECT)
+        TITLE=$(cat $HOME/release-title.txt)
 
         # Collect release artifact files
         ATTACH_FLAGS=""
@@ -302,10 +322,21 @@ spec:
           ATTACH_FLAGS="${ATTACH_FLAGS} ${f}"
         done
 
+        if [ "${DRAFT}" = "false" ]; then
+          # Publish directly. Explicitly opt out of GitHub's "Latest"
+          # auto-marking (which is based on publish date, not semver), since
+          # patch releases for older branches can be published out of
+          # chronological order; callers that do want this release marked
+          # "Latest" can pass --latest afterwards with `gh release edit`.
+          STATE_FLAGS="--latest=false"
+        else
+          STATE_FLAGS="--draft --prerelease"
+        fi
+
         gh release create "${VERSION}" \
           --repo "${PROJECT}" \
-          --draft \
-          --prerelease \
+          --title "${TITLE}" \
+          ${STATE_FLAGS} \
           --target "${GIT_REVISION}" \
           --notes-file "$HOME/release.md" \
           ${ATTACH_FLAGS}
@@ -332,6 +363,12 @@ spec:
     description: OCI bucket where to get the release files from (e.g. tekton-releases)
   - name: rekor-uuid
     description: The Rekor UUID associated to the attestation
+  - name: draft
+    description: |
+      Whether to create the GitHub release as a draft pre-release for manual
+      review (the default, preserving existing behavior). Set to "false" to
+      publish the release directly instead.
+    default: "true"
   workspaces:
     - name: shared
       description: Workspace where the git repo is prepared for testing
@@ -439,3 +476,5 @@ spec:
           value: $(params.previous-release-tag)
         - name: rekor-uuid
           value: $(params.rekor-uuid)
+        - name: draft
+          value: $(params.draft)


### PR DESCRIPTION
# Changes

The `create-draft-release-oci` task (used by e.g. tektoncd/operator's release
pipeline) never set the GitHub release title (`gh release create` was never
given `--title`), while the H1 line in the generated release body fell back
to a synthesized `Release ${VERSION}` name whenever none was given. This
produced a duplicated, quoted title once a maintainer copied that H1 into
the release name by hand, e.g.:

```
Tekton Operator release v0.79.2 "Release v0.79.2"
```

This PR:

- Only appends the quoted release name when one is actually provided,
  instead of synthesizing a redundant fallback.
- Explicitly sets `--title` on `gh release create`, so the release always
  gets a clean, correct title (e.g. `Tekton Operator release v0.79.2`) even
  while left as a draft, instead of sitting untitled until a human edits it.
- Adds an optional `draft` param (default `"true"`, preserving current
  behavior for all existing callers) so projects that don't need manual
  curation for every release — e.g. routine patch releases — can opt to
  publish the release directly instead of leaving an unpublished draft
  behind. When publishing directly, `--latest=false` is passed so GitHub's
  publish-date-based "Latest" auto-marking can't be tripped by an older
  release branch being published after a newer one; callers that do want
  "Latest" set can still do so afterwards via `gh release edit --latest`.

Both the `create-draft-release-oci` Task and the wrapping `release-draft-oci`
Pipeline get the new `draft` param, for symmetry. The older, GCS/`hub`-based
`create-draft-release` task and `release-draft` pipeline are intentionally
left untouched, to keep this change scoped to the actively used OCI variant.

/kind bug

# Submitter Checklist

- [x] Includes docs (README update for the new `draft` param)
- [x] Commit messages follow commit message best practices

Made with [Cursor](https://cursor.com)