### PR TITLE
fix: preserve manually assigned issue types and priorities

### DIFF
--- a/.github/workflows/sync-issue-types.yml
+++ b/.github/workflows/sync-issue-types.yml
@@ -3,7 +3,7 @@
 # Syncs GitHub Issue Types based on kind/* labels for all tektoncd repos.
 # Labels are the source of truth:
 # - kind/bug → Bug, kind/feature → Feature, other kind/* → Task
-# - No kind/* label → clears the type
+# - No kind/* label → preserves any manually assigned type
 #
 # Queries each repository individually to avoid the GitHub Search API's
 # 1000-result cap.
@@ -140,7 +140,6 @@ jobs:
           echo "::endgroup::"
 
           UPDATED=0
-          CLEARED=0
           SKIPPED=0
           ERRORS=0
           PROCESSED=0
@@ -159,7 +158,7 @@ jobs:
             # Log progress every 100 issues
             if (( PROCESSED % 100 == 0 )); then
               ELAPSED=$(( $(date +%s) - START_TIME ))
-              echo "--- Progress: $PROCESSED/$TOTAL (${ELAPSED}s elapsed, updated=$UPDATED cleared=$CLEARED skipped=$SKIPPED errors=$ERRORS) ---"
+              echo "--- Progress: $PROCESSED/$TOTAL (${ELAPSED}s elapsed, updated=$UPDATED skipped=$SKIPPED errors=$ERRORS) ---"
             fi
 
             # Get kind/* labels
@@ -246,44 +245,8 @@ jobs:
               continue
             fi
 
-            # Case 2: No kind label but has type - clear the type
-            if [ "$CURRENT_TYPE" != "none" ]; then
-              echo "CLEAR: $REPO_NAME#$ISSUE_NUMBER - removing type $CURRENT_TYPE (no kind/* label)"
-
-              if [ "$DRY_RUN" != "true" ]; then
-                # Capture stdout only; see comment on the set-type mutation.
-                RESULT=$(gh api graphql -f query='
-                  mutation($issueId: ID!) {
-                    updateIssueIssueType(input: {
-                      issueId: $issueId
-                      issueTypeId: null
-                    }) {
-                      issue {
-                        id
-                        issueType { name }
-                      }
-                    }
-                  }' -f issueId="$ISSUE_ID" 2>/dev/null || true)
-
-                if ! jq -e . <<< "$RESULT" > /dev/null 2>&1; then
-                  echo "::error::$REPO_NAME#$ISSUE_NUMBER: gh returned non-JSON output: $RESULT"
-                  ((++ERRORS))
-                elif jq -e '.errors' <<< "$RESULT" > /dev/null 2>&1; then
-                  echo "::error::$REPO_NAME#$ISSUE_NUMBER: $(jq -r '.errors[0].message' <<< "$RESULT")"
-                  ((++ERRORS))
-                else
-                  ((++CLEARED))
-                fi
-
-                sleep 0.3
-              else
-                ((++CLEARED))
-              fi
-              continue
-            fi
-
-            # Case 3: No kind label and no type - already correct
-            echo "SKIP: $REPO_NAME#$ISSUE_NUMBER - no kind/* label and no type"
+            # Case 2: No kind label — preserve any existing type
+            echo "SKIP: $REPO_NAME#$ISSUE_NUMBER - no kind/* label, preserving current type ($CURRENT_TYPE)"
             ((++SKIPPED))
 
           done < <(jq -c '.[]' /tmp/issues.json)
@@ -294,14 +257,12 @@ jobs:
           echo "::group::Results (completed in ${ELAPSED}s)"
           echo "Processed: $PROCESSED"
           echo "Types set: $UPDATED"
-          echo "Types cleared: $CLEARED"
           echo "Skipped: $SKIPPED"
           echo "Errors: $ERRORS"
           echo "::endgroup::"
 
           # Set outputs for summary
           echo "updated=$UPDATED" >> $GITHUB_OUTPUT
-          echo "cleared=$CLEARED" >> $GITHUB_OUTPUT
           echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
           echo "errors=$ERRORS" >> $GITHUB_OUTPUT
 
@@ -313,8 +274,7 @@ jobs:
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Issues found | ${{ steps.search_issues.outputs.issue_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Types set | ${{ steps.sync_types.outputs.updated || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Types cleared | ${{ steps.sync_types.outputs.cleared || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Skipped | ${{ steps.sync_types.outputs.skipped || '0' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Skipped (preserved) | ${{ steps.sync_types.outputs.skipped || '0' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Errors | ${{ steps.sync_types.outputs.errors || '0' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Label → Type Mapping" >> $GITHUB_STEP_SUMMARY
@@ -323,7 +283,7 @@ jobs:
           echo "| kind/bug | Bug |" >> $GITHUB_STEP_SUMMARY
           echo "| kind/feature | Feature |" >> $GITHUB_STEP_SUMMARY
           echo "| kind/* (other) | Task |" >> $GITHUB_STEP_SUMMARY
-          echo "| (no kind/* label) | (cleared) |" >> $GITHUB_STEP_SUMMARY
+          echo "| (no kind/* label) | (preserved) |" >> $GITHUB_STEP_SUMMARY
 
       - name: Verify types persisted
         if: steps.sync_types.outputs.updated > 0 && inputs.dry_run != 'true'

--- a/.github/workflows/sync-priority.yml
+++ b/.github/workflows/sync-priority.yml
@@ -5,7 +5,7 @@
 # Labels are the source of truth:
 # - priority/urgent → Urgent, priority/high → High,
 #   priority/medium → Medium, priority/low → Low
-# - No priority/* label → clears the field
+# - No priority/* label → preserves any manually assigned priority
 #
 # Uses the setIssueFieldValue mutation (Issue Fields API, public preview).
 #
@@ -156,7 +156,6 @@ jobs:
           echo "::endgroup::"
 
           UPDATED=0
-          CLEARED=0
           SKIPPED=0
           ERRORS=0
           PROCESSED=0
@@ -184,7 +183,7 @@ jobs:
             # Log progress every 100 issues
             if (( PROCESSED % 100 == 0 )); then
               ELAPSED=$(( $(date +%s) - START_TIME ))
-              echo "--- Progress: $PROCESSED/$TOTAL (${ELAPSED}s elapsed, updated=$UPDATED cleared=$CLEARED skipped=$SKIPPED errors=$ERRORS) ---"
+              echo "--- Progress: $PROCESSED/$TOTAL (${ELAPSED}s elapsed, updated=$UPDATED skipped=$SKIPPED errors=$ERRORS) ---"
             fi
 
             # Get priority/* labels
@@ -299,44 +298,8 @@ jobs:
               continue
             fi
 
-            # Case 2: No priority label but has priority field — clear it
-            if [ "$CURRENT_PRIORITY" != "none" ]; then
-              echo "CLEAR: $REPO_NAME#$ISSUE_NUMBER - removing priority $CURRENT_PRIORITY (no priority/* label)"
-
-              if [ "$DRY_RUN" != "true" ]; then
-                RESULT=$(gh api graphql -f query='
-                  mutation($issueId: ID!, $fieldId: ID!) {
-                    setIssueFieldValue(input: {
-                      issueId: $issueId
-                      issueFields: [{
-                        fieldId: $fieldId
-                        delete: true
-                      }]
-                    }) {
-                      issue { id }
-                    }
-                  }' -f issueId="$ISSUE_ID" \
-                     -f fieldId="${{ env.PRIORITY_FIELD_ID }}" 2>/dev/null || true)
-
-                if ! jq -e . <<< "$RESULT" > /dev/null 2>&1; then
-                  echo "::error::$REPO_NAME#$ISSUE_NUMBER: gh returned non-JSON output: $RESULT"
-                  ((++ERRORS))
-                elif jq -e '.errors' <<< "$RESULT" > /dev/null 2>&1; then
-                  echo "::error::$REPO_NAME#$ISSUE_NUMBER: $(jq -r '.errors[0].message' <<< "$RESULT")"
-                  ((++ERRORS))
-                else
-                  ((++CLEARED))
-                fi
-
-                sleep 0.3
-              else
-                ((++CLEARED))
-              fi
-              continue
-            fi
-
-            # Case 3: No priority label and no priority field — already correct
-            echo "SKIP: $REPO_NAME#$ISSUE_NUMBER - no priority/* label and no priority field"
+            # Case 2: No priority label — preserve any existing priority
+            echo "SKIP: $REPO_NAME#$ISSUE_NUMBER - no priority/* label, preserving current priority ($CURRENT_PRIORITY)"
             ((++SKIPPED))
 
           done < <(jq -c '.[]' /tmp/issues.json)
@@ -347,14 +310,12 @@ jobs:
           echo "::group::Results (completed in ${ELAPSED}s)"
           echo "Processed: $PROCESSED"
           echo "Priority set: $UPDATED"
-          echo "Priority cleared: $CLEARED"
           echo "Skipped: $SKIPPED"
           echo "Errors: $ERRORS"
           echo "::endgroup::"
 
           # Set outputs for summary
           echo "updated=$UPDATED" >> $GITHUB_OUTPUT
-          echo "cleared=$CLEARED" >> $GITHUB_OUTPUT
           echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
           echo "errors=$ERRORS" >> $GITHUB_OUTPUT
 
@@ -366,8 +327,7 @@ jobs:
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Issues found | ${{ steps.search_issues.outputs.issue_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Priority set | ${{ steps.sync_priority.outputs.updated || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Priority cleared | ${{ steps.sync_priority.outputs.cleared || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Skipped | ${{ steps.sync_priority.outputs.skipped || '0' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Skipped (preserved) | ${{ steps.sync_priority.outputs.skipped || '0' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Errors | ${{ steps.sync_priority.outputs.errors || '0' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Label → Priority Mapping" >> $GITHUB_STEP_SUMMARY
@@ -377,7 +337,7 @@ jobs:
           echo "| priority/high | High |" >> $GITHUB_STEP_SUMMARY
           echo "| priority/medium | Medium |" >> $GITHUB_STEP_SUMMARY
           echo "| priority/low | Low |" >> $GITHUB_STEP_SUMMARY
-          echo "| (no priority/* label) | (cleared) |" >> $GITHUB_STEP_SUMMARY
+          echo "| (no priority/* label) | (preserved) |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Legacy Labels (supported during transition)" >> $GITHUB_STEP_SUMMARY
           echo "| Legacy Label | Maps to |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
# Changes

Stop clearing GitHub Issue Types and Priority fields from issues that don't have `kind/*` or `priority/*` labels. Previously, the daily sync workflows would remove manually assigned values from every unlabeled issue, overwriting types/priorities set directly through GitHub.

Now:
- `kind/*` labels still set the Issue Type (Bug, Feature, Task)
- `priority/*` labels still set the Priority field
- Issues without labels keep their current values (no more clearing)

Fixes #3533
Fixes #3534

/kind bug

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
