### PR TITLE
Fix gofmt failure in add-pr-body under Go 1.26 (#3588)

### DIFF
--- a/tekton/ci/cluster-interceptors/add-pr-body/pkg/pr_test.go
+++ b/tekton/ci/cluster-interceptors/add-pr-body/pkg/pr_test.go
@@ -164,5 +164,3 @@ func TestInterceptor_Process_Error(t *testing.T) {
 		})
 	}
 }
-
-


### PR DESCRIPTION
Targets the dependabot branch for #3588.

The dependency bump raises `go.mod` to `go 1.26.4`, so CI's setup-go installs Go 1.26. In Go 1.26 `gofmt -d`/`-l` exit non-zero when a file needs reformatting (Go <=1.25 always exited 0). The CI gofmt step runs under `bash -eo pipefail`, so `set -e` aborts it. This surfaced two pre-existing trailing blank lines in `pkg/pr_test.go`.

Removing them makes gofmt clean and lets #3588 go green. Merge this into the dependabot branch to unblock #3588.