### PR TITLE
Add PAC Repository CRs for tektoncd/triggers and tektoncd/results

### DIFF
--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/kustomization.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/kustomization.yaml
@@ -9,5 +9,7 @@ resources:
 - repositories/cli.yaml
 - repositories/pruner.yaml
 - repositories/chains.yaml
+- repositories/triggers.yaml
+- repositories/results.yaml
 patches:
 - path: pipelines-as-code-configmap.yaml

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/release-rbac.yaml
@@ -171,3 +171,71 @@ subjects:
 - kind: ServiceAccount
   name: release
   namespace: releases-chains
+
+# --- releases-triggers ---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release
+  namespace: releases-triggers
+secrets:
+- name: ghcr-chains-auth
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-chain-watcher
+  namespace: releases-triggers
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["taskruns"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-chain-watcher
+  namespace: releases-triggers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-chain-watcher
+subjects:
+- kind: ServiceAccount
+  name: release
+  namespace: releases-triggers
+
+# --- releases-results ---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release
+  namespace: releases-results
+secrets:
+- name: ghcr-chains-auth
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-chain-watcher
+  namespace: releases-results
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["taskruns"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-chain-watcher
+  namespace: releases-results
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-chain-watcher
+subjects:
+- kind: ServiceAccount
+  name: release
+  namespace: releases-results

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/results.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/results.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Repository CR for tektoncd/results.
+# PAC matches incoming events (push, incoming webhook) to PipelineRuns
+# defined in the repository's .tekton/ directory.
+# PipelineRuns are executed in the releases-results namespace.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: releases-results
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: tektoncd-results
+  namespace: releases-results
+spec:
+  url: "https://github.com/tektoncd/results"
+  settings:
+    # Fetch .tekton/ from the default branch (main), not from the PR branch.
+    # This prevents PR authors from modifying release pipelines — only merged
+    # changes to main take effect.
+    pipelinerun_provenance: "default_branch"
+    policy:
+      # Only results maintainers and plumbing maintainers can approve
+      # external PRs with /ok-to-test
+      ok_to_test:
+        - results-maintainers
+        - plumbing-maintainers
+      # Only results maintainers can trigger CI on their own PRs
+      pull_request:
+        - results-maintainers
+  incoming:
+    # Patch releases — triggered by .github/workflows/patch-release.yaml
+    - targets:
+        - "release-v*"
+      secret:
+        name: pac-incoming-secret
+      type: webhook-url
+      params:
+        - version
+        - release_as_latest
+    # Nightly builds — triggered by .github/workflows/nightly-builds.yaml
+    - targets:
+        - "main"
+      secret:
+        name: pac-incoming-secret
+      type: webhook-url
+      params:
+        - version_tag

--- a/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/triggers.yaml
+++ b/tekton/cd/pipelines-as-code/overlays/oci-ci-cd/repositories/triggers.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Repository CR for tektoncd/triggers.
+# PAC matches incoming events (push, incoming webhook) to PipelineRuns
+# defined in the repository's .tekton/ directory.
+# PipelineRuns are executed in the releases-triggers namespace.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: releases-triggers
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: tektoncd-triggers
+  namespace: releases-triggers
+spec:
+  url: "https://github.com/tektoncd/triggers"
+  settings:
+    # Fetch .tekton/ from the default branch (main), not from the PR branch.
+    # This prevents PR authors from modifying release pipelines — only merged
+    # changes to main take effect.
+    pipelinerun_provenance: "default_branch"
+    policy:
+      # Only triggers maintainers and plumbing maintainers can approve
+      # external PRs with /ok-to-test
+      ok_to_test:
+        - triggers-maintainers
+        - plumbing-maintainers
+      # Only triggers maintainers can trigger CI on their own PRs
+      pull_request:
+        - triggers-maintainers
+  incoming:
+    # Patch releases — triggered by .github/workflows/patch-release.yaml
+    - targets:
+        - "release-v*"
+      secret:
+        name: pac-incoming-secret
+      type: webhook-url
+      params:
+        - version
+        - release_as_latest
+    # Nightly builds — triggered by .github/workflows/nightly-builds.yaml
+    - targets:
+        - "main"
+      secret:
+        name: pac-incoming-secret
+      type: webhook-url
+      params:
+        - version_tag


### PR DESCRIPTION
## Summary

Adds PAC `Repository` CRs and namespaces for `tektoncd/triggers` and `tektoncd/results` so Pipelines-as-Code can dispatch release PipelineRuns from their new `.tekton/` directories.

Follows the identical pattern as the existing `chains`, `pipeline`, `pruner`, `operator`, and `cli` CRs in this directory.

> Replaces #3488 (closed due to a force-push during review).

## Companion PRs

- tektoncd/triggers#2062 — adds `.tekton/release.yaml` + `.tekton/release-patch.yaml`
- tektoncd/results#1373 — adds `.tekton/release.yaml` + `.tekton/release-patch.yaml`

## Changes

- `repositories/triggers.yaml` — `Namespace` + `Repository` CR for `releases-triggers`
- `repositories/results.yaml` — `Namespace` + `Repository` CR for `releases-results`
- `release-rbac.yaml` — `ServiceAccount`, `Role`, `RoleBinding` for `releases-triggers` and `releases-results`
- `kustomization.yaml` — registers both new files as resources