### PR TITLE
chore: enable Dependabot for tini-git

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -218,6 +218,19 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
+    directory: "/tekton/images/tini-git"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "dependencies"
+      - "release-note-none"
+      - "kind/misc"
+    groups:
+      all:
+        patterns:
+          - "*"
+  - package-ecosystem: "docker"
     directory: "/tekton/images/kind-e2e"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Configure weekly Dependabot Docker updates for the `tini-git` image so its pinned Alpine base receives update pull requests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
-->

```release-note
NONE
```
