### PR TITLE
feat(cherry-pick): Assign comment author to Cherry-Pick Pull Request

### DIFF
--- a/.github/workflows/_cherry-pick-command.yaml
+++ b/.github/workflows/_cherry-pick-command.yaml
@@ -271,13 +271,16 @@ jobs:
 
               echo "Created PR: $PR_URL"
               echo "new_pr_url=$PR_URL" >> $GITHUB_OUTPUT
-
-              # Assign the user who triggered the cherry-pick if accessible.
-              # Accessing user login requires additional permissions (read:org) so it is an optional post-cherry pick step
-              gh pr edit "$PR_URL" --add-assignee "${{ github.event.client_payload.github.payload.comment.user.login }}" 2>&1 || echo "⚠️ Failed to assign user (non-fatal)"
-
-              echo "✅ Cherry-pick completed successfully!"
             fi
+
+            # Assign the user who triggered the cherry-pick if accessible.
+            # Accessing user login requires additional permissions (read:org) so it is an optional post-cherry-pick step.
+            ASSIGNEE_LOGIN='${{ github.event.client_payload.github.payload.comment.user.login }}'
+            if [ -n "$ASSIGNEE_LOGIN" ]; then
+              gh pr edit "$PR_URL" --add-assignee "$ASSIGNEE_LOGIN" 2>&1 || echo "⚠️ Failed to assign user (non-fatal)"
+            fi
+
+            echo "✅ Cherry-pick completed successfully!"
           } 2>&1 | tee "$OUTPUT_FILE"
 
           EXIT_CODE=${PIPESTATUS[0]}

--- a/.github/workflows/_cherry-pick-command.yaml
+++ b/.github/workflows/_cherry-pick-command.yaml
@@ -271,6 +271,11 @@ jobs:
 
               echo "Created PR: $PR_URL"
               echo "new_pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+              # Assign the user who triggered the cherry-pick if accessible.
+              # Accessing user login requires additional permissions (read:org) so it is an optional post-cherry pick step
+              gh pr edit "$PR_URL" --add-assignee "${{ github.event.client_payload.github.payload.comment.user.login }}" 2>&1 || echo "⚠️ Failed to assign user (non-fatal)"
+
               echo "✅ Cherry-pick completed successfully!"
             fi
           } 2>&1 | tee "$OUTPUT_FILE"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a user cherry-picks a pull request, the user is now assigned to the cherry-pick PR to ensure they have ownership over its review and merging, as well as to ensure they have general visibility into the PR(s).

Since user.login may be null and requires read:org permissions, the assigning is done as a separate step and is fail-safe

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind feat

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

Examples:
- Action where it failed to assign the author due to permissions: [comment](https://github.com/aThorp96/tekton-pipeline/pull/3#issuecomment-5025746868), [action](https://github.com/aThorp96/tekton-pipeline/actions/runs/29767782684/job/88438110317), and [PR](https://github.com/aThorp96/tekton-pipeline/pull/4)
- Action where it succeeded in assigning the author: [comment](https://github.com/aThorp96/tekton-pipeline/pull/3#issuecomment-5025785256), [action](https://github.com/aThorp96/tekton-pipeline/actions/runs/29768169146/job/88439407733), and [PR](https://github.com/aThorp96/tekton-pipeline/pull/5)