### PR TITLE
Upgrade tini-git base to Alpine 3.24 to fix libcurl CVEs

### DIFF
--- a/tekton/images/tini-git/Dockerfile
+++ b/tekton/images/tini-git/Dockerfile
@@ -16,6 +16,7 @@ LABEL maintainer="Tekton Authors <tekton-dev@googlegroups.com>"
 LABEL org.opencontainers.image.source=https://github.com/tektoncd/plumbing
 LABEL org.opencontainers.image.description="Image for tini"
 LABEL org.opencontainers.image.licenses=Apache-2.0
-RUN apk add --no-cache tini git
+RUN apk add --no-cache tini git && \
+    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main libcurl
 USER 65532
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/tekton/images/tini-git/Dockerfile
+++ b/tekton/images/tini-git/Dockerfile
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine:3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 LABEL maintainer="Tekton Authors <tekton-dev@googlegroups.com>"
 LABEL org.opencontainers.image.source=https://github.com/tektoncd/plumbing
 LABEL org.opencontainers.image.description="Image for tini"
 LABEL org.opencontainers.image.licenses=Apache-2.0
-RUN apk add --no-cache tini git && \
-    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main libcurl
+RUN apk add --no-cache tini git
 USER 65532
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
## Summary

The `tini-git` image is based on `alpine:3.22` which ships `libcurl 8.14.1-r3`. Several libcurl security advisories apply to this version:

- CVE-2026-8927 — proxy auth credentials not cleared across sequential transfers
- CVE-2026-8926 — `.netrc` credentials exposed when URL contains a bare username
- CVE-2026-11856 — Digest auth credentials reused across origins
- CVE-2026-9079 — proxy credentials not cleared

Severity ratings are as published by the curl project (Low–Medium). A downstream security scanner (JFrog Xray) rates these higher; this PR addresses the upstream advisories.

Note: CVE-2026-8925 (GSASL double-free) was introduced in curl 8.15.0 and does **not** affect `libcurl 8.14.1`.

## Change

Bumps the base image from `alpine:3.22` to `alpine:3.24`. Alpine 3.24 stable ships `libcurl 8.21.0-r0` on all supported architectures, which resolves all applicable advisories. The existing `apk add --no-cache tini git` installs `libcurl 8.21.0-r0` transitively — no extra steps needed.

## Related

- tektoncd/pipeline#10642 — updates `.ko.yaml` resolvers digest to consume the fixed image