### PR TITLE
Fix auto merge for release-* branches

### DIFF
--- a/terraform/branch-protection/main.tf
+++ b/terraform/branch-protection/main.tf
@@ -66,11 +66,17 @@ resource "github_branch_protection" "releases" {
     )
   }
 
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = var.dismiss_stale_reviews
-    require_code_owner_reviews      = var.require_code_owner_reviews
-    required_approving_review_count = var.required_approving_review_count_releases
-  }
+  # Note: PR reviews not required here (same as main branches). Tekton's
+  # review flow is Prow label-based (/lgtm, /approve -> lgtm/approved labels),
+  # not necessarily a formal GitHub "Approve" review. Requiring a native
+  # GitHub approving review here blocked Tide from completing automerges on
+  # release branches even after lgtm+approved were set.
+  # Can be enabled later by uncommenting:
+  # required_pull_request_reviews {
+  #   dismiss_stale_reviews           = var.dismiss_stale_reviews
+  #   require_code_owner_reviews      = var.require_code_owner_reviews
+  #   required_approving_review_count = var.required_approving_review_count_releases
+  # }
 }
 
 # Main branch protection for tektoncd-catalog repositories


### PR DESCRIPTION
PR reviews not required here (same as main branches). Tekton's review flow is Prow label-based (/lgtm, /approve -> lgtm/approved labels), not necessarily a formal GitHub "Approve" review. Requiring a native GitHub approving review here blocked Tide from completing automerges on release branches even after lgtm+approved were set. For main the issue was fixed by d55ffda9.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>
Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._