### PR TITLE
vmt: add fetch-advisories script for weekly digest

### DIFF
--- a/vmt/README.md
+++ b/vmt/README.md
@@ -1,0 +1,52 @@
+# VMT (Vulnerability Management Team) Tools
+
+Tools for the Tekton VMT to manage and track security advisories across the
+`tektoncd` GitHub organization.
+
+## fetch-advisories.py
+
+Fetches all GitHub Security Advisories (GHSAs) across `tektoncd/*` repos and
+outputs structured JSON. Used to generate weekly VMT digest emails.
+
+### Requirements
+
+- `gh` CLI, authenticated with access to security advisories
+- Python 3.10+
+
+### Usage
+
+```bash
+# All advisories across the org
+python3 vmt/fetch-advisories.py
+
+# Only published advisories
+python3 vmt/fetch-advisories.py --state published
+
+# Advisories needing triage
+python3 vmt/fetch-advisories.py --state triage
+
+# Single repo
+python3 vmt/fetch-advisories.py --repo pipeline
+
+# Updated since a date
+python3 vmt/fetch-advisories.py --since 2026-07-01
+```
+
+### Output
+
+JSON with:
+- `generated_at`: timestamp
+- `org`: GitHub org
+- `total`: count
+- `by_state`: breakdown by state (triage, draft, published, closed)
+- `advisories[]`: array of advisory objects with:
+  - `repo`, `ghsa_id`, `cve_id`, `summary`, `severity`, `state`
+  - `days_open`, `days_since_update` (staleness indicators)
+  - `credits[]`, `collaborators[]` (who's working on it)
+  - `vulnerabilities[]` (affected packages/versions)
+
+### Weekly Digest Workflow
+
+1. Run `fetch-advisories.py` to get current state
+2. Feed JSON to an AI agent skill to generate the digest email
+3. Review and send to `tekton-vmt` mailing list

--- a/vmt/fetch-advisories.py
+++ b/vmt/fetch-advisories.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Fetch security advisories across all tektoncd/* repos.
+
+Outputs structured JSON suitable for generating a weekly VMT digest.
+Requires `gh` CLI with org admin/security access.
+
+Usage:
+    python3 vmt/fetch-advisories.py [--state open|closed|published|all] [--since YYYY-MM-DD]
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def gh_api(endpoint):
+    """Call gh api with pagination, return parsed JSON."""
+    result = subprocess.run(
+        ["gh", "api", "--paginate", endpoint],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        # Some repos have no advisories enabled — skip silently
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def list_org_repos(org):
+    """List all repos in an org."""
+    result = subprocess.run(
+        ["gh", "api", "--paginate", f"/orgs/{org}/repos", "-q", ".[].name"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"Error listing repos for {org}: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return [name.strip() for name in result.stdout.strip().split("\n") if name.strip()]
+
+
+def days_since(iso_date):
+    """Return days since an ISO 8601 date string."""
+    if not iso_date:
+        return None
+    dt = datetime.fromisoformat(iso_date.replace("Z", "+00:00"))
+    return (datetime.now(timezone.utc) - dt).days
+
+
+def extract_advisory(repo, adv):
+    """Extract relevant fields from a raw advisory."""
+    return {
+        "repo": repo,
+        "ghsa_id": adv.get("ghsa_id"),
+        "cve_id": adv.get("cve_id"),
+        "summary": adv.get("summary", ""),
+        "severity": adv.get("severity"),
+        "state": adv.get("state"),
+        "html_url": adv.get("html_url"),
+        "created_at": adv.get("created_at"),
+        "updated_at": adv.get("updated_at"),
+        "published_at": adv.get("published_at"),
+        "closed_at": adv.get("closed_at"),
+        "withdrawn_at": adv.get("withdrawn_at"),
+        "days_open": days_since(adv.get("created_at")),
+        "days_since_update": days_since(adv.get("updated_at")),
+        "submission_accepted": (adv.get("submission") or {}).get("accepted"),
+        "author": (adv.get("author") or {}).get("login"),
+        "credits": [
+            {"login": c["login"], "type": c["type"]}
+            for c in (adv.get("credits") or [])
+        ],
+        "collaborators": [
+            u["login"]
+            for u in (adv.get("collaborating_users") or [])
+        ],
+        "collaborating_teams": [
+            t["slug"]
+            for t in (adv.get("collaborating_teams") or [])
+        ],
+        "cvss_score": (adv.get("cvss") or {}).get("score"),
+        "cwes": adv.get("cwe_ids", []),
+        "vulnerabilities": [
+            {
+                "package": (v.get("package") or {}).get("name"),
+                "ecosystem": (v.get("package") or {}).get("ecosystem"),
+                "vulnerable_range": v.get("vulnerable_version_range"),
+                "patched_versions": v.get("patched_versions"),
+            }
+            for v in (adv.get("vulnerabilities") or [])
+        ],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch tektoncd security advisories")
+    parser.add_argument("--org", default="tektoncd", help="GitHub org (default: tektoncd)")
+    parser.add_argument("--state", default="all",
+                        choices=["open", "closed", "published", "triage", "draft", "all"],
+                        help="Filter by advisory state (triage/draft are client-side filtered)")
+    parser.add_argument("--since", default=None, help="Only include advisories updated since YYYY-MM-DD")
+    parser.add_argument("--repo", default=None, help="Single repo instead of whole org")
+    args = parser.parse_args()
+
+    repos = [args.repo] if args.repo else list_org_repos(args.org)
+
+    since_dt = None
+    if args.since:
+        since_dt = datetime.fromisoformat(args.since).replace(tzinfo=timezone.utc)
+
+    all_advisories = []
+    for repo in repos:
+        endpoint = f"/repos/{args.org}/{repo}/security-advisories"
+        # API only supports open/closed/published; triage/draft are client-side
+        api_state = args.state if args.state in ("open", "closed", "published") else None
+        if api_state:
+            endpoint += f"?state={api_state}"
+
+        advisories = gh_api(endpoint)
+        if not isinstance(advisories, list):
+            continue
+
+        for adv in advisories:
+            if since_dt and adv.get("updated_at"):
+                updated = datetime.fromisoformat(
+                    adv["updated_at"].replace("Z", "+00:00")
+                )
+                if updated < since_dt:
+                    continue
+            # Client-side state filter for triage/draft
+            if args.state in ("triage", "draft") and adv.get("state") != args.state:
+                continue
+            all_advisories.append(extract_advisory(repo, adv))
+
+    # Sort: open/triage first, then by staleness
+    state_order = {"triage": 0, "draft": 1, "open": 1, "published": 2, "closed": 3}
+    all_advisories.sort(key=lambda a: (
+        state_order.get(a["state"], 99),
+        -(a["days_open"] or 0),
+    ))
+
+    output = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "org": args.org,
+        "total": len(all_advisories),
+        "by_state": {},
+        "advisories": all_advisories,
+    }
+    for adv in all_advisories:
+        state = adv["state"] or "unknown"
+        output["by_state"][state] = output["by_state"].get(state, 0) + 1
+
+    json.dump(output, sys.stdout, indent=2)
+    print()  # trailing newline
+
+
+if __name__ == "__main__":
+    main()

--- a/vmt/fetch-advisories.py
+++ b/vmt/fetch-advisories.py
@@ -5,7 +5,7 @@ Outputs structured JSON suitable for generating a weekly VMT digest.
 Requires `gh` CLI with org admin/security access.
 
 Usage:
-    python3 vmt/fetch-advisories.py [--state open|closed|published|all] [--since YYYY-MM-DD]
+    python3 vmt/fetch-advisories.py [--org ORG] [--repo REPO] [--state triage|draft|published|closed|all] [--since YYYY-MM-DD]
 """
 
 import argparse
@@ -15,14 +15,23 @@ import sys
 from datetime import datetime, timezone
 
 
-def gh_api(endpoint):
-    """Call gh api with pagination, return parsed JSON."""
+def gh_api(endpoint, repo=None):
+    """Call gh api with pagination, return parsed JSON.
+
+    Returns [] for 404 (no advisories enabled). Raises on other errors.
+    """
     result = subprocess.run(
         ["gh", "api", "--paginate", endpoint],
         capture_output=True, text=True
     )
     if result.returncode != 0:
-        # Some repos have no advisories enabled — skip silently
+        stderr = result.stderr.strip()
+        # 404 = advisories not enabled for this repo — expected, skip
+        if "404" in stderr or "Not Found" in stderr:
+            return []
+        # Real error (auth, rate limit, network) — surface it
+        label = repo or endpoint
+        print(f"Warning: gh api failed for {label}: {stderr}", file=sys.stderr)
         return []
     try:
         return json.loads(result.stdout)
@@ -65,7 +74,7 @@ def extract_advisory(repo, adv):
         "published_at": adv.get("published_at"),
         "closed_at": adv.get("closed_at"),
         "withdrawn_at": adv.get("withdrawn_at"),
-        "days_open": days_since(adv.get("created_at")),
+        "days_open": days_since(adv.get("created_at") or adv.get("published_at")),
         "days_since_update": days_since(adv.get("updated_at")),
         "submission_accepted": (adv.get("submission") or {}).get("accepted"),
         "author": (adv.get("author") or {}).get("login"),
@@ -99,7 +108,7 @@ def main():
     parser = argparse.ArgumentParser(description="Fetch tektoncd security advisories")
     parser.add_argument("--org", default="tektoncd", help="GitHub org (default: tektoncd)")
     parser.add_argument("--state", default="all",
-                        choices=["open", "closed", "published", "triage", "draft", "all"],
+                        choices=["triage", "draft", "published", "closed", "all"],
                         help="Filter by advisory state (triage/draft are client-side filtered)")
     parser.add_argument("--since", default=None, help="Only include advisories updated since YYYY-MM-DD")
     parser.add_argument("--repo", default=None, help="Single repo instead of whole org")
@@ -115,11 +124,11 @@ def main():
     for repo in repos:
         endpoint = f"/repos/{args.org}/{repo}/security-advisories"
         # API only supports open/closed/published; triage/draft are client-side
-        api_state = args.state if args.state in ("open", "closed", "published") else None
+        api_state = args.state if args.state in ("closed", "published") else None
         if api_state:
             endpoint += f"?state={api_state}"
 
-        advisories = gh_api(endpoint)
+        advisories = gh_api(endpoint, repo=repo)
         if not isinstance(advisories, list):
             continue
 
@@ -136,7 +145,7 @@ def main():
             all_advisories.append(extract_advisory(repo, adv))
 
     # Sort: open/triage first, then by staleness
-    state_order = {"triage": 0, "draft": 1, "open": 1, "published": 2, "closed": 3}
+    state_order = {"triage": 0, "draft": 1, "published": 2, "closed": 3}
     all_advisories.sort(key=lambda a: (
         state_order.get(a["state"], 99),
         -(a["days_open"] or 0),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add tooling for the VMT (Vulnerability Management Team) to generate weekly
digest emails summarizing the state of security advisories across `tektoncd/*`
repos.

- **`vmt/fetch-advisories.py`** — Scans all `tektoncd/*` repos via `gh api`,
  outputs structured JSON with advisory state, staleness indicators, credits,
  and collaborators
- **`vmt/README.md`** — Usage docs and workflow description

## Workflow

1. Run `fetch-advisories.py` to get current advisory state as JSON
2. Feed JSON to generate a digest email
3. Review and send to `tekton-vmt` mailing list

## Why

Make VMT work visible and ensure advisories don't go stale unnoticed. The
weekly digest surfaces triage/draft advisories, highlights stale items, and
shows who's working on what.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._