### PR TITLE
fix: add chains-signed guard to create-draft-release-oci task

### DIFF
--- a/tekton/resources/release/base/github_release_oci.yaml
+++ b/tekton/resources/release/base/github_release_oci.yaml
@@ -41,6 +41,13 @@ spec:
       (the default, preserving existing behavior). Set to "false" to
       publish the release directly instead.
     default: "true"
+  - name: chains-signed
+    description: |
+      Chains signing status from the wait-for-chains task ("true", "failed", or
+      "timeout"). If not "true", the task exits 1 with a clear message and no
+      draft release is created. Defaults to "true" so existing callers that do
+      not pass this param are unaffected.
+    default: "true"
   workspaces:
   - name: shared
     description: contains the cloned repo and the release files
@@ -73,6 +80,13 @@ spec:
       script: |
         #!/bin/sh
         set -ex
+
+        if [ "$(params.chains-signed)" != "true" ]; then
+          echo "ERROR: Chains signing did not succeed (status: $(params.chains-signed))."
+          echo "Release artifacts are published. Create the draft release manually once signing is resolved."
+          exit 1
+        fi
+
         TEKTON_PROJECT=$(basename $PROJECT)
         BQ="\`" # Backquote
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Follow-up to a review comment on [tektoncd/pipeline#10441](https://github.com/tektoncd/pipeline/pull/10441#discussion_r3615089745).

That PR removed this `when` condition from `create-draft-release` in
`release-pipeline.yaml`:

```yaml
- input: "$(tasks.wait-for-chains.results.signed)"
  operator: in
  values: ["true"]
```

because Tekton resolves all variable substitutions in a task's `when` block
before evaluating any condition — it does not short-circuit. So even when the
first `when` condition is false, Tekton still tries to substitute
`$(tasks.wait-for-chains.results.signed)` from a skipped task (nightly builds
skip `wait-for-chains`), which is unresolvable and fails the PipelineRun
instead of skipping it gracefully.

Removing that condition, however, left `create-draft-release` with no way to
gate on the Chains signing result at all. `wait-for-chains` polls Chains
signing and writes one of `"true"`, `"failed"`, or `"timeout"` to
`results.signed`; a real release run should not create a draft release if
signing did not succeed.

This PR reintroduces that guard, but inside the task itself instead of a
pipeline-level `when` condition, so it can never depend on a skipped task's
result:

- Adds a `chains-signed` param to `create-draft-release-oci`
  ([github_release_oci.yaml](https://github.com/tektoncd/plumbing/blob/main/tekton/resources/release/base/github_release_oci.yaml)),
  defaulting to `"true"` so existing callers are unaffected.
- The `header` step now exits 1 with a clear message, before any GitHub API
  calls, if `chains-signed` is not `"true"`.

No other task logic is changed.

Once merged, a follow-up PR in `tektoncd/pipeline` will bump the plumbing
resolver revision pin and pass:

```yaml
- name: chains-signed
  value: $(tasks.wait-for-chains.results.signed)
```

to `create-draft-release`. This is a **param reference**, not a `when`
condition, so it is safe even when `wait-for-chains` is skipped: on nightly
runs, `create-draft-release` is already gated by `releaseMode=='stable'` and
is itself skipped before its params are ever resolved.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
